### PR TITLE
ci: Dependabot で npm / GitHub Actions の依存更新を自動化 (#33)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,66 @@
+version: 2
+
+updates:
+  # アプリ本体の npm 依存
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    # 新リリースは一定期間寝かせてから取り込む（初期不具合を踏まないため）。
+    # cooldown は version-updates にのみ適用される。Dependabot security updates は
+    # cooldown を無視して即時 PR が立つので、脆弱性対応の速度は損なわれない。
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+      include:
+        - "*"
+    # patch / minor はまとめて 1 PR に集約。major は個別 PR にして慎重にレビュー。
+    groups:
+      production-minor-patch:
+        applies-to: version-updates
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development-minor-patch:
+        applies-to: version-updates
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "deps"
+      prefix-development: "deps-dev"
+      include: "scope"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+      include:
+        - "*"
+    groups:
+      actions-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "ci"
+      include: "scope"


### PR DESCRIPTION
- 週次 (月曜 09:00 JST) で npm と github-actions の更新 PR を生成
- cooldown を設定し、新リリースは一定期間寝かせてから取り込む
  (major: 30日 / minor: 7日 / patch: 3日)
- cooldown は version-updates にのみ適用される。Dependabot security
  updates はこれを無視して即時 PR を立てるので、脆弱性対応の速度は
  損なわない
- patch / minor はまとめて 1 PR、major は個別 PR に分けてレビュー粒度
  を調整
- open-pull-requests-limit: 5