### PR TITLE
refactor: tree-view feature を prototype.jsx から分離

### DIFF
--- a/src/features/tree-view/DateGroup.jsx
+++ b/src/features/tree-view/DateGroup.jsx
@@ -1,0 +1,76 @@
+import { PROJECTS } from "../../entities/project/projects.js";
+import { formatDate } from "../../shared/lib/time.js";
+import { lanesWidthPx, nodeCenterPx } from "./layout.js";
+
+/**
+ * 1つの日付に属するタスク群を、日付見出しとノード列で描画する。
+ */
+export function DateGroup({ date, items, projectOrder }) {
+  const lanesWidth = lanesWidthPx(projectOrder.length);
+
+  return (
+    <div>
+      <div
+        style={{
+          padding: "10px 16px 2px",
+          display: "flex",
+          alignItems: "center",
+        }}
+      >
+        <div style={{ width: lanesWidth }} />
+        <span style={{ fontSize: 10, color: "#52525b" }}>
+          {formatDate(date)}
+        </span>
+        <div
+          style={{
+            flex: 1,
+            height: 1,
+            background: "#18181b",
+            marginLeft: 8,
+          }}
+        />
+      </div>
+      {items.map((task) => {
+        const pi = projectOrder.indexOf(task.project);
+        const nodeLeft = nodeCenterPx(pi);
+        return (
+          <div
+            key={task.id}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              minHeight: 30,
+              padding: "2px 16px",
+              position: "relative",
+            }}
+          >
+            <div
+              style={{
+                position: "absolute",
+                left: nodeLeft - 4,
+                top: "50%",
+                transform: "translateY(-50%)",
+                width: 8,
+                height: 8,
+                borderRadius: "50%",
+                background: "#0a0a0b",
+                border: `2px solid ${PROJECTS[task.project].color}`,
+                zIndex: 3,
+              }}
+            />
+            <div style={{ width: lanesWidth, flexShrink: 0 }} />
+            <span
+              style={{
+                fontFamily: "'Noto Sans JP', sans-serif",
+                fontSize: 11,
+                color: "#71717a",
+              }}
+            >
+              {task.title}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/tree-view/ProjectLanes.jsx
+++ b/src/features/tree-view/ProjectLanes.jsx
@@ -1,0 +1,62 @@
+import { PROJECTS } from "../../entities/project/projects.js";
+import { laneLeftPx } from "./layout.js";
+
+/**
+ * プロジェクトごとの縦線（ブランチ）と上部レジェンド。
+ */
+export function ProjectLanes({ projectOrder }) {
+  return (
+    <>
+      {projectOrder.map((pk, pi) => (
+        <div
+          key={pk}
+          style={{
+            position: "absolute",
+            left: laneLeftPx(pi),
+            top: 0,
+            bottom: 0,
+            width: 2,
+            background: PROJECTS[pk].color,
+            opacity: 0.3,
+            zIndex: 1,
+            pointerEvents: "none",
+          }}
+        />
+      ))}
+      <div
+        style={{
+          padding: "14px 16px 6px",
+          display: "flex",
+          gap: 12,
+          position: "relative",
+          zIndex: 2,
+        }}
+      >
+        {projectOrder.map((k) => (
+          <div
+            key={k}
+            style={{ display: "flex", alignItems: "center", gap: 4 }}
+          >
+            <div
+              style={{
+                width: 6,
+                height: 6,
+                borderRadius: "50%",
+                background: PROJECTS[k].color,
+              }}
+            />
+            <span
+              style={{
+                fontSize: 9,
+                color: "#52525b",
+                fontFamily: "'Noto Sans JP', sans-serif",
+              }}
+            >
+              {PROJECTS[k].name}
+            </span>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/features/tree-view/TreeView.jsx
+++ b/src/features/tree-view/TreeView.jsx
@@ -1,0 +1,27 @@
+import { DateGroup } from "./DateGroup.jsx";
+import { groupByDateDesc } from "./layout.js";
+import { ProjectLanes } from "./ProjectLanes.jsx";
+
+/**
+ * git log tree 風の履歴ビュー。
+ * 縦軸が時間（日付）、横軸がプロジェクト（レーン）。
+ */
+export function TreeView({ historyData, projectOrder }) {
+  const dateGroups = groupByDateDesc(historyData);
+
+  return (
+    <div style={{ position: "relative", paddingBottom: 40 }}>
+      <ProjectLanes projectOrder={projectOrder} />
+      <div style={{ position: "relative", zIndex: 2 }}>
+        {dateGroups.map(([date, items]) => (
+          <DateGroup
+            key={date}
+            date={date}
+            items={items}
+            projectOrder={projectOrder}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/tree-view/TreeView.test.jsx
+++ b/src/features/tree-view/TreeView.test.jsx
@@ -1,0 +1,58 @@
+import { render } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { TreeView } from "./TreeView.jsx";
+
+const projectOrder = ["career", "loadtest", "slo", "tasuki"];
+
+const history = [
+  { id: "h1", project: "career", title: "転職ドラフト応募完了", date: "2026-04-05", done: true },
+  { id: "h2", project: "slo", title: "SLI候補の洗い出し", date: "2026-04-05", done: true },
+  { id: "h3", project: "tasuki", title: "php-parser PoC完了", date: "2026-04-06", done: true },
+];
+
+describe("TreeView", () => {
+  test("空 historyData でも crash しない", () => {
+    const { container } = render(
+      <TreeView historyData={[]} projectOrder={projectOrder} />,
+    );
+    expect(container.firstChild).toBeTruthy();
+  });
+
+  test("プロジェクトレジェンド（名前）を表示する", () => {
+    const { getByText } = render(
+      <TreeView historyData={history} projectOrder={projectOrder} />,
+    );
+    expect(getByText("転職活動")).toBeTruthy();
+    expect(getByText("SLO推進")).toBeTruthy();
+    expect(getByText("Tasuki")).toBeTruthy();
+  });
+
+  test("各タスクタイトルを表示する", () => {
+    const { getByText } = render(
+      <TreeView historyData={history} projectOrder={projectOrder} />,
+    );
+    expect(getByText("転職ドラフト応募完了")).toBeTruthy();
+    expect(getByText("SLI候補の洗い出し")).toBeTruthy();
+    expect(getByText("php-parser PoC完了")).toBeTruthy();
+  });
+
+  test("日付見出し（formatDate）を表示する", () => {
+    const { getByText } = render(
+      <TreeView historyData={history} projectOrder={projectOrder} />,
+    );
+    // 2026-04-05 は日曜、2026-04-06 は月曜
+    expect(getByText("4/5 (日)")).toBeTruthy();
+    expect(getByText("4/6 (月)")).toBeTruthy();
+  });
+
+  test("日付は降順で並ぶ", () => {
+    const { container } = render(
+      <TreeView historyData={history} projectOrder={projectOrder} />,
+    );
+    const text = container.textContent;
+    const idx6 = text.indexOf("4/6");
+    const idx5 = text.indexOf("4/5");
+    expect(idx6).toBeGreaterThan(-1);
+    expect(idx5).toBeGreaterThan(idx6);
+  });
+});

--- a/src/features/tree-view/layout.js
+++ b/src/features/tree-view/layout.js
@@ -1,0 +1,36 @@
+export const COL = 16;
+export const GRAPH_LEFT = 12;
+
+/**
+ * プロジェクトレーン（縦線）の x 座標を返す。
+ * TreeView コンテナの padding (16px) を含む絶対位置。
+ */
+export function laneLeftPx(projectIndex) {
+  return GRAPH_LEFT + projectIndex * COL + COL / 2 - 1 + 16;
+}
+
+/**
+ * タスクノードの丸印の中心 x 座標を返す。
+ */
+export function nodeCenterPx(projectIndex) {
+  return 16 + GRAPH_LEFT + projectIndex * COL + COL / 2;
+}
+
+/**
+ * プロジェクトレーン全体の横幅を返す。日付見出しやタスクラベルの左側 padding に使う。
+ */
+export function lanesWidthPx(projectCount) {
+  return GRAPH_LEFT + COL * projectCount + 6;
+}
+
+/**
+ * historyData を日付でグループ化し、日付降順で返す。
+ */
+export function groupByDateDesc(historyData) {
+  const groups = {};
+  for (const item of historyData) {
+    if (!groups[item.date]) groups[item.date] = [];
+    groups[item.date].push(item);
+  }
+  return Object.entries(groups).sort(([a], [b]) => b.localeCompare(a));
+}

--- a/src/features/tree-view/layout.test.js
+++ b/src/features/tree-view/layout.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+import {
+  COL,
+  GRAPH_LEFT,
+  groupByDateDesc,
+  laneLeftPx,
+  lanesWidthPx,
+  nodeCenterPx,
+} from "./layout.js";
+
+describe("laneLeftPx / nodeCenterPx / lanesWidthPx", () => {
+  test("プロジェクトインデックス 0 のレーン位置", () => {
+    expect(laneLeftPx(0)).toBe(GRAPH_LEFT + 0 + COL / 2 - 1 + 16);
+    expect(nodeCenterPx(0)).toBe(16 + GRAPH_LEFT + 0 + COL / 2);
+  });
+
+  test("プロジェクト数に比例してレーン幅が伸びる", () => {
+    expect(lanesWidthPx(1)).toBe(GRAPH_LEFT + COL + 6);
+    expect(lanesWidthPx(4)).toBe(GRAPH_LEFT + COL * 4 + 6);
+  });
+});
+
+describe("groupByDateDesc", () => {
+  test("空配列は空配列を返す", () => {
+    expect(groupByDateDesc([])).toEqual([]);
+  });
+
+  test("日付でグループ化し、日付降順でソート", () => {
+    const history = [
+      { id: "h1", date: "2026-04-05", title: "t1" },
+      { id: "h2", date: "2026-04-07", title: "t2" },
+      { id: "h3", date: "2026-04-05", title: "t3" },
+      { id: "h4", date: "2026-04-06", title: "t4" },
+    ];
+    const result = groupByDateDesc(history);
+    expect(result.map(([date]) => date)).toEqual([
+      "2026-04-07",
+      "2026-04-06",
+      "2026-04-05",
+    ]);
+    expect(result[2][1]).toHaveLength(2);
+  });
+});

--- a/src/prototype.jsx
+++ b/src/prototype.jsx
@@ -4,12 +4,13 @@ import { TODAY } from "./mocks/today.js";
 import { initialEvents } from "./mocks/events.js";
 import { initialTasks } from "./mocks/tasks.js";
 import { historyData } from "./mocks/history.js";
-import { fmtDuration, formatDate, timeToMin } from "./shared/lib/time.js";
+import { fmtDuration, timeToMin } from "./shared/lib/time.js";
 import { renderMarkdown } from "./shared/lib/markdown.jsx";
 import { ACTION_TYPES, log } from "./entities/action-log/logger.js";
 import { DayTimeline } from "./features/day-timeline/DayTimeline.jsx";
 import { TaskDetailPanel } from "./features/task-detail/TaskDetailPanel.jsx";
 import { EventDetailPanel } from "./features/event-detail/EventDetailPanel.jsx";
+import { TreeView } from "./features/tree-view/TreeView.jsx";
 
 // ─── Main ───────────────────────────────────────────────────────────
 export default function App() {
@@ -148,7 +149,7 @@ export default function App() {
           onOpenEvent={setEventDetailId}
         />
       ) : (
-        <TreeView historyData={historyData} />
+        <TreeView historyData={historyData} projectOrder={projectOrder} />
       )}
 
       {/* Detail panel overlay */}
@@ -658,145 +659,3 @@ function StackView({
   );
 }
 
-// ─── Tree View ──────────────────────────────────────────────────────
-function TreeView({ historyData }) {
-  const COL = 16,
-    GRAPH_LEFT = 12;
-  const groups = {};
-  historyData.forEach((t) => {
-    if (!groups[t.date]) groups[t.date] = [];
-    groups[t.date].push(t);
-  });
-  const dateGroups = Object.entries(groups).sort(([a], [b]) =>
-    b.localeCompare(a),
-  );
-
-  return (
-    <div style={{ position: "relative", paddingBottom: 40 }}>
-      {projectOrder.map((pk, pi) => (
-        <div
-          key={pk}
-          style={{
-            position: "absolute",
-            left: GRAPH_LEFT + pi * COL + COL / 2 - 1 + 16,
-            top: 0,
-            bottom: 0,
-            width: 2,
-            background: PROJECTS[pk].color,
-            opacity: 0.3,
-            zIndex: 1,
-            pointerEvents: "none",
-          }}
-        />
-      ))}
-      <div
-        style={{
-          padding: "14px 16px 6px",
-          display: "flex",
-          gap: 12,
-          position: "relative",
-          zIndex: 2,
-        }}
-      >
-        {projectOrder.map((k) => (
-          <div
-            key={k}
-            style={{ display: "flex", alignItems: "center", gap: 4 }}
-          >
-            <div
-              style={{
-                width: 6,
-                height: 6,
-                borderRadius: "50%",
-                background: PROJECTS[k].color,
-              }}
-            />
-            <span
-              style={{
-                fontSize: 9,
-                color: "#52525b",
-                fontFamily: "'Noto Sans JP', sans-serif",
-              }}
-            >
-              {PROJECTS[k].name}
-            </span>
-          </div>
-        ))}
-      </div>
-      <div style={{ position: "relative", zIndex: 2 }}>
-        {dateGroups.map(([date, items]) => (
-          <div key={date}>
-            <div
-              style={{
-                padding: "10px 16px 2px",
-                display: "flex",
-                alignItems: "center",
-              }}
-            >
-              <div
-                style={{ width: GRAPH_LEFT + COL * projectOrder.length + 6 }}
-              />
-              <span style={{ fontSize: 10, color: "#52525b" }}>
-                {formatDate(date)}
-              </span>
-              <div
-                style={{
-                  flex: 1,
-                  height: 1,
-                  background: "#18181b",
-                  marginLeft: 8,
-                }}
-              />
-            </div>
-            {items.map((task) => {
-              const pi = projectOrder.indexOf(task.project);
-              const nodeLeft = 16 + GRAPH_LEFT + pi * COL + COL / 2;
-              return (
-                <div
-                  key={task.id}
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    minHeight: 30,
-                    padding: "2px 16px",
-                    position: "relative",
-                  }}
-                >
-                  <div
-                    style={{
-                      position: "absolute",
-                      left: nodeLeft - 4,
-                      top: "50%",
-                      transform: "translateY(-50%)",
-                      width: 8,
-                      height: 8,
-                      borderRadius: "50%",
-                      background: "#0a0a0b",
-                      border: `2px solid ${PROJECTS[task.project].color}`,
-                      zIndex: 3,
-                    }}
-                  />
-                  <div
-                    style={{
-                      width: GRAPH_LEFT + COL * projectOrder.length + 6,
-                      flexShrink: 0,
-                    }}
-                  />
-                  <span
-                    style={{
-                      fontFamily: "'Noto Sans JP', sans-serif",
-                      fontSize: 11,
-                      color: "#71717a",
-                    }}
-                  >
-                    {task.title}
-                  </span>
-                </div>
-              );
-            })}
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}


### PR DESCRIPTION
## 概要

`TreeView` を `features/tree-view/` に分離。単一ファイルではなく、レイアウト計算を純粋関数に切り出した上で、`ProjectLanes` / `DateGroup` / `TreeView` の3コンポーネントに分割した。

Closes #9
Part of #3

## 主な変更

- `layout.js`: レーン位置・ノード位置・日付グルーピングの純粋関数
  - `laneLeftPx(i)`, `nodeCenterPx(i)`, `lanesWidthPx(count)`, `groupByDateDesc(history)`
- `ProjectLanes.jsx`: プロジェクトレーン（縦線 + レジェンド）
- `DateGroup.jsx`: 日付見出し + 同日タスクのノード列
- `TreeView.jsx`: 上記を組み合わせるラッパー
- `prototype.jsx` から `TreeView` 宣言を削除（約142行削減）
- `projectOrder` を `TreeView` の prop に（features → mocks 依存を避ける）
- 不要になった `formatDate` の import を削除

<details>
<summary>設計判断</summary>

- **layout.js を分離**: マジックナンバー（`COL=16`, `GRAPH_LEFT=12`）とレーン計算ロジックを1箇所に集約し、純粋関数としてテスト可能に
- **3コンポーネント分割**: `TreeView` → `ProjectLanes` + `DateGroup` とすることで、将来 Phase 3-4 で `DateGroup` に「その日の完了内訳サマリ」等を追加しやすい構造にする
- **`projectOrder` は prop**: `TreeView` / `ProjectLanes` / `DateGroup` すべてで受け取る。features 内で mocks を import せず、エントリ側（prototype.jsx / 将来の App）から注入する

</details>

## Test plan

- [x] `npm test` — 71テスト全パス（+9: layout 4, TreeView 5）
- [x] UI 動作確認は #12 (Next.js化) にて

## 次のステップ

残るは **#6 task-stack**（DnD含む最重量）。これで Task A (#3) 完了。

🤖 Generated with [Claude Code](https://claude.com/claude-code)