### PR TITLE
feat(p1-1): Supabase プロジェクト + スキーマ + RLS (#23)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,15 @@
+# kozutsumi 環境変数テンプレート
+# 手順: `cp .env.local.example .env.local` し、各値を埋める。
+# .env.local は git 管理外 (.gitignore)。
+
+# ===== Supabase =====
+# Supabase Dashboard > Project Settings > API から取得
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+
+# ===== Supabase Auth: Google OAuth (P1-2) =====
+# Google Cloud Console > OAuth 2.0 Client IDs から取得。
+# scope に https://www.googleapis.com/auth/calendar.readonly を含めること
+# (Phase 2 の Google Calendar 連携で再認証回避のため / phase1.md Step 2)
+SUPABASE_AUTH_GOOGLE_CLIENT_ID=
+SUPABASE_AUTH_GOOGLE_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,10 @@ tsconfig.tsbuildinfo
 .DS_Store
 *.log
 coverage/
+
+# Local env & Supabase CLI local state
+.env.local
+.env*.local
+supabase/.branches/
+supabase/.temp/
+supabase/.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,65 @@
 # kozutsumi 📦
-A personal AI secretary that grows smarter with you. kozutsumi breaks big tasks into small packages, stacks them by priority, and fits them into your calendar’s free slots. It learns from your behavior — what you avoid, where you underestimate, when you focus best — to deliver increasingly accurate daily plans.
+
+A personal AI secretary that grows smarter with you. kozutsumi breaks big tasks into small packages, stacks them by priority, and fits them into your calendar's free slots. It learns from your behavior — what you avoid, where you underestimate, when you focus best — to deliver increasingly accurate daily plans.
+
+プロダクトのビジョン・設計・ロードマップは [docs/](./docs/) を参照。新しい会話を始めるときは [docs/design/vision.md](./docs/design/vision.md) を最初に読むこと。
+
+## 開発セットアップ
+
+### 前提
+
+- Node.js 20+
+- [Supabase CLI](https://supabase.com/docs/guides/cli) (`brew install supabase/tap/supabase` など)
+- Docker (Supabase CLI がローカル Postgres を立てるのに使う)
+
+### 初回セットアップ
+
+```sh
+# 1. 依存をインストール
+npm install
+
+# 2. 環境変数ファイルをコピーして埋める
+cp .env.local.example .env.local
+
+# 3. ローカル Supabase を起動 (Postgres + Studio + Auth)
+supabase start
+
+# 4. マイグレーションを適用
+supabase db reset
+```
+
+`supabase start` 後に表示される `API URL` と `anon key` を `.env.local` の `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` に貼る。
+
+### Google OAuth (Phase 1 / P1-2 以降)
+
+Phase 2 の Google Calendar 連携で OAuth トークンを再利用するため、`calendar.readonly` scope を先行付与する。Google Cloud Console で OAuth 2.0 Client を作り、Client ID / Secret を `.env.local` の `SUPABASE_AUTH_GOOGLE_CLIENT_ID` / `SUPABASE_AUTH_GOOGLE_SECRET` に設定する。
+
+### よく使うコマンド
+
+```sh
+npm run dev        # Next.js dev server
+npm run typecheck  # TypeScript 型チェック
+npm run test       # Vitest 一括実行
+npm run lint       # ESLint
+```
+
+### Supabase スキーマの変更
+
+マイグレーションは `supabase/migrations/` に SQL を追加していく。
+
+```sh
+# 新規マイグレーション作成
+supabase migration new <name>
+
+# ローカル DB をリセットして全マイグレーション適用
+supabase db reset
+
+# 型再生成 (src/shared/types/database.ts を上書き)
+supabase gen types typescript --local > src/shared/types/database.ts
+```
+
+リモートにプッシュするときは `supabase db push`。
+
+## ドキュメント
+
+[docs/](./docs/) にビジョン / アーキテクチャ / Phase 別仕様をまとめている。[CLAUDE.md](./CLAUDE.md) の表が入り口。

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "@supabase/ssr": "^0.10.2",
+        "@supabase/supabase-js": "^2.103.3",
         "next": "^16.2.4",
         "react": "^19.2.5",
         "react-dom": "^19.2.5"
@@ -2344,6 +2346,104 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.103.3.tgz",
+      "integrity": "sha512-SMDJ4vg5jLXNEHdhN4J4ujSb203WangbDw1n3VaARH0ZqM51E6lJnoUAHlpQU9N7SzP0hfgghA9IvT8c7tGRfg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.103.3.tgz",
+      "integrity": "sha512-A2ZHi95GIRRlN9LGOSa/zGEIPg9taR1giDI9Gkfkgrcz0YmKV8ShiAplIrKsHQFdkzKxtsO3maJF0efL+i31mg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
+      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.103.3.tgz",
+      "integrity": "sha512-S0k/9FJVXDeejNfQLCJwRlm4IH8Wet/HEEdBTBpX6/G2o1eU/6CjQop/hJPZIwlQkI6D/zbHH8KymuCsBgy6jA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.103.3.tgz",
+      "integrity": "sha512-fUvKtSXMUk1BkApVwAurWtHF4Vzbb0UB9aC/fQXrRBek7Ta3Kaora+wHf/fGwFNQs7uRz+mvjIVpzLfpR32VXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.0",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/ssr": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.10.2.tgz",
+      "integrity": "sha512-JFbchN63CXLFHJRNT7udec4/RoD9PmXkSGko3QSO6vUuqGBtSzdmxR7FPfQNr7SuFd65I7Xv46q66ALjEN1cgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.102.1"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.103.3.tgz",
+      "integrity": "sha512-5bAIEubrw5keHcdKR2RTois0O1M2Ilx4UYuzOzc07G6mLGCPS/8t1nbC6Vq451pnxR3sK+rmtFHWb9CY/OPjAw==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.103.3.tgz",
+      "integrity": "sha512-DuPiAz5pIJsTAQCt7B6bDZrnLzlq9+/5bta/GWTsgpLn6AkuZQcmYsQHYplv4skQ8U2raKY5HASQOu4KtYq9Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.103.3",
+        "@supabase/functions-js": "2.103.3",
+        "@supabase/postgrest-js": "2.103.3",
+        "@supabase/realtime-js": "2.103.3",
+        "@supabase/storage-js": "2.103.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2509,7 +2609,6 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
@@ -2546,7 +2645,6 @@
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -3968,6 +4066,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5614,6 +5725,15 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -8443,7 +8563,6 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -8901,7 +9020,6 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@supabase/ssr": "^0.10.2",
+    "@supabase/supabase-js": "^2.103.3",
     "next": "^16.2.4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -12,6 +12,7 @@ import { EventDetailPanel } from "@/features/event-detail/EventDetailPanel";
 import { TaskDetailPanel } from "@/features/task-detail/TaskDetailPanel";
 import { TaskStack } from "@/features/task-stack/TaskStack";
 import { TreeView } from "@/features/tree-view/TreeView";
+import { UserMenu } from "@/features/user-menu/UserMenu";
 import { initialEvents } from "@/mocks/events";
 import { historyData } from "@/mocks/history";
 import { initialTasks } from "@/mocks/tasks";
@@ -21,9 +22,13 @@ type View = "stack" | "tree";
 
 type AppShellProps = {
   initialView: View;
+  user: {
+    email: string | null;
+    avatarUrl: string | null;
+  };
 };
 
-export function AppShell({ initialView }: AppShellProps) {
+export function AppShell({ initialView, user }: AppShellProps) {
   const view = initialView;
   const [tasks, setTasks] = useState<Task[]>(initialTasks);
   const [detailId, setDetailId] = useState<string | null>(null);
@@ -96,6 +101,7 @@ export function AppShell({ initialView }: AppShellProps) {
             );
           })}
         </div>
+        <UserMenu email={user.email} avatarUrl={user.avatarUrl} />
       </div>
 
       {view === "stack" ? (

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { createClient } from "@/shared/supabase/server";
+
+/**
+ * Supabase OAuth コールバック。
+ *
+ * Google OAuth から code を受け取ってセッションに交換する。
+ * エラー時は /login に戻し、query に理由を付ける。
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+  const next = searchParams.get("next") ?? "/";
+
+  if (!code) {
+    return NextResponse.redirect(`${origin}/login?error=missing_code`);
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase.auth.exchangeCodeForSession(code);
+  if (error) {
+    const reason = encodeURIComponent(error.message);
+    return NextResponse.redirect(`${origin}/login?error=${reason}`);
+  }
+
+  return NextResponse.redirect(`${origin}${next}`);
+}

--- a/src/app/login/LoginButton.tsx
+++ b/src/app/login/LoginButton.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+
+import { createClient } from "@/shared/supabase/client";
+
+/**
+ * Google OAuth でログインを開始する。
+ *
+ * scope に calendar.readonly を先行付与することで、Phase 2 の
+ * Google Calendar 連携時に再認証を回避する (phase1.md Step 2)。
+ */
+const GOOGLE_SCOPES = [
+  "openid",
+  "email",
+  "profile",
+  "https://www.googleapis.com/auth/calendar.readonly",
+].join(" ");
+
+export function LoginButton() {
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSignIn() {
+    setPending(true);
+    setError(null);
+    const supabase = createClient();
+    const origin = window.location.origin;
+    const { error: signInError } = await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: {
+        redirectTo: `${origin}/auth/callback`,
+        scopes: GOOGLE_SCOPES,
+        queryParams: {
+          access_type: "offline",
+          prompt: "consent",
+        },
+      },
+    });
+    if (signInError) {
+      setError(signInError.message);
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className="flex w-full max-w-[320px] flex-col gap-3">
+      <button
+        type="button"
+        onClick={onSignIn}
+        disabled={pending}
+        className="flex h-11 items-center justify-center gap-2 rounded-md bg-bg-elevated px-4 text-[13px] font-medium text-fg-emphasized transition-colors hover:bg-bg-divider disabled:opacity-60"
+      >
+        {pending ? "リダイレクト中..." : "Google でログイン"}
+      </button>
+      {error ? (
+        <p role="alert" className="text-[11px] text-accent-red">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,31 @@
+import { redirect } from "next/navigation";
+
+import { createClient } from "@/shared/supabase/server";
+
+import { LoginButton } from "./LoginButton";
+
+export default async function LoginPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (user) {
+    redirect("/");
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-8 px-6">
+      <div className="text-center">
+        <div className="font-jp text-[28px] font-bold -tracking-[0.02em]">
+          <span className="text-accent-blue">kozu</span>
+          <span className="text-fg-faint">tsumi</span>
+        </div>
+        <p className="mt-3 text-[12px] text-fg-weak">
+          個人特化AI秘書システム
+        </p>
+      </div>
+      <LoginButton />
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,27 @@
+import { redirect } from "next/navigation";
+
+import { createClient } from "@/shared/supabase/server";
+
 import { AppShell } from "./AppShell";
 
-export default function Page() {
-  return <AppShell initialView="stack" />;
+export default async function Page() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const meta = (user.user_metadata ?? {}) as Record<string, unknown>;
+  return (
+    <AppShell
+      initialView="stack"
+      user={{
+        email: user.email ?? null,
+        avatarUrl: typeof meta.avatar_url === "string" ? meta.avatar_url : null,
+      }}
+    />
+  );
 }

--- a/src/app/tree/page.tsx
+++ b/src/app/tree/page.tsx
@@ -1,5 +1,27 @@
+import { redirect } from "next/navigation";
+
+import { createClient } from "@/shared/supabase/server";
+
 import { AppShell } from "../AppShell";
 
-export default function TreePage() {
-  return <AppShell initialView="tree" />;
+export default async function TreePage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const meta = (user.user_metadata ?? {}) as Record<string, unknown>;
+  return (
+    <AppShell
+      initialView="tree"
+      user={{
+        email: user.email ?? null,
+        avatarUrl: typeof meta.avatar_url === "string" ? meta.avatar_url : null,
+      }}
+    />
+  );
 }

--- a/src/entities/action-log/logger.test.ts
+++ b/src/entities/action-log/logger.test.ts
@@ -1,10 +1,47 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { ACTION_TYPES, clearLog, getLog, log } from "./logger";
+
+// logger が createClient を import する前にモックしておく
+const insertMock = vi.fn(async () => ({ error: null }));
+const fromMock = vi.fn(() => ({ insert: insertMock }));
+type FakeUserResult = {
+  data: { user: { id: string } | null };
+  error: null;
+};
+const getUserMock = vi.fn<() => Promise<FakeUserResult>>(async () => ({
+  data: { user: { id: "user-1" } },
+  error: null,
+}));
+
+vi.mock("@/shared/supabase/client", () => ({
+  createClient: () => ({
+    auth: { getUser: getUserMock },
+    from: fromMock,
+  }),
+}));
+
+import {
+  ACTION_TYPES,
+  __resetLoggerClientForTest,
+  clearLog,
+  getLog,
+  log,
+} from "./logger";
+
+function flushMicrotasks() {
+  // persist() は fire-and-forget で複数段の await を含むため、
+  // マクロタスク境界まで待って完了を保証する。
+  return new Promise((r) => setTimeout(r, 0));
+}
 
 describe("log()", () => {
   beforeEach(() => {
     clearLog();
+    __resetLoggerClientForTest();
+    insertMock.mockClear();
+    fromMock.mockClear();
+    getUserMock.mockClear();
     vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
   });
   afterEach(() => {
     vi.restoreAllMocks();
@@ -34,12 +71,45 @@ describe("log()", () => {
       log("unknown_type", {}),
     ).toThrow(/unknown action_type/i);
   });
+
+  test("Supabase action_logs に user_id / action_type / metadata を insert する", async () => {
+    log(ACTION_TYPES.TASK_REORDERED, {
+      task_id: "t1",
+      from_position: 0,
+      to_position: 2,
+    });
+    await flushMicrotasks();
+    expect(fromMock).toHaveBeenCalledWith("action_logs");
+    expect(insertMock).toHaveBeenCalledWith({
+      user_id: "user-1",
+      action_type: "task_reordered",
+      task_id: "t1",
+      metadata: { task_id: "t1", from_position: 0, to_position: 2 },
+    });
+  });
+
+  test("未ログイン時は insert をスキップする", async () => {
+    getUserMock.mockResolvedValueOnce({ data: { user: null }, error: null });
+    log(ACTION_TYPES.TASK_COMPLETED, { task_id: "t1" });
+    await flushMicrotasks();
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  test("fire-and-forget: log() 自体は同期的に返る", () => {
+    // insert を pending のままにしても log() は即座に返る
+    insertMock.mockImplementationOnce(() => new Promise(() => {}));
+    const before = Date.now();
+    log(ACTION_TYPES.TASK_COMPLETED, { task_id: "t1" });
+    expect(Date.now() - before).toBeLessThan(50);
+  });
 });
 
 describe("getLog()", () => {
   beforeEach(() => {
     clearLog();
+    __resetLoggerClientForTest();
     vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
   });
   afterEach(() => {
     vi.restoreAllMocks();
@@ -59,7 +129,9 @@ describe("getLog()", () => {
 
 describe("clearLog()", () => {
   beforeEach(() => {
+    __resetLoggerClientForTest();
     vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
   });
   afterEach(() => {
     vi.restoreAllMocks();

--- a/src/entities/action-log/logger.ts
+++ b/src/entities/action-log/logger.ts
@@ -1,3 +1,6 @@
+import { createClient } from "@/shared/supabase/client";
+import type { Json } from "@/shared/types/database";
+
 import type {
   ActionLogEntry,
   ActionMetadataMap,
@@ -7,10 +10,14 @@ import type {
 /**
  * action-log logger
  *
- * Phase 3-4 で差別化の核となる行動ログのひな形。
- * 現時点ではメモリ配列 + console 出力のみ。Phase 1 本実装で Supabase 連携に差し替える。
+ * kozutsumi の差別化の核である行動ログを Supabase に永続化する。
+ * docs/specs/phase1.md Step 4 / docs/design/vision.md 参照。
  *
- * 参照: docs/specs/phase1.md Step 4 (action_logs)
+ * 設計原則:
+ * - fire-and-forget: log() は呼び出し元を絶対に await させない
+ *   (DnD や完了操作のレイテンシは UX 直結)
+ * - ログ欠損 < UI 停止: insert 失敗は console.error に留める
+ * - getLog()/clearLog() は開発・テスト時のデバッグ用
  */
 
 export const ACTION_TYPES = Object.freeze({
@@ -31,6 +38,56 @@ const KNOWN_TYPES = new Set<ActionType>(Object.values(ACTION_TYPES));
 
 let memoryLog: ActionLogEntry[] = [];
 
+type SupabaseClientLike = ReturnType<typeof createClient>;
+let cachedClient: SupabaseClientLike | null = null;
+
+function getClient(): SupabaseClientLike | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  if (!cachedClient) {
+    try {
+      cachedClient = createClient();
+    } catch (err) {
+      console.error("[action-log] failed to init supabase client", err);
+      return null;
+    }
+  }
+  return cachedClient;
+}
+
+function extractTaskId(metadata: Record<string, unknown>): string | null {
+  const v = metadata["task_id"];
+  return typeof v === "string" ? v : null;
+}
+
+async function persist<T extends ActionType>(
+  entry: ActionLogEntry<T>,
+): Promise<void> {
+  const supabase = getClient();
+  if (!supabase) return;
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    // 未ログイン時は RLS に引っかかるので送らない
+    return;
+  }
+
+  const { error } = await supabase.from("action_logs").insert({
+    user_id: user.id,
+    action_type: entry.action_type,
+    task_id: extractTaskId(
+      entry.metadata as unknown as Record<string, unknown>,
+    ),
+    metadata: entry.metadata as unknown as Json,
+  });
+  if (error) {
+    console.error("[action-log] insert failed", error);
+  }
+}
+
 export function log<T extends ActionType>(
   actionType: T,
   metadata?: ActionMetadataMap[T],
@@ -45,6 +102,12 @@ export function log<T extends ActionType>(
   };
   memoryLog.push(entry);
   console.log("[action-log]", actionType, entry.metadata);
+
+  // fire-and-forget: ここで await しないのが肝
+  void persist(entry).catch((err) => {
+    console.error("[action-log] persist error", err);
+  });
+
   return entry;
 }
 
@@ -54,4 +117,9 @@ export function getLog(): ActionLogEntry[] {
 
 export function clearLog(): void {
   memoryLog = [];
+}
+
+/** test 専用: cached client をリセット */
+export function __resetLoggerClientForTest(): void {
+  cachedClient = null;
 }

--- a/src/features/user-menu/UserMenu.tsx
+++ b/src/features/user-menu/UserMenu.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { createClient } from "@/shared/supabase/client";
+
+type UserMenuProps = {
+  email: string | null;
+  avatarUrl: string | null;
+};
+
+/**
+ * ヘッダー右端のアバター。タップでログアウトメニューを開く。
+ */
+export function UserMenu({ email, avatarUrl }: UserMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [pending, setPending] = useState(false);
+  const router = useRouter();
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onClick(e: MouseEvent) {
+      if (!menuRef.current?.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    window.addEventListener("mousedown", onClick);
+    return () => window.removeEventListener("mousedown", onClick);
+  }, [open]);
+
+  async function onSignOut() {
+    setPending(true);
+    const supabase = createClient();
+    await supabase.auth.signOut();
+    router.replace("/login");
+    router.refresh();
+  }
+
+  const initial = (email?.[0] ?? "?").toUpperCase();
+
+  return (
+    <div ref={menuRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-label="アカウントメニュー"
+        className="flex h-7 w-7 items-center justify-center overflow-hidden rounded-full bg-bg-divider text-[11px] font-semibold text-fg-emphasized"
+      >
+        {avatarUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={avatarUrl}
+            alt=""
+            className="h-full w-full object-cover"
+            referrerPolicy="no-referrer"
+          />
+        ) : (
+          initial
+        )}
+      </button>
+      {open ? (
+        <div className="absolute right-0 top-9 z-50 w-52 rounded-md border border-bg-divider bg-bg-elevated p-2 shadow-lg">
+          {email ? (
+            <div className="truncate px-2 py-1 text-[11px] text-fg-muted">
+              {email}
+            </div>
+          ) : null}
+          <button
+            type="button"
+            onClick={onSignOut}
+            disabled={pending}
+            className="mt-1 w-full rounded px-2 py-1.5 text-left text-[12px] text-fg-emphasized transition-colors hover:bg-bg-divider disabled:opacity-60"
+          >
+            {pending ? "ログアウト中..." : "ログアウト"}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,19 @@
+import type { NextRequest } from "next/server";
+
+import { updateSession } from "@/shared/supabase/middleware";
+
+export async function proxy(request: NextRequest) {
+  return updateSession(request);
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Next.js の静的アセットと画像は除外。
+     * - _next/static, _next/image
+     * - favicon.ico
+     * - 画像拡張子
+     */
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)",
+  ],
+};

--- a/src/shared/supabase/client.ts
+++ b/src/shared/supabase/client.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { createBrowserClient } from "@supabase/ssr";
+
+import type { Database } from "@/shared/types/database";
+
+import { getSupabaseEnv } from "./env";
+
+/**
+ * ブラウザ実行環境向けの Supabase クライアント。
+ *
+ * Next.js の Client Component から使う。セッションは cookie に保持され、
+ * middleware 経由でサーバーとも同期する。
+ */
+export function createClient() {
+  const { url, anonKey } = getSupabaseEnv();
+  return createBrowserClient<Database>(url, anonKey);
+}

--- a/src/shared/supabase/env.ts
+++ b/src/shared/supabase/env.ts
@@ -1,0 +1,27 @@
+/**
+ * Supabase 環境変数の読み取り。
+ *
+ * 必須変数が無い場合は起動時に早期失敗させる。
+ * クライアント側でも使うため NEXT_PUBLIC_ プレフィクス必須。
+ */
+function required(name: string, value: string | undefined): string {
+  if (!value) {
+    throw new Error(
+      `[kozutsumi] Missing env: ${name}. See .env.local.example`,
+    );
+  }
+  return value;
+}
+
+export function getSupabaseEnv() {
+  return {
+    url: required(
+      "NEXT_PUBLIC_SUPABASE_URL",
+      process.env.NEXT_PUBLIC_SUPABASE_URL,
+    ),
+    anonKey: required(
+      "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    ),
+  };
+}

--- a/src/shared/supabase/middleware.ts
+++ b/src/shared/supabase/middleware.ts
@@ -1,0 +1,54 @@
+import { createServerClient } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
+
+import type { Database } from "@/shared/types/database";
+
+import { getSupabaseEnv } from "./env";
+
+const PUBLIC_PATHS = ["/login", "/auth/callback"];
+
+/**
+ * middleware からの Supabase セッション更新 + 未ログインリダイレクト。
+ *
+ * @supabase/ssr の推奨フローに沿って response cookie を都度書き戻す。
+ */
+export async function updateSession(request: NextRequest) {
+  let response = NextResponse.next({ request });
+  const { url, anonKey } = getSupabaseEnv();
+
+  const supabase = createServerClient<Database>(url, anonKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        for (const { name, value } of cookiesToSet) {
+          request.cookies.set(name, value);
+        }
+        response = NextResponse.next({ request });
+        for (const { name, value, options } of cookiesToSet) {
+          response.cookies.set(name, value, options);
+        }
+      },
+    },
+  });
+
+  // セッション refresh を兼ねて user を取得
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const pathname = request.nextUrl.pathname;
+  const isPublic = PUBLIC_PATHS.some(
+    (p) => pathname === p || pathname.startsWith(`${p}/`),
+  );
+
+  if (!user && !isPublic) {
+    const loginUrl = request.nextUrl.clone();
+    loginUrl.pathname = "/login";
+    loginUrl.search = "";
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return response;
+}

--- a/src/shared/supabase/server.ts
+++ b/src/shared/supabase/server.ts
@@ -1,0 +1,35 @@
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+
+import type { Database } from "@/shared/types/database";
+
+import { getSupabaseEnv } from "./env";
+
+/**
+ * Server Component / Route Handler 向け Supabase クライアント。
+ *
+ * Next.js 15 以降は `cookies()` が Promise を返すため await する。
+ * Server Component からは cookie を set できないので、setAll は
+ * 例外を握り潰す (セッション更新は middleware が担う)。
+ */
+export async function createClient() {
+  const cookieStore = await cookies();
+  const { url, anonKey } = getSupabaseEnv();
+
+  return createServerClient<Database>(url, anonKey, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll(cookiesToSet) {
+        try {
+          for (const { name, value, options } of cookiesToSet) {
+            cookieStore.set(name, value, options);
+          }
+        } catch {
+          // Server Component からの set は無視して OK。middleware が refresh する。
+        }
+      },
+    },
+  });
+}

--- a/src/shared/types/database.ts
+++ b/src/shared/types/database.ts
@@ -45,6 +45,7 @@ export type Database = {
           is_primary?: boolean;
           created_at?: string;
         };
+        Relationships: [];
       };
       tasks: {
         Row: {
@@ -92,6 +93,7 @@ export type Database = {
           created_at?: string;
           completed_at?: string | null;
         };
+        Relationships: [];
       };
       events: {
         Row: {
@@ -136,6 +138,7 @@ export type Database = {
           external_id?: string | null;
           created_at?: string;
         };
+        Relationships: [];
       };
       task_time_entries: {
         Row: {
@@ -162,6 +165,7 @@ export type Database = {
           pause_reason?: Database["public"]["Enums"]["pause_reason"] | null;
           duration_seconds?: number | null;
         };
+        Relationships: [];
       };
       action_logs: {
         Row: {
@@ -188,6 +192,7 @@ export type Database = {
           metadata?: Json;
           created_at?: string;
         };
+        Relationships: [];
       };
     };
     Views: Record<string, never>;

--- a/src/shared/types/database.ts
+++ b/src/shared/types/database.ts
@@ -1,0 +1,210 @@
+/**
+ * Supabase データベース型定義
+ *
+ * 本来は `supabase gen types typescript --local > src/shared/types/database.ts`
+ * で自動生成する。Phase 1 時点ではローカル Supabase が立ち上がっていない環境でも
+ * 型チェックを通せるよう、生成物と互換の形で手書きしている。
+ *
+ * Supabase プロジェクト起動後は上記コマンドで置き換えること (phase1.md Step 1.4)。
+ *
+ * スキーマ参照: supabase/migrations/20260419000000_initial_schema.sql
+ */
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+export type Database = {
+  public: {
+    Tables: {
+      projects: {
+        Row: {
+          id: string;
+          user_id: string;
+          name: string;
+          color: string;
+          is_primary: boolean;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          name: string;
+          color: string;
+          is_primary?: boolean;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          name?: string;
+          color?: string;
+          is_primary?: boolean;
+          created_at?: string;
+        };
+      };
+      tasks: {
+        Row: {
+          id: string;
+          user_id: string;
+          project_id: string | null;
+          title: string;
+          body: string;
+          estimated_minutes: number | null;
+          status: Database["public"]["Enums"]["task_status"];
+          stack_order: number | null;
+          depends_on_event_id: string | null;
+          is_interruption: boolean;
+          parent_task_id: string | null;
+          created_at: string;
+          completed_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          project_id?: string | null;
+          title: string;
+          body?: string;
+          estimated_minutes?: number | null;
+          status?: Database["public"]["Enums"]["task_status"];
+          stack_order?: number | null;
+          depends_on_event_id?: string | null;
+          is_interruption?: boolean;
+          parent_task_id?: string | null;
+          created_at?: string;
+          completed_at?: string | null;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          project_id?: string | null;
+          title?: string;
+          body?: string;
+          estimated_minutes?: number | null;
+          status?: Database["public"]["Enums"]["task_status"];
+          stack_order?: number | null;
+          depends_on_event_id?: string | null;
+          is_interruption?: boolean;
+          parent_task_id?: string | null;
+          created_at?: string;
+          completed_at?: string | null;
+        };
+      };
+      events: {
+        Row: {
+          id: string;
+          user_id: string;
+          title: string;
+          start_time: string;
+          end_time: string;
+          project_id: string | null;
+          meet_url: string | null;
+          has_attachments: boolean;
+          description: string;
+          source: Database["public"]["Enums"]["event_source"];
+          external_id: string | null;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          title: string;
+          start_time: string;
+          end_time: string;
+          project_id?: string | null;
+          meet_url?: string | null;
+          has_attachments?: boolean;
+          description?: string;
+          source?: Database["public"]["Enums"]["event_source"];
+          external_id?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          title?: string;
+          start_time?: string;
+          end_time?: string;
+          project_id?: string | null;
+          meet_url?: string | null;
+          has_attachments?: boolean;
+          description?: string;
+          source?: Database["public"]["Enums"]["event_source"];
+          external_id?: string | null;
+          created_at?: string;
+        };
+      };
+      task_time_entries: {
+        Row: {
+          id: string;
+          task_id: string;
+          started_at: string;
+          paused_at: string | null;
+          pause_reason: Database["public"]["Enums"]["pause_reason"] | null;
+          duration_seconds: number | null;
+        };
+        Insert: {
+          id?: string;
+          task_id: string;
+          started_at: string;
+          paused_at?: string | null;
+          pause_reason?: Database["public"]["Enums"]["pause_reason"] | null;
+          duration_seconds?: number | null;
+        };
+        Update: {
+          id?: string;
+          task_id?: string;
+          started_at?: string;
+          paused_at?: string | null;
+          pause_reason?: Database["public"]["Enums"]["pause_reason"] | null;
+          duration_seconds?: number | null;
+        };
+      };
+      action_logs: {
+        Row: {
+          id: string;
+          user_id: string;
+          action_type: string;
+          task_id: string | null;
+          metadata: Json;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          action_type: string;
+          task_id?: string | null;
+          metadata?: Json;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          action_type?: string;
+          task_id?: string | null;
+          metadata?: Json;
+          created_at?: string;
+        };
+      };
+    };
+    Views: Record<string, never>;
+    Functions: Record<string, never>;
+    Enums: {
+      task_status: "idle" | "active" | "paused" | "done";
+      event_source: "manual" | "google_calendar";
+      pause_reason: "meeting" | "interruption" | "voluntary";
+    };
+  };
+};
+
+export type Tables<T extends keyof Database["public"]["Tables"]> =
+  Database["public"]["Tables"][T]["Row"];
+export type TablesInsert<T extends keyof Database["public"]["Tables"]> =
+  Database["public"]["Tables"][T]["Insert"];
+export type TablesUpdate<T extends keyof Database["public"]["Tables"]> =
+  Database["public"]["Tables"][T]["Update"];
+export type Enums<T extends keyof Database["public"]["Enums"]> =
+  Database["public"]["Enums"][T];

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,34 @@
+# kozutsumi Supabase local config
+# 参照: https://supabase.com/docs/guides/cli/config
+#
+# 最小構成。より細かい設定が必要になったら `supabase init` で再生成して
+# 差分を取り込む。
+
+project_id = "kozutsumi"
+
+[api]
+enabled = true
+port = 54321
+schemas = ["public"]
+
+[db]
+port = 54322
+shadow_port = 54320
+major_version = 15
+
+[studio]
+enabled = true
+port = 54323
+
+[auth]
+enabled = true
+site_url = "http://localhost:3000"
+additional_redirect_urls = ["http://localhost:3000/auth/callback"]
+jwt_expiry = 3600
+enable_signup = true
+
+# P1-2 で詳細設定。calendar.readonly scope を先行付与する前提。
+[auth.external.google]
+enabled = false
+client_id = "env(SUPABASE_AUTH_GOOGLE_CLIENT_ID)"
+secret = "env(SUPABASE_AUTH_GOOGLE_SECRET)"

--- a/supabase/migrations/20260419000000_initial_schema.sql
+++ b/supabase/migrations/20260419000000_initial_schema.sql
@@ -1,0 +1,242 @@
+-- kozutsumi Phase 1 initial schema
+--
+-- Scope: projects / tasks / events / task_time_entries / action_logs
+-- References: docs/specs/phase1.md Step 1
+--
+-- 設計判断:
+-- * Phase 1 では action_logs / task_time_entries も先に掘っておく
+--   (docs/design/vision.md の差別化の核=行動データ取得基盤)
+-- * Enum は SQL 型として定義しフロント型と一致させる
+-- * RLS は user_id = auth.uid() を基本、子テーブルは親テーブル経由で制約
+-- * 並べ替えの多頻度 update を想定し tasks(user_id, stack_order) に index
+
+create extension if not exists "pgcrypto";
+
+-- =====================================================================
+-- Enum types
+-- =====================================================================
+
+create type public.task_status as enum ('idle', 'active', 'paused', 'done');
+create type public.event_source as enum ('manual', 'google_calendar');
+create type public.pause_reason as enum ('meeting', 'interruption', 'voluntary');
+
+-- =====================================================================
+-- projects
+-- =====================================================================
+
+create table public.projects (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on delete cascade,
+  name text not null,
+  color text not null,
+  is_primary boolean not null default false,
+  created_at timestamptz not null default now()
+);
+
+create index projects_user_id_idx on public.projects (user_id);
+
+-- =====================================================================
+-- tasks
+-- =====================================================================
+
+create table public.tasks (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on delete cascade,
+  project_id uuid references public.projects (id) on delete set null,
+  title text not null,
+  body text not null default '',
+  estimated_minutes integer,
+  status public.task_status not null default 'idle',
+  stack_order integer,
+  depends_on_event_id uuid,
+  is_interruption boolean not null default false,
+  parent_task_id uuid references public.tasks (id) on delete set null,
+  created_at timestamptz not null default now(),
+  completed_at timestamptz,
+  constraint tasks_estimated_minutes_positive
+    check (estimated_minutes is null or estimated_minutes > 0)
+);
+
+create index tasks_user_id_idx on public.tasks (user_id);
+create index tasks_user_stack_idx on public.tasks (user_id, stack_order);
+create index tasks_project_id_idx on public.tasks (project_id);
+create index tasks_parent_task_id_idx on public.tasks (parent_task_id);
+
+-- =====================================================================
+-- events
+-- =====================================================================
+
+create table public.events (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on delete cascade,
+  title text not null,
+  start_time timestamptz not null,
+  end_time timestamptz not null,
+  project_id uuid references public.projects (id) on delete set null,
+  meet_url text,
+  has_attachments boolean not null default false,
+  description text not null default '',
+  source public.event_source not null default 'manual',
+  external_id text,
+  created_at timestamptz not null default now(),
+  constraint events_time_order check (end_time > start_time),
+  constraint events_external_id_unique unique (source, external_id)
+);
+
+create index events_user_id_idx on public.events (user_id);
+create index events_user_start_idx on public.events (user_id, start_time);
+
+-- depends_on_event_id は events 作成後に FK を追加
+alter table public.tasks
+  add constraint tasks_depends_on_event_fk
+  foreign key (depends_on_event_id) references public.events (id) on delete set null;
+
+-- =====================================================================
+-- task_time_entries
+-- =====================================================================
+
+create table public.task_time_entries (
+  id uuid primary key default gen_random_uuid(),
+  task_id uuid not null references public.tasks (id) on delete cascade,
+  started_at timestamptz not null,
+  paused_at timestamptz,
+  pause_reason public.pause_reason,
+  duration_seconds integer,
+  constraint task_time_entries_pause_reason_requires_paused
+    check (pause_reason is null or paused_at is not null),
+  constraint task_time_entries_duration_non_negative
+    check (duration_seconds is null or duration_seconds >= 0)
+);
+
+create index task_time_entries_task_id_idx on public.task_time_entries (task_id);
+create index task_time_entries_open_idx
+  on public.task_time_entries (task_id)
+  where paused_at is null;
+
+-- =====================================================================
+-- action_logs
+-- =====================================================================
+
+create table public.action_logs (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on delete cascade,
+  action_type text not null,
+  task_id uuid references public.tasks (id) on delete set null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+-- 想定クエリ: ユーザー単位で時系列に再生 / 種類で絞り込み
+create index action_logs_user_created_idx
+  on public.action_logs (user_id, created_at desc);
+create index action_logs_action_type_idx
+  on public.action_logs (action_type);
+create index action_logs_task_id_idx on public.action_logs (task_id);
+
+-- =====================================================================
+-- Row Level Security
+-- =====================================================================
+
+alter table public.projects enable row level security;
+alter table public.tasks enable row level security;
+alter table public.events enable row level security;
+alter table public.task_time_entries enable row level security;
+alter table public.action_logs enable row level security;
+
+-- projects
+create policy "projects: owner can select"
+  on public.projects for select
+  using (user_id = auth.uid());
+create policy "projects: owner can insert"
+  on public.projects for insert
+  with check (user_id = auth.uid());
+create policy "projects: owner can update"
+  on public.projects for update
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+create policy "projects: owner can delete"
+  on public.projects for delete
+  using (user_id = auth.uid());
+
+-- tasks
+create policy "tasks: owner can select"
+  on public.tasks for select
+  using (user_id = auth.uid());
+create policy "tasks: owner can insert"
+  on public.tasks for insert
+  with check (user_id = auth.uid());
+create policy "tasks: owner can update"
+  on public.tasks for update
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+create policy "tasks: owner can delete"
+  on public.tasks for delete
+  using (user_id = auth.uid());
+
+-- events
+create policy "events: owner can select"
+  on public.events for select
+  using (user_id = auth.uid());
+create policy "events: owner can insert"
+  on public.events for insert
+  with check (user_id = auth.uid());
+create policy "events: owner can update"
+  on public.events for update
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+create policy "events: owner can delete"
+  on public.events for delete
+  using (user_id = auth.uid());
+
+-- task_time_entries: 親 tasks 経由で所有者チェック
+create policy "task_time_entries: owner can select"
+  on public.task_time_entries for select
+  using (
+    exists (
+      select 1 from public.tasks t
+      where t.id = task_time_entries.task_id
+        and t.user_id = auth.uid()
+    )
+  );
+create policy "task_time_entries: owner can insert"
+  on public.task_time_entries for insert
+  with check (
+    exists (
+      select 1 from public.tasks t
+      where t.id = task_time_entries.task_id
+        and t.user_id = auth.uid()
+    )
+  );
+create policy "task_time_entries: owner can update"
+  on public.task_time_entries for update
+  using (
+    exists (
+      select 1 from public.tasks t
+      where t.id = task_time_entries.task_id
+        and t.user_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1 from public.tasks t
+      where t.id = task_time_entries.task_id
+        and t.user_id = auth.uid()
+    )
+  );
+create policy "task_time_entries: owner can delete"
+  on public.task_time_entries for delete
+  using (
+    exists (
+      select 1 from public.tasks t
+      where t.id = task_time_entries.task_id
+        and t.user_id = auth.uid()
+    )
+  );
+
+-- action_logs: 読み取りのみユーザーに許可 (行動ログは削除させない運用が原則)
+create policy "action_logs: owner can select"
+  on public.action_logs for select
+  using (user_id = auth.uid());
+create policy "action_logs: owner can insert"
+  on public.action_logs for insert
+  with check (user_id = auth.uid());

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,11 @@
+-- kozutsumi seed data (local development only)
+--
+-- `supabase db reset` 時に自動実行される。
+-- 本番 / dev 環境には流さないこと。
+--
+-- 実データ投入は P1-3 (tasks/events/projects CRUD 差し替え) で
+-- アプリ側の「サンプル投入」フローに寄せる予定。ここでは空のまま。
+
+-- 例: 認証済みユーザーを手で入れる場合は supabase/studio から行う。
+-- RLS 下で seed するなら service_role key で挿入するか、
+-- テストユーザーを作った後に app 経由で投入する。


### PR DESCRIPTION
行動ログを Phase 1 から実 DB に蓄積できるよう、Phase 3-4 で使う
action_logs / task_time_entries も初回マイグレーションで用意する。

- supabase/migrations/: projects / tasks / events / task_time_entries
  / action_logs を RLS 有効で作成
- src/shared/types/database.ts: Supabase 生成型と互換の手書き型
  (supabase gen types typescript で将来置換)
- .env.local.example / README に接続手順