### PR TITLE
ci: GitHub Actions で typecheck / lint / test / build / gitleaks を並列実行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm test
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+
+  gitleaks:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- PR と main への push で `typecheck` / `lint` / `test` / `build` / `gitleaks` を **並列実行**（依存がないので `needs:` なし）
- `concurrency` で同一ブランチの古い run を自動キャンセル（CI 枠節約）
- Node 22 + `cache: npm` で `npm ci` を高速化
- `gitleaks` は `fetch-depth: 0` で全履歴スキャン

## 構成

| Job | コマンド | 役割 |
|---|---|---|
| Typecheck | `npm run typecheck` | TS 型崩れ検知 |
| Lint | `npm run lint` | ESLint 違反検知 |
| Test | `npm test` | Vitest（94 tests）退行検知 |
| Build | `npm run build` | Next.js ビルド失敗 / RSC 境界エラー検知 |
| Secret scan | `gitleaks/gitleaks-action@v2` | Supabase キー等の混入予防 |

## 今回やらないこと（別 issue）

- Prettier 導入 + format チェック
- Supabase migration の CI 検証
- Dependabot 設定

## Test plan

- [x] この PR で全 5 ジョブが並列に起動することを Actions タブで確認
- [x] いずれのジョブも green になること
- [ ] 追加 push 時に古い run が cancel されること

https://claude.ai/code/session_01MnNSPbpAoeqL4dFHZnuXgf