### PR TITLE
feat(p1-3): tasks / events / projects CRUD を Supabase 化 (#26)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.103.3",
+        "@tanstack/react-query": "^5.99.1",
         "next": "^16.2.4",
         "react": "^19.2.5",
         "react-dom": "^19.2.5"
@@ -2451,6 +2452,32 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.99.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.1.tgz",
+      "integrity": "sha512-5E8xwxyWvr22yt7zvzP3KOZ5TUElOdVA45NP3/Ao1m9mvc9i18NLTDe9m3M00BH2DR5J20cv7xckMPlhKNs+vQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.99.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.1.tgz",
+      "integrity": "sha512-akg5GdwW70lvJvCqVHZ7tizGyc+TATjUzKX9RuF1xknhEe/1leofXk7YLYbrbRsuhNbHJBAayaQUMvvOFZ5L5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.99.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.103.3",
+    "@tanstack/react-query": "^5.99.1",
     "next": "^16.2.4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -1,27 +1,54 @@
 "use client";
 
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type QueryClient,
+} from "@tanstack/react-query";
 import Link from "next/link";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { ACTION_TYPES, log } from "@/entities/action-log/logger";
+import {
+  createEvent as apiCreateEvent,
+  listEvents,
+  type CreateEventInput,
+} from "@/entities/event/api";
 import type { Event } from "@/entities/event/types";
-import { projectOrder } from "@/entities/project/projects";
+import {
+  createProject as apiCreateProject,
+  listProjects,
+  type CreateProjectInput,
+} from "@/entities/project/api";
+import { ProjectsProvider } from "@/entities/project/ProjectsContext";
+import type { Project } from "@/entities/project/types";
+import {
+  createTask as apiCreateTask,
+  deleteTask as apiDeleteTask,
+  listTasks,
+  reorderTasks as apiReorderTasks,
+  updateTask as apiUpdateTask,
+  type CreateTaskInput,
+} from "@/entities/task/api";
 import type { Task } from "@/entities/task/types";
+import { AddButton } from "@/features/add-forms/AddButton";
+import { AddPanel } from "@/features/add-forms/AddPanel";
 import { DayTimeline } from "@/features/day-timeline/DayTimeline";
 import { EventDetailPanel } from "@/features/event-detail/EventDetailPanel";
 import { TaskDetailPanel } from "@/features/task-detail/TaskDetailPanel";
 import { TaskStack } from "@/features/task-stack/TaskStack";
 import { TreeView } from "@/features/tree-view/TreeView";
 import { UserMenu } from "@/features/user-menu/UserMenu";
-import { buildInitialEvents } from "@/mocks/events";
 import { historyData } from "@/mocks/history";
-import { buildInitialTasks } from "@/mocks/tasks";
+import { clearAllUserData, seedSampleDataToSupabase } from "@/mocks/seed";
 import {
   readSampleDataMode,
   writeSampleDataMode,
 } from "@/shared/lib/sample-data";
 import { isDone } from "@/shared/lib/task";
 import { nowMinutesOfDay, todayIso } from "@/shared/lib/time";
+import { createClient } from "@/shared/supabase/client";
 
 type View = "stack" | "tree";
 
@@ -33,84 +60,272 @@ type AppShellProps = {
   };
 };
 
+/**
+ * Query key と「どの queryClient から書き換えるか」をここに集約する。
+ * 各ミューテーションは optimistic update を同じキーに対して適用する。
+ */
+const keys = {
+  projects: ["projects"] as const,
+  tasks: ["tasks"] as const,
+  events: ["events"] as const,
+};
+
 export function AppShell({ initialView, user }: AppShellProps) {
   const view = initialView;
-  const [tasks, setTasks] = useState<Task[]>(() => buildInitialTasks());
-  const [events, setEvents] = useState<Event[]>(() => buildInitialEvents());
+  const supabase = useMemo(() => createClient(), []);
+  const queryClient = useQueryClient();
+
+  const projectsQuery = useQuery({
+    queryKey: keys.projects,
+    queryFn: () => listProjects(supabase),
+  });
+  const tasksQuery = useQuery({
+    queryKey: keys.tasks,
+    queryFn: () => listTasks(supabase),
+  });
+  const eventsQuery = useQuery({
+    queryKey: keys.events,
+    queryFn: () => listEvents(supabase),
+  });
+
+  const projects = useMemo(
+    () => projectsQuery.data ?? [],
+    [projectsQuery.data],
+  );
+  const tasks = useMemo(() => tasksQuery.data ?? [], [tasksQuery.data]);
+  const events = useMemo(() => eventsQuery.data ?? [], [eventsQuery.data]);
+
   const [detailId, setDetailId] = useState<string | null>(null);
   const [eventDetailId, setEventDetailId] = useState<string | null>(null);
+  const [addOpen, setAddOpen] = useState(false);
   const [nowMin, setNowMin] = useState<number>(9 * 60);
   const today = useMemo(() => todayIso(), []);
 
-  // クライアント初期化: マウント後に localStorage(外部ストア) と現在時刻を同期する。
-  // SSR では window が無いため、この 3 つの setState はハイドレート後の 1 回だけ発火する。
   useEffect(() => {
+    // マウント後にローカル時刻と同期する。SSR 時 nowMinutesOfDay() はブラウザ API 依存のため不可。
     /* eslint-disable react-hooks/set-state-in-effect */
-    if (readSampleDataMode() === "cleared") {
-      setTasks([]);
-      setEvents([]);
-    }
     setNowMin(nowMinutesOfDay());
     /* eslint-enable react-hooks/set-state-in-effect */
     const id = window.setInterval(() => setNowMin(nowMinutesOfDay()), 60_000);
     return () => window.clearInterval(id);
   }, []);
 
-  const toggleDone = useCallback((id: string) => {
-    setTasks((ts) => {
-      const target = ts.find((t) => t.id === id);
+  // 初回ログイン時に自動 seed: 全テーブル空かつ「cleared」フラグ無しなら投入する。
+  // ref ガードでストリクトモードでの 2 重 fire を防ぎつつ、ローディング完了後 1 回だけ実行。
+  const seedingRef = useRef(false);
+  useEffect(() => {
+    if (seedingRef.current) return;
+    if (!projectsQuery.isSuccess || !tasksQuery.isSuccess || !eventsQuery.isSuccess) {
+      return;
+    }
+    if (readSampleDataMode() === "cleared") return;
+    if (projects.length > 0 || tasks.length > 0 || events.length > 0) return;
+    seedingRef.current = true;
+    seedSampleDataToSupabase(supabase)
+      .then(() => {
+        writeSampleDataMode("default");
+        return invalidateAll(queryClient);
+      })
+      .catch((err) => {
+        // 失敗時に再試行ループへ入らないよう seedingRef は立てたまま。
+        // ユーザー明示操作「サンプル再投入」で再試行できる。
+        console.error("[seed] failed", err);
+      });
+  }, [
+    projectsQuery.isSuccess,
+    tasksQuery.isSuccess,
+    eventsQuery.isSuccess,
+    projects.length,
+    tasks.length,
+    events.length,
+    supabase,
+    queryClient,
+  ]);
+
+  // ---- Mutations (optimistic) ---------------------------------------------
+
+  const toggleDoneMutation = useMutation({
+    mutationFn: (id: string) => {
+      const target = tasks.find((t) => t.id === id);
+      if (!target) throw new Error("task not found");
+      const nextDone = !isDone(target);
+      return apiUpdateTask(supabase, id, {
+        status: nextDone ? "done" : "idle",
+        completedAt: nextDone ? new Date().toISOString() : null,
+      });
+    },
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: keys.tasks });
+      const previous = queryClient.getQueryData<Task[]>(keys.tasks);
+      const target = previous?.find((t) => t.id === id);
       if (target && !isDone(target)) {
         log(ACTION_TYPES.TASK_COMPLETED, { task_id: id });
       }
-      return ts.map((t) =>
-        t.id === id
-          ? {
-              ...t,
-              status: isDone(t) ? "idle" : "done",
-              completedAt: isDone(t) ? null : new Date().toISOString(),
-            }
-          : t,
+      queryClient.setQueryData<Task[]>(keys.tasks, (prev) =>
+        (prev ?? []).map((t) =>
+          t.id === id
+            ? {
+                ...t,
+                status: isDone(t) ? "idle" : "done",
+                completedAt: isDone(t) ? null : new Date().toISOString(),
+              }
+            : t,
+        ),
       );
-    });
-  }, []);
+      return { previous };
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(keys.tasks, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: keys.tasks });
+    },
+  });
 
-  const updateBody = useCallback((id: string, body: string) => {
-    setTasks((ts) => ts.map((t) => (t.id === id ? { ...t, body } : t)));
-  }, []);
+  const updateBodyMutation = useMutation({
+    mutationFn: ({ id, body }: { id: string; body: string }) =>
+      apiUpdateTask(supabase, id, { body }),
+    onMutate: async ({ id, body }) => {
+      await queryClient.cancelQueries({ queryKey: keys.tasks });
+      const previous = queryClient.getQueryData<Task[]>(keys.tasks);
+      queryClient.setQueryData<Task[]>(keys.tasks, (prev) =>
+        (prev ?? []).map((t) => (t.id === id ? { ...t, body } : t)),
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(keys.tasks, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: keys.tasks });
+    },
+  });
 
-  const reorder = useCallback((fromIdx: number, toIdx: number) => {
-    setTasks((ts) => {
-      const pending = ts.filter((t) => !isDone(t));
-      const done = ts.filter((t) => isDone(t));
+  const reorderMutation = useMutation({
+    mutationFn: (entries: { id: string; stackOrder: number | null }[]) =>
+      apiReorderTasks(supabase, entries),
+    // DnD は optimistic で UI 側は onMutate で即反映、サーバー同期は背面で進める。
+  });
+
+  const createTaskMutation = useMutation({
+    mutationFn: (input: CreateTaskInput) => apiCreateTask(supabase, input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: keys.tasks });
+    },
+  });
+
+  const createEventMutation = useMutation({
+    mutationFn: (input: CreateEventInput) => apiCreateEvent(supabase, input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: keys.events });
+    },
+  });
+
+  const createProjectMutation = useMutation({
+    mutationFn: (input: CreateProjectInput) => apiCreateProject(supabase, input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: keys.projects });
+    },
+  });
+
+  // タスク削除は TASK_DELETED action_log も記録する (api.ts の deleteTask 内)。
+  const deleteTaskMutation = useMutation({
+    mutationFn: (id: string) => apiDeleteTask(supabase, id),
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: keys.tasks });
+      const previous = queryClient.getQueryData<Task[]>(keys.tasks);
+      queryClient.setQueryData<Task[]>(keys.tasks, (prev) =>
+        (prev ?? []).filter((t) => t.id !== id),
+      );
+      return { previous };
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(keys.tasks, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: keys.tasks });
+    },
+  });
+
+  const toggleDone = useCallback(
+    (id: string) => toggleDoneMutation.mutate(id),
+    [toggleDoneMutation],
+  );
+
+  const updateBody = useCallback(
+    (id: string, body: string) => updateBodyMutation.mutate({ id, body }),
+    [updateBodyMutation],
+  );
+
+  const reorder = useCallback(
+    (fromIdx: number, toIdx: number) => {
+      const cached = queryClient.getQueryData<Task[]>(keys.tasks) ?? [];
+      const pending = cached.filter((t) => !isDone(t));
+      const done = cached.filter((t) => isDone(t));
+      if (fromIdx < 0 || fromIdx >= pending.length) return;
+      if (toIdx < 0 || toIdx >= pending.length) return;
       const next = [...pending];
       const [item] = next.splice(fromIdx, 1);
       next.splice(toIdx, 0, item);
+      const reordered = next.map((t, i) => ({ ...t, stackOrder: i }));
+      queryClient.setQueryData<Task[]>(keys.tasks, [...reordered, ...done]);
       log(ACTION_TYPES.TASK_REORDERED, {
         task_id: item.id,
         from_position: fromIdx,
         to_position: toIdx,
       });
-      return [...next, ...done];
-    });
-  }, []);
+      reorderMutation.mutate(
+        reordered.map((t) => ({ id: t.id, stackOrder: t.stackOrder })),
+        {
+          onError: () => {
+            // 失敗したら再取得して辻褄を合わせる (UI は一瞬戻るが DB 正とする)
+            queryClient.invalidateQueries({ queryKey: keys.tasks });
+          },
+        },
+      );
+    },
+    [queryClient, reorderMutation],
+  );
 
-  const resetSample = useCallback(() => {
-    setTasks(buildInitialTasks());
-    setEvents(buildInitialEvents());
-    writeSampleDataMode("default");
-  }, []);
+  const resetSample = useCallback(async () => {
+    try {
+      await clearAllUserData(supabase);
+      await seedSampleDataToSupabase(supabase);
+      writeSampleDataMode("default");
+      await invalidateAll(queryClient);
+    } catch (err) {
+      console.error("[reset-sample] failed", err);
+    }
+  }, [supabase, queryClient]);
 
-  const clearAll = useCallback(() => {
-    setTasks([]);
-    setEvents([]);
-    setDetailId(null);
-    setEventDetailId(null);
-    writeSampleDataMode("cleared");
-  }, []);
+  const clearAll = useCallback(async () => {
+    try {
+      await clearAllUserData(supabase);
+      writeSampleDataMode("cleared");
+      setDetailId(null);
+      setEventDetailId(null);
+      await invalidateAll(queryClient);
+    } catch (err) {
+      console.error("[clear-all] failed", err);
+    }
+  }, [supabase, queryClient]);
 
-  const pendingTasks = tasks.filter((t) => !isDone(t));
-  const doneTasks = tasks.filter((t) => isDone(t));
+  const pendingTasks = useMemo(
+    () => tasks.filter((t) => !isDone(t)),
+    [tasks],
+  );
+  const doneTasks = useMemo(() => tasks.filter((t) => isDone(t)), [tasks]);
   const detailTask = detailId ? tasks.find((t) => t.id === detailId) : null;
+
+  // Tree View は Phase 1 PoC では現行 mock history をそのまま描画する。
+  // 将来: tasks where status='done' から生成する (docs/specs/phase1.md Tree View)
+  const projectOrderForTree = useMemo(() => {
+    if (projects.length === 0) {
+      // history mock の projectId (slug) を fallback として並べる
+      return Array.from(new Set(historyData.map((h) => h.projectId)));
+    }
+    return projects.map((p) => p.id);
+  }, [projects]);
 
   const tabs: { key: View; label: string; href: string }[] = [
     { key: "stack", label: "Stack", href: "/" },
@@ -118,81 +333,153 @@ export function AppShell({ initialView, user }: AppShellProps) {
   ];
 
   return (
-    <div className="relative select-none">
-      {/* Header */}
-      <div className="sticky top-0 z-50 flex items-center gap-3 border-b border-bg-elevated bg-bg-primary px-5 pb-3 pt-4">
-        <div className="font-jp text-[16px] font-bold -tracking-[0.02em]">
-          <span className="text-accent-blue">kozu</span>
-          <span className="text-fg-faint">tsumi</span>
+    <ProjectsProvider projects={mergeTreeProjects(projects, historyData)}>
+      <div className="relative select-none">
+        {/* Header */}
+        <div className="sticky top-0 z-50 flex items-center gap-3 border-b border-bg-elevated bg-bg-primary px-5 pb-3 pt-4">
+          <div className="font-jp text-[16px] font-bold -tracking-[0.02em]">
+            <span className="text-accent-blue">kozu</span>
+            <span className="text-fg-faint">tsumi</span>
+          </div>
+          <div className="flex-1" />
+          <div className="flex rounded-md bg-bg-elevated p-0.5">
+            {tabs.map((tab) => {
+              const active = view === tab.key;
+              return (
+                <Link
+                  key={tab.key}
+                  href={tab.href}
+                  className={`cursor-pointer rounded-[4px] px-3.5 py-1 text-[11px] font-medium no-underline ${
+                    active
+                      ? "bg-bg-divider text-fg-emphasized"
+                      : "bg-transparent text-fg-weak"
+                  }`}
+                >
+                  {tab.label}
+                </Link>
+              );
+            })}
+          </div>
+          <UserMenu
+            email={user.email}
+            avatarUrl={user.avatarUrl}
+            onResetSample={resetSample}
+            onClearAll={clearAll}
+          />
         </div>
-        <div className="flex-1" />
-        <div className="flex rounded-md bg-bg-elevated p-0.5">
-          {tabs.map((tab) => {
-            const active = view === tab.key;
-            return (
-              <Link
-                key={tab.key}
-                href={tab.href}
-                className={`cursor-pointer rounded-[4px] px-3.5 py-1 text-[11px] font-medium no-underline ${
-                  active
-                    ? "bg-bg-divider text-fg-emphasized"
-                    : "bg-transparent text-fg-weak"
-                }`}
-              >
-                {tab.label}
-              </Link>
-            );
-          })}
-        </div>
-        <UserMenu
-          email={user.email}
-          avatarUrl={user.avatarUrl}
-          onResetSample={resetSample}
-          onClearAll={clearAll}
-        />
+
+        {view === "stack" ? (
+          <StackView
+            events={events}
+            pendingTasks={pendingTasks}
+            doneTasks={doneTasks}
+            toggleDone={toggleDone}
+            reorder={reorder}
+            nowMin={nowMin}
+            today={today}
+            onOpenDetail={setDetailId}
+            onOpenEvent={setEventDetailId}
+          />
+        ) : (
+          <TreeView
+            historyData={historyData}
+            projectOrder={projectOrderForTree}
+          />
+        )}
+
+        {detailTask && (
+          <TaskDetailPanel
+            task={detailTask}
+            events={events}
+            onClose={() => setDetailId(null)}
+            onUpdate={updateBody}
+            onToggleDone={toggleDone}
+            onDelete={(id) => deleteTaskMutation.mutate(id)}
+          />
+        )}
+
+        {eventDetailId &&
+          (() => {
+            const ev = events.find((e) => e.id === eventDetailId);
+            return ev ? (
+              <EventDetailPanel
+                event={ev}
+                onClose={() => setEventDetailId(null)}
+              />
+            ) : null;
+          })()}
+
+        <AddButton onClick={() => setAddOpen(true)} />
+
+        {addOpen ? (
+          <AddPanel
+            projects={projects}
+            events={events}
+            onClose={() => setAddOpen(false)}
+            onCreateTask={async (input) => {
+              // stackOrder は末尾に割り当て (pending 件数)
+              const stackOrder = pendingTasks.length;
+              await createTaskMutation.mutateAsync({ ...input, stackOrder });
+            }}
+            onCreateEvent={async (input) => {
+              await createEventMutation.mutateAsync(input);
+            }}
+            onCreateProject={async (input) => {
+              await createProjectMutation.mutateAsync(input);
+            }}
+          />
+        ) : null}
+
       </div>
-
-      {view === "stack" ? (
-        <StackView
-          events={events}
-          pendingTasks={pendingTasks}
-          doneTasks={doneTasks}
-          toggleDone={toggleDone}
-          reorder={reorder}
-          nowMin={nowMin}
-          today={today}
-          onOpenDetail={setDetailId}
-          onOpenEvent={setEventDetailId}
-        />
-      ) : (
-        <TreeView historyData={historyData} projectOrder={projectOrder} />
-      )}
-
-      {/* Detail panel overlay */}
-      {detailTask && (
-        <TaskDetailPanel
-          task={detailTask}
-          events={events}
-          onClose={() => setDetailId(null)}
-          onUpdate={updateBody}
-          onToggleDone={toggleDone}
-        />
-      )}
-
-      {/* Event detail overlay */}
-      {eventDetailId &&
-        (() => {
-          const ev = events.find((e) => e.id === eventDetailId);
-          return ev ? (
-            <EventDetailPanel
-              event={ev}
-              onClose={() => setEventDetailId(null)}
-            />
-          ) : null;
-        })()}
-    </div>
+    </ProjectsProvider>
   );
 }
+
+async function invalidateAll(queryClient: QueryClient): Promise<void> {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: keys.projects }),
+    queryClient.invalidateQueries({ queryKey: keys.tasks }),
+    queryClient.invalidateQueries({ queryKey: keys.events }),
+  ]);
+}
+
+/**
+ * Tree View の mock history が参照する旧 slug (`career` 等) を、
+ * 同名シードが DB にある場合はその Project として、
+ * 無い場合は PROJECT_SEEDS 由来の fallback Project として補完する。
+ */
+function mergeTreeProjects(
+  projects: readonly Project[],
+  history: readonly { projectId: string }[],
+): Project[] {
+  const known = new Set(projects.map((p) => p.id));
+  const missing = Array.from(
+    new Set(history.map((h) => h.projectId).filter((id) => !known.has(id))),
+  );
+  const result = [...projects];
+  for (const slug of missing) {
+    const seed = TREE_FALLBACK_BY_SLUG.get(slug);
+    result.push(
+      seed ?? {
+        id: slug,
+        name: slug,
+        color: "#52525b",
+        isPrimary: false,
+        createdAt: "",
+      },
+    );
+  }
+  return result;
+}
+
+// PROJECT_SEEDS を import すると循環が見えにくくなるので、slug→Project をここで簡易定義。
+// history (mock) に現れる slug 群だけ埋めれば十分。
+const TREE_FALLBACK_BY_SLUG: ReadonlyMap<string, Project> = new Map([
+  ["career", { id: "career", name: "転職活動", color: "#E85D04", isPrimary: false, createdAt: "" }],
+  ["loadtest", { id: "loadtest", name: "負荷試験", color: "#0096C7", isPrimary: false, createdAt: "" }],
+  ["slo", { id: "slo", name: "SLO推進", color: "#2D9F45", isPrimary: true, createdAt: "" }],
+  ["tasuki", { id: "tasuki", name: "Tasuki", color: "#9B5DE5", isPrimary: false, createdAt: "" }],
+]);
 
 type StackViewProps = {
   events: Event[];

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { IBM_Plex_Mono, Noto_Sans_JP } from "next/font/google";
 
+import { QueryProvider } from "@/shared/query/QueryProvider";
+
 import "./globals.css";
 
 const ibmPlexMono = IBM_Plex_Mono({
@@ -31,7 +33,7 @@ export default function RootLayout({
   return (
     <html lang="ja" className={`${ibmPlexMono.variable} ${notoSansJp.variable}`}>
       <body className="mx-auto min-h-screen max-w-[480px] bg-bg-primary font-mono text-fg-default">
-        {children}
+        <QueryProvider>{children}</QueryProvider>
       </body>
     </html>
   );

--- a/src/entities/event/api.ts
+++ b/src/entities/event/api.ts
@@ -1,0 +1,122 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type {
+  Database,
+  Tables,
+  TablesInsert,
+  TablesUpdate,
+} from "@/shared/types/database";
+
+import type { Event } from "./types";
+
+type Sb = SupabaseClient<Database>;
+
+function fromRow(row: Tables<"events">): Event {
+  return {
+    id: row.id,
+    title: row.title,
+    startTime: row.start_time,
+    endTime: row.end_time,
+    projectId: row.project_id,
+    meetUrl: row.meet_url,
+    hasAttachments: row.has_attachments,
+    description: row.description,
+    source: row.source,
+    externalId: row.external_id,
+    createdAt: row.created_at,
+  };
+}
+
+async function getUserId(supabase: Sb): Promise<string> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("not authenticated");
+  return user.id;
+}
+
+export async function listEvents(supabase: Sb): Promise<Event[]> {
+  const { data, error } = await supabase
+    .from("events")
+    .select("*")
+    .order("start_time", { ascending: true });
+  if (error) throw error;
+  return (data ?? []).map(fromRow);
+}
+
+export type CreateEventInput = {
+  title: string;
+  startTime: string;
+  endTime: string;
+  projectId?: string | null;
+  meetUrl?: string | null;
+  hasAttachments?: boolean;
+  description?: string;
+  source?: Event["source"];
+  externalId?: string | null;
+};
+
+export async function createEvent(
+  supabase: Sb,
+  input: CreateEventInput,
+): Promise<Event> {
+  const user_id = await getUserId(supabase);
+  const payload: TablesInsert<"events"> = {
+    user_id,
+    title: input.title,
+    start_time: input.startTime,
+    end_time: input.endTime,
+    project_id: input.projectId ?? null,
+    meet_url: input.meetUrl ?? null,
+    has_attachments: input.hasAttachments ?? false,
+    description: input.description ?? "",
+    source: input.source ?? "manual",
+    external_id: input.externalId ?? null,
+  };
+  const { data, error } = await supabase
+    .from("events")
+    .insert(payload)
+    .select("*")
+    .single();
+  if (error) throw error;
+  return fromRow(data);
+}
+
+export type UpdateEventInput = {
+  title?: string;
+  startTime?: string;
+  endTime?: string;
+  projectId?: string | null;
+  meetUrl?: string | null;
+  hasAttachments?: boolean;
+  description?: string;
+};
+
+export async function updateEvent(
+  supabase: Sb,
+  id: string,
+  patch: UpdateEventInput,
+): Promise<Event> {
+  const update: TablesUpdate<"events"> = {};
+  if (patch.title !== undefined) update.title = patch.title;
+  if (patch.startTime !== undefined) update.start_time = patch.startTime;
+  if (patch.endTime !== undefined) update.end_time = patch.endTime;
+  if (patch.projectId !== undefined) update.project_id = patch.projectId;
+  if (patch.meetUrl !== undefined) update.meet_url = patch.meetUrl;
+  if (patch.hasAttachments !== undefined)
+    update.has_attachments = patch.hasAttachments;
+  if (patch.description !== undefined) update.description = patch.description;
+  const { data, error } = await supabase
+    .from("events")
+    .update(update)
+    .eq("id", id)
+    .select("*")
+    .single();
+  if (error) throw error;
+  return fromRow(data);
+}
+
+export async function deleteEvent(supabase: Sb, id: string): Promise<void> {
+  const { error } = await supabase.from("events").delete().eq("id", id);
+  if (error) throw error;
+}

--- a/src/entities/event/types.ts
+++ b/src/entities/event/types.ts
@@ -1,5 +1,3 @@
-import type { ProjectKey } from "../project/types";
-
 export type EventSource = "manual" | "google_calendar";
 
 /**
@@ -11,7 +9,7 @@ export type Event = {
   title: string;
   startTime: string;
   endTime: string;
-  projectId: ProjectKey | null;
+  projectId: string | null;
   meetUrl: string | null;
   hasAttachments: boolean;
   description: string;

--- a/src/entities/project/ProjectsContext.tsx
+++ b/src/entities/project/ProjectsContext.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { createContext, useContext, useMemo } from "react";
+
+import { FALLBACK_PROJECT, indexProjectsById } from "./projects";
+import type { Project } from "./types";
+
+type ProjectsContextValue = {
+  projects: readonly Project[];
+  projectsById: Record<string, Project>;
+};
+
+const ProjectsContext = createContext<ProjectsContextValue | null>(null);
+
+export function ProjectsProvider({
+  projects,
+  children,
+}: {
+  projects: readonly Project[];
+  children: React.ReactNode;
+}) {
+  const value = useMemo<ProjectsContextValue>(
+    () => ({ projects, projectsById: indexProjectsById(projects) }),
+    [projects],
+  );
+  return (
+    <ProjectsContext.Provider value={value}>
+      {children}
+    </ProjectsContext.Provider>
+  );
+}
+
+/**
+ * 未提供時は空配列と fallback 1 件のみのマップを返す (unit テストで Provider 包むのを省略可)。
+ */
+export function useProjects(): ProjectsContextValue {
+  const ctx = useContext(ProjectsContext);
+  if (!ctx) {
+    return {
+      projects: [],
+      projectsById: { [FALLBACK_PROJECT.id]: FALLBACK_PROJECT },
+    };
+  }
+  return ctx;
+}

--- a/src/entities/project/api.ts
+++ b/src/entities/project/api.ts
@@ -1,0 +1,90 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { Database, Tables, TablesInsert, TablesUpdate } from "@/shared/types/database";
+
+import type { Project } from "./types";
+
+type Sb = SupabaseClient<Database>;
+
+function fromRow(row: Tables<"projects">): Project {
+  return {
+    id: row.id,
+    name: row.name,
+    color: row.color,
+    isPrimary: row.is_primary,
+    createdAt: row.created_at,
+  };
+}
+
+async function getUserId(supabase: Sb): Promise<string> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("not authenticated");
+  return user.id;
+}
+
+export async function listProjects(supabase: Sb): Promise<Project[]> {
+  const { data, error } = await supabase
+    .from("projects")
+    .select("*")
+    .order("created_at", { ascending: true });
+  if (error) throw error;
+  return (data ?? []).map(fromRow);
+}
+
+export type CreateProjectInput = {
+  name: string;
+  color: string;
+  isPrimary?: boolean;
+};
+
+export async function createProject(
+  supabase: Sb,
+  input: CreateProjectInput,
+): Promise<Project> {
+  const user_id = await getUserId(supabase);
+  const payload: TablesInsert<"projects"> = {
+    user_id,
+    name: input.name,
+    color: input.color,
+    is_primary: input.isPrimary ?? false,
+  };
+  const { data, error } = await supabase
+    .from("projects")
+    .insert(payload)
+    .select("*")
+    .single();
+  if (error) throw error;
+  return fromRow(data);
+}
+
+export type UpdateProjectInput = {
+  name?: string;
+  color?: string;
+  isPrimary?: boolean;
+};
+
+export async function updateProject(
+  supabase: Sb,
+  id: string,
+  patch: UpdateProjectInput,
+): Promise<Project> {
+  const update: TablesUpdate<"projects"> = {};
+  if (patch.name !== undefined) update.name = patch.name;
+  if (patch.color !== undefined) update.color = patch.color;
+  if (patch.isPrimary !== undefined) update.is_primary = patch.isPrimary;
+  const { data, error } = await supabase
+    .from("projects")
+    .update(update)
+    .eq("id", id)
+    .select("*")
+    .single();
+  if (error) throw error;
+  return fromRow(data);
+}
+
+export async function deleteProject(supabase: Sb, id: string): Promise<void> {
+  const { error } = await supabase.from("projects").delete().eq("id", id);
+  if (error) throw error;
+}

--- a/src/entities/project/projects.ts
+++ b/src/entities/project/projects.ts
@@ -1,15 +1,51 @@
-import type { ProjectKey, ProjectMap } from "./types";
+import type { Project } from "./types";
 
-export const PROJECTS: ProjectMap = {
-  career: { name: "転職活動", color: "#E85D04" },
-  loadtest: { name: "負荷試験", color: "#0096C7" },
-  slo: { name: "SLO推進", color: "#2D9F45" },
-  tasuki: { name: "Tasuki", color: "#9B5DE5" },
+/**
+ * シード用のプロジェクト初期定義。
+ * 初回ログイン時 or 「サンプルを再投入」ボタンからこれらを Supabase に挿入する。
+ * slug (key) はサンプルタスク/イベントの projectId 参照に使うためのローカル識別子。
+ */
+export type ProjectSeed = {
+  slug: string;
+  name: string;
+  color: string;
+  isPrimary: boolean;
 };
 
-export const projectOrder: readonly ProjectKey[] = [
-  "career",
-  "loadtest",
-  "slo",
-  "tasuki",
+export const PROJECT_SEEDS: readonly ProjectSeed[] = [
+  { slug: "career", name: "転職活動", color: "#E85D04", isPrimary: false },
+  { slug: "loadtest", name: "負荷試験", color: "#0096C7", isPrimary: false },
+  { slug: "slo", name: "SLO推進", color: "#2D9F45", isPrimary: true },
+  { slug: "tasuki", name: "Tasuki", color: "#9B5DE5", isPrimary: false },
 ];
+
+/**
+ * Project 配列から id → Project のマップを作る。
+ */
+export function indexProjectsById(
+  projects: readonly Project[],
+): Record<string, Project> {
+  const out: Record<string, Project> = {};
+  for (const p of projects) out[p.id] = p;
+  return out;
+}
+
+/**
+ * 未知の projectId を参照された時の安全な fallback。
+ * DB 削除と UI キャッシュがズレた瞬間に落ちないための保険。
+ */
+export const FALLBACK_PROJECT: Project = {
+  id: "__fallback__",
+  name: "—",
+  color: "#52525b",
+  isPrimary: false,
+  createdAt: "",
+};
+
+export function getProject(
+  projectsById: Record<string, Project>,
+  projectId: string | null | undefined,
+): Project {
+  if (!projectId) return FALLBACK_PROJECT;
+  return projectsById[projectId] ?? FALLBACK_PROJECT;
+}

--- a/src/entities/project/types.ts
+++ b/src/entities/project/types.ts
@@ -1,8 +1,19 @@
-export type ProjectKey = "career" | "loadtest" | "slo" | "tasuki";
-
+/**
+ * Project (DB: public.projects) と 1:1 対応。
+ * id は UUID (DB から発行) だが、PoC のシード段階では slug ("career" など) を流用する。
+ */
 export type Project = {
-  readonly name: string;
-  readonly color: string;
+  id: string;
+  name: string;
+  color: string;
+  isPrimary: boolean;
+  createdAt: string;
 };
 
-export type ProjectMap = Readonly<Record<ProjectKey, Project>>;
+/**
+ * Phase 1 初期段階ではプロジェクトを動的に追加できる設計のため、
+ * ProjectKey は固定 union ではなく Project.id を指す文字列エイリアス。
+ */
+export type ProjectKey = string;
+
+export type ProjectMap = Readonly<Record<string, Project>>;

--- a/src/entities/task/api.ts
+++ b/src/entities/task/api.ts
@@ -1,0 +1,162 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { ACTION_TYPES, log } from "@/entities/action-log/logger";
+import type {
+  Database,
+  Tables,
+  TablesInsert,
+  TablesUpdate,
+} from "@/shared/types/database";
+
+import type { Task } from "./types";
+
+type Sb = SupabaseClient<Database>;
+
+function fromRow(row: Tables<"tasks">): Task {
+  return {
+    id: row.id,
+    projectId: row.project_id ?? "",
+    title: row.title,
+    body: row.body,
+    estimatedMinutes: row.estimated_minutes,
+    status: row.status,
+    stackOrder: row.stack_order,
+    dependsOnEventId: row.depends_on_event_id,
+    isInterruption: row.is_interruption,
+    parentTaskId: row.parent_task_id,
+    createdAt: row.created_at,
+    completedAt: row.completed_at,
+  };
+}
+
+async function getUserId(supabase: Sb): Promise<string> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("not authenticated");
+  return user.id;
+}
+
+/**
+ * ユーザーの全タスクを並び順で取得する。
+ * - stack_order が NULL (= idle 以外 or 並び順未指定) は末尾に並べる
+ * - done は created_at 昇順で stack_order null 扱い
+ */
+export async function listTasks(supabase: Sb): Promise<Task[]> {
+  const { data, error } = await supabase
+    .from("tasks")
+    .select("*")
+    .order("stack_order", { ascending: true, nullsFirst: false })
+    .order("created_at", { ascending: true });
+  if (error) throw error;
+  return (data ?? []).map(fromRow);
+}
+
+export type CreateTaskInput = {
+  projectId: string;
+  title: string;
+  body?: string;
+  estimatedMinutes?: number | null;
+  stackOrder?: number | null;
+  dependsOnEventId?: string | null;
+  isInterruption?: boolean;
+  parentTaskId?: string | null;
+};
+
+export async function createTask(
+  supabase: Sb,
+  input: CreateTaskInput,
+): Promise<Task> {
+  const user_id = await getUserId(supabase);
+  const payload: TablesInsert<"tasks"> = {
+    user_id,
+    project_id: input.projectId,
+    title: input.title,
+    body: input.body ?? "",
+    estimated_minutes: input.estimatedMinutes ?? null,
+    stack_order: input.stackOrder ?? null,
+    depends_on_event_id: input.dependsOnEventId ?? null,
+    is_interruption: input.isInterruption ?? false,
+    parent_task_id: input.parentTaskId ?? null,
+  };
+  const { data, error } = await supabase
+    .from("tasks")
+    .insert(payload)
+    .select("*")
+    .single();
+  if (error) throw error;
+  return fromRow(data);
+}
+
+export type UpdateTaskInput = {
+  projectId?: string;
+  title?: string;
+  body?: string;
+  estimatedMinutes?: number | null;
+  status?: Task["status"];
+  stackOrder?: number | null;
+  dependsOnEventId?: string | null;
+  isInterruption?: boolean;
+  completedAt?: string | null;
+};
+
+export async function updateTask(
+  supabase: Sb,
+  id: string,
+  patch: UpdateTaskInput,
+): Promise<Task> {
+  const update: TablesUpdate<"tasks"> = {};
+  if (patch.projectId !== undefined) update.project_id = patch.projectId;
+  if (patch.title !== undefined) update.title = patch.title;
+  if (patch.body !== undefined) update.body = patch.body;
+  if (patch.estimatedMinutes !== undefined)
+    update.estimated_minutes = patch.estimatedMinutes;
+  if (patch.status !== undefined) update.status = patch.status;
+  if (patch.stackOrder !== undefined) update.stack_order = patch.stackOrder;
+  if (patch.dependsOnEventId !== undefined)
+    update.depends_on_event_id = patch.dependsOnEventId;
+  if (patch.isInterruption !== undefined)
+    update.is_interruption = patch.isInterruption;
+  if (patch.completedAt !== undefined)
+    update.completed_at = patch.completedAt;
+  const { data, error } = await supabase
+    .from("tasks")
+    .update(update)
+    .eq("id", id)
+    .select("*")
+    .single();
+  if (error) throw error;
+  return fromRow(data);
+}
+
+/**
+ * スタック並べ替え: (id, stack_order) のペアをまとめて適用する。
+ *
+ * Supabase の .update() は WHERE 単位なので、複数行の個別値を 1 call で書くには
+ * upsert + on_conflict を使う。全カラムを送るので、呼び出し元は最新タスク全体を渡す。
+ */
+export async function reorderTasks(
+  supabase: Sb,
+  entries: readonly { id: string; stackOrder: number | null }[],
+): Promise<void> {
+  if (entries.length === 0) return;
+  // 並列 update: 個別 patch を Promise.all で流す。件数は高々 20〜30 件想定。
+  await Promise.all(
+    entries.map(({ id, stackOrder }) =>
+      supabase
+        .from("tasks")
+        .update({ stack_order: stackOrder } satisfies TablesUpdate<"tasks">)
+        .eq("id", id),
+    ),
+  );
+}
+
+/**
+ * task_deleted action_log 呼び出しを削除操作にバインドする。
+ * (Phase 1 仕様 Step 4 / vision.md: 行動ログ欠損を防ぐ)
+ */
+export async function deleteTask(supabase: Sb, id: string): Promise<void> {
+  const { error } = await supabase.from("tasks").delete().eq("id", id);
+  if (error) throw error;
+  log(ACTION_TYPES.TASK_DELETED, { task_id: id });
+}

--- a/src/entities/task/types.ts
+++ b/src/entities/task/types.ts
@@ -1,14 +1,13 @@
-import type { ProjectKey } from "../project/types";
-
 export type TaskStatus = "idle" | "active" | "paused" | "done";
 
 /**
  * DB スキーマ (supabase/migrations/..._initial_schema.sql の tasks) と 1:1 対応。
- * PoC では projectId に ProjectKey(slug) を入れ、本番では UUID を入れる。
+ * projectId は projects.id を参照する UUID (初回 seed では slug 由来の UUID)。
+ * DB 上は project_id が nullable だが、UI では常に割り当てさせる運用なので string を前提とする。
  */
 export type Task = {
   id: string;
-  projectId: ProjectKey;
+  projectId: string;
   title: string;
   body: string;
   estimatedMinutes: number | null;
@@ -27,7 +26,7 @@ export type Task = {
  */
 export type HistoryEntry = {
   id: string;
-  projectId: ProjectKey;
+  projectId: string;
   title: string;
   date: string;
 };

--- a/src/features/add-forms/AddButton.tsx
+++ b/src/features/add-forms/AddButton.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+type AddButtonProps = {
+  onClick: () => void;
+};
+
+/**
+ * 画面右下の + ボタン。タップで AddPanel を開く。
+ * max-width 480px のレイアウトに収まるよう fixed + safe-area を考慮。
+ */
+export function AddButton({ onClick }: AddButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label="新規追加"
+      className="fixed bottom-5 right-5 z-[100] flex h-12 w-12 items-center justify-center rounded-full bg-accent-blue text-fg-invert shadow-lg transition-transform active:scale-95"
+      style={{
+        // max-w-480 の本体にアンカーする: 実質右下で OK (body が中央配置のため)
+        right: "max(1.25rem, calc((100vw - 480px) / 2 + 1.25rem))",
+      }}
+    >
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+        <path d="M12 5V19M5 12H19" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />
+      </svg>
+    </button>
+  );
+}

--- a/src/features/add-forms/AddPanel.tsx
+++ b/src/features/add-forms/AddPanel.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState } from "react";
+
+import type { CreateEventInput } from "@/entities/event/api";
+import type { Event } from "@/entities/event/types";
+import type { CreateProjectInput } from "@/entities/project/api";
+import type { Project } from "@/entities/project/types";
+import type { CreateTaskInput } from "@/entities/task/api";
+
+import { EventForm } from "./EventForm";
+import { ProjectForm } from "./ProjectForm";
+import { TaskForm } from "./TaskForm";
+
+type Tab = "task" | "event" | "project";
+
+type AddPanelProps = {
+  projects: readonly Project[];
+  events: readonly Event[];
+  initialTab?: Tab;
+  onClose: () => void;
+  onCreateTask: (input: CreateTaskInput) => Promise<void>;
+  onCreateEvent: (input: CreateEventInput) => Promise<void>;
+  onCreateProject: (input: CreateProjectInput) => Promise<void>;
+};
+
+/**
+ * タスク / イベント / プロジェクト追加フォームを切り替える共通ボトムシート。
+ */
+export function AddPanel({
+  projects,
+  events,
+  initialTab = "task",
+  onClose,
+  onCreateTask,
+  onCreateEvent,
+  onCreateProject,
+}: AddPanelProps) {
+  const [tab, setTab] = useState<Tab>(initialTab);
+
+  const tabs: { key: Tab; label: string }[] = [
+    { key: "task", label: "タスク" },
+    { key: "event", label: "イベント" },
+    { key: "project", label: "プロジェクト" },
+  ];
+
+  return (
+    <div className="fixed inset-0 z-[210] flex flex-col">
+      <div
+        onClick={onClose}
+        className="absolute inset-0 bg-black/60 backdrop-blur-[4px]"
+      />
+      <div className="relative mt-auto flex max-h-[85vh] animate-panel-slide-up flex-col rounded-t-2xl bg-bg-surface">
+        <div className="flex justify-center pb-1 pt-2.5">
+          <div className="h-[3px] w-8 rounded-[2px] bg-bg-divider" />
+        </div>
+
+        <div className="flex gap-1 px-4 pt-1">
+          {tabs.map((t) => {
+            const active = tab === t.key;
+            return (
+              <button
+                type="button"
+                key={t.key}
+                onClick={() => setTab(t.key)}
+                className={`rounded-t-md px-3 py-1.5 font-jp text-[11px] font-medium ${
+                  active
+                    ? "bg-bg-elevated text-fg-emphasized"
+                    : "bg-transparent text-fg-weak"
+                }`}
+              >
+                {t.label}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="mx-4 h-px bg-bg-border" />
+
+        <div className="flex-1 overflow-auto px-5 pb-6 pt-4">
+          {tab === "task" ? (
+            projects.length === 0 ? (
+              <EmptyProjectsNotice onSwitch={() => setTab("project")} />
+            ) : (
+              <TaskForm
+                projects={projects}
+                events={events}
+                onSubmit={onCreateTask}
+                onClose={onClose}
+              />
+            )
+          ) : null}
+          {tab === "event" ? (
+            <EventForm
+              projects={projects}
+              onSubmit={onCreateEvent}
+              onClose={onClose}
+            />
+          ) : null}
+          {tab === "project" ? (
+            <ProjectForm onSubmit={onCreateProject} onClose={onClose} />
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EmptyProjectsNotice({ onSwitch }: { onSwitch: () => void }) {
+  return (
+    <div className="flex flex-col items-center gap-3 py-6 text-center">
+      <p className="font-jp text-[12px] text-fg-muted">
+        タスクにはプロジェクトが必要です。
+      </p>
+      <button
+        type="button"
+        onClick={onSwitch}
+        className="rounded bg-accent-blue px-4 py-1.5 font-jp text-[11px] font-semibold text-fg-invert"
+      >
+        プロジェクトを先に作る
+      </button>
+    </div>
+  );
+}

--- a/src/features/add-forms/EventForm.tsx
+++ b/src/features/add-forms/EventForm.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState } from "react";
+
+import type { CreateEventInput } from "@/entities/event/api";
+import type { Project } from "@/entities/project/types";
+import { todayIso } from "@/shared/lib/time";
+
+type EventFormProps = {
+  projects: readonly Project[];
+  onSubmit: (input: CreateEventInput) => Promise<void>;
+  onClose: () => void;
+};
+
+/**
+ * Phase 1 仕様 Step 3「イベント追加フォーム（タイトル、開始-終了時刻、会議URL、プロジェクト）」。
+ * 時刻は `<input type="datetime-local">` を使い、ローカル時刻を ISO 8601 風に送る。
+ */
+export function EventForm({ projects, onSubmit, onClose }: EventFormProps) {
+  const [title, setTitle] = useState("");
+  const [startLocal, setStartLocal] = useState<string>(`${todayIso()}T09:00`);
+  const [endLocal, setEndLocal] = useState<string>(`${todayIso()}T10:00`);
+  const [projectId, setProjectId] = useState<string>("");
+  const [meetUrl, setMeetUrl] = useState<string>("");
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (pending) return;
+    if (!title.trim()) {
+      setError("タイトルは必須です");
+      return;
+    }
+    if (!startLocal || !endLocal) {
+      setError("開始/終了時刻は必須です");
+      return;
+    }
+    if (new Date(endLocal).getTime() <= new Date(startLocal).getTime()) {
+      setError("終了時刻は開始時刻より後にしてください");
+      return;
+    }
+    setPending(true);
+    setError(null);
+    try {
+      await onSubmit({
+        title: title.trim(),
+        // datetime-local の値は tz なしローカル時刻。`:00` を補完して DB の timestamptz に渡す。
+        startTime: `${startLocal}:00`,
+        endTime: `${endLocal}:00`,
+        projectId: projectId || null,
+        meetUrl: meetUrl.trim() || null,
+      });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "保存に失敗しました");
+      setPending(false);
+    }
+  };
+
+  return (
+    <form onSubmit={submit} className="flex flex-col gap-3">
+      <label className="flex flex-col gap-1">
+        <span className="font-jp text-[10px] text-fg-weak">タイトル</span>
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          autoFocus
+          className="rounded border border-bg-divider bg-bg-elevated px-3 py-2 text-[13px] text-fg-default outline-none focus:border-accent-blue"
+          placeholder="例: SLOレビューMTG"
+        />
+      </label>
+
+      <div className="flex gap-2">
+        <label className="flex flex-1 flex-col gap-1">
+          <span className="font-jp text-[10px] text-fg-weak">開始</span>
+          <input
+            type="datetime-local"
+            value={startLocal}
+            onChange={(e) => setStartLocal(e.target.value)}
+            className="rounded border border-bg-divider bg-bg-elevated px-3 py-2 text-[13px] text-fg-default outline-none focus:border-accent-blue"
+          />
+        </label>
+        <label className="flex flex-1 flex-col gap-1">
+          <span className="font-jp text-[10px] text-fg-weak">終了</span>
+          <input
+            type="datetime-local"
+            value={endLocal}
+            onChange={(e) => setEndLocal(e.target.value)}
+            className="rounded border border-bg-divider bg-bg-elevated px-3 py-2 text-[13px] text-fg-default outline-none focus:border-accent-blue"
+          />
+        </label>
+      </div>
+
+      <label className="flex flex-col gap-1">
+        <span className="font-jp text-[10px] text-fg-weak">プロジェクト (任意)</span>
+        <select
+          value={projectId}
+          onChange={(e) => setProjectId(e.target.value)}
+          className="rounded border border-bg-divider bg-bg-elevated px-3 py-2 text-[13px] text-fg-default outline-none focus:border-accent-blue"
+        >
+          <option value="">なし</option>
+          {projects.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1">
+        <span className="font-jp text-[10px] text-fg-weak">会議URL (任意)</span>
+        <input
+          type="url"
+          value={meetUrl}
+          onChange={(e) => setMeetUrl(e.target.value)}
+          className="rounded border border-bg-divider bg-bg-elevated px-3 py-2 text-[13px] text-fg-default outline-none focus:border-accent-blue"
+          placeholder="https://meet.google.com/..."
+        />
+      </label>
+
+      {error ? (
+        <div className="rounded bg-[#ef444420] px-2 py-1.5 text-[11px] text-accent-red">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="mt-1 flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded border border-bg-divider bg-transparent px-3 py-1.5 font-jp text-[11px] text-fg-subtle"
+        >
+          キャンセル
+        </button>
+        <button
+          type="submit"
+          disabled={pending}
+          className="rounded bg-accent-blue px-4 py-1.5 font-jp text-[11px] font-semibold text-fg-invert disabled:opacity-60"
+        >
+          {pending ? "保存中..." : "追加"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/features/add-forms/ProjectForm.tsx
+++ b/src/features/add-forms/ProjectForm.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useState } from "react";
+
+import type { CreateProjectInput } from "@/entities/project/api";
+
+type ProjectFormProps = {
+  onSubmit: (input: CreateProjectInput) => Promise<void>;
+  onClose: () => void;
+};
+
+const DEFAULT_COLORS = [
+  "#E85D04",
+  "#0096C7",
+  "#2D9F45",
+  "#9B5DE5",
+  "#58A6FF",
+  "#EF4444",
+];
+
+/**
+ * Phase 1 仕様 Step 3「プロジェクト管理（名前、色、本業フラグ）」。
+ */
+export function ProjectForm({ onSubmit, onClose }: ProjectFormProps) {
+  const [name, setName] = useState("");
+  const [color, setColor] = useState<string>(DEFAULT_COLORS[0]);
+  const [isPrimary, setIsPrimary] = useState(false);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (pending) return;
+    if (!name.trim()) {
+      setError("名前は必須です");
+      return;
+    }
+    setPending(true);
+    setError(null);
+    try {
+      await onSubmit({ name: name.trim(), color, isPrimary });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "保存に失敗しました");
+      setPending(false);
+    }
+  };
+
+  return (
+    <form onSubmit={submit} className="flex flex-col gap-3">
+      <label className="flex flex-col gap-1">
+        <span className="font-jp text-[10px] text-fg-weak">名前</span>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          autoFocus
+          className="rounded border border-bg-divider bg-bg-elevated px-3 py-2 text-[13px] text-fg-default outline-none focus:border-accent-blue"
+          placeholder="例: 転職活動"
+        />
+      </label>
+
+      <div className="flex flex-col gap-1">
+        <span className="font-jp text-[10px] text-fg-weak">色</span>
+        <div className="flex flex-wrap gap-2">
+          {DEFAULT_COLORS.map((c) => (
+            <button
+              type="button"
+              key={c}
+              onClick={() => setColor(c)}
+              className={`h-7 w-7 rounded-full transition-all ${
+                color === c ? "ring-2 ring-offset-2 ring-offset-bg-primary" : ""
+              }`}
+              style={{ background: c, boxShadow: color === c ? `0 0 0 2px ${c}` : undefined }}
+              aria-label={c}
+            />
+          ))}
+          <label className="flex h-7 w-7 cursor-pointer items-center justify-center overflow-hidden rounded-full border border-bg-divider">
+            <input
+              type="color"
+              value={color}
+              onChange={(e) => setColor(e.target.value)}
+              className="h-10 w-10 cursor-pointer border-0 bg-transparent p-0"
+            />
+          </label>
+        </div>
+      </div>
+
+      <label className="flex items-center gap-2 font-jp text-[11px] text-fg-muted">
+        <input
+          type="checkbox"
+          checked={isPrimary}
+          onChange={(e) => setIsPrimary(e.target.checked)}
+        />
+        本業として扱う
+      </label>
+
+      {error ? (
+        <div className="rounded bg-[#ef444420] px-2 py-1.5 text-[11px] text-accent-red">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="mt-1 flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded border border-bg-divider bg-transparent px-3 py-1.5 font-jp text-[11px] text-fg-subtle"
+        >
+          キャンセル
+        </button>
+        <button
+          type="submit"
+          disabled={pending}
+          className="rounded bg-accent-blue px-4 py-1.5 font-jp text-[11px] font-semibold text-fg-invert disabled:opacity-60"
+        >
+          {pending ? "保存中..." : "追加"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/features/add-forms/TaskForm.tsx
+++ b/src/features/add-forms/TaskForm.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState } from "react";
+
+import type { CreateTaskInput } from "@/entities/task/api";
+import type { Event } from "@/entities/event/types";
+import type { Project } from "@/entities/project/types";
+import { formatClock } from "@/shared/lib/time";
+
+type TaskFormProps = {
+  projects: readonly Project[];
+  events: readonly Event[];
+  onSubmit: (input: CreateTaskInput) => Promise<void>;
+  onClose: () => void;
+};
+
+/**
+ * Phase 1 仕様 Step 3「タスク追加フォーム（タイトル、プロジェクト選択、見積もり時間）」。
+ * 依存イベントも任意で選べるようにしてある (feature-spec.md: event-gated タスク)。
+ */
+export function TaskForm({ projects, events, onSubmit, onClose }: TaskFormProps) {
+  const [title, setTitle] = useState("");
+  const [projectId, setProjectId] = useState<string>(projects[0]?.id ?? "");
+  const [minutes, setMinutes] = useState<string>("");
+  const [dependsOnEventId, setDependsOnEventId] = useState<string>("");
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (pending) return;
+    if (!title.trim()) {
+      setError("タイトルは必須です");
+      return;
+    }
+    if (!projectId) {
+      setError("プロジェクトを選んでください");
+      return;
+    }
+    setPending(true);
+    setError(null);
+    try {
+      const estimated = minutes.trim() === "" ? null : Number(minutes);
+      if (estimated !== null && (!Number.isFinite(estimated) || estimated <= 0)) {
+        setError("見積もり分数は正の整数で指定してください");
+        setPending(false);
+        return;
+      }
+      await onSubmit({
+        projectId,
+        title: title.trim(),
+        estimatedMinutes: estimated,
+        dependsOnEventId: dependsOnEventId || null,
+      });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "保存に失敗しました");
+      setPending(false);
+    }
+  };
+
+  return (
+    <form onSubmit={submit} className="flex flex-col gap-3">
+      <label className="flex flex-col gap-1">
+        <span className="font-jp text-[10px] text-fg-weak">タイトル</span>
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          autoFocus
+          className="rounded border border-bg-divider bg-bg-elevated px-3 py-2 text-[13px] text-fg-default outline-none focus:border-accent-blue"
+          placeholder="例: 面接対策"
+        />
+      </label>
+
+      <label className="flex flex-col gap-1">
+        <span className="font-jp text-[10px] text-fg-weak">プロジェクト</span>
+        <select
+          value={projectId}
+          onChange={(e) => setProjectId(e.target.value)}
+          className="rounded border border-bg-divider bg-bg-elevated px-3 py-2 text-[13px] text-fg-default outline-none focus:border-accent-blue"
+        >
+          {projects.length === 0 ? (
+            <option value="">プロジェクトがありません</option>
+          ) : null}
+          {projects.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1">
+        <span className="font-jp text-[10px] text-fg-weak">見積もり (分)</span>
+        <input
+          type="number"
+          min="1"
+          value={minutes}
+          onChange={(e) => setMinutes(e.target.value)}
+          className="rounded border border-bg-divider bg-bg-elevated px-3 py-2 text-[13px] text-fg-default outline-none focus:border-accent-blue"
+          placeholder="45"
+        />
+      </label>
+
+      <label className="flex flex-col gap-1">
+        <span className="font-jp text-[10px] text-fg-weak">依存イベント (任意)</span>
+        <select
+          value={dependsOnEventId}
+          onChange={(e) => setDependsOnEventId(e.target.value)}
+          className="rounded border border-bg-divider bg-bg-elevated px-3 py-2 text-[13px] text-fg-default outline-none focus:border-accent-blue"
+        >
+          <option value="">なし</option>
+          {events.map((ev) => (
+            <option key={ev.id} value={ev.id}>
+              {formatClock(ev.startTime)} {ev.title}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      {error ? (
+        <div className="rounded bg-[#ef444420] px-2 py-1.5 text-[11px] text-accent-red">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="mt-1 flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded border border-bg-divider bg-transparent px-3 py-1.5 font-jp text-[11px] text-fg-subtle"
+        >
+          キャンセル
+        </button>
+        <button
+          type="submit"
+          disabled={pending}
+          className="rounded bg-accent-blue px-4 py-1.5 font-jp text-[11px] font-semibold text-fg-invert disabled:opacity-60"
+        >
+          {pending ? "保存中..." : "追加"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/features/day-timeline/EventCard.tsx
+++ b/src/features/day-timeline/EventCard.tsx
@@ -1,5 +1,6 @@
 import type { Event } from "../../entities/event/types";
-import { PROJECTS } from "../../entities/project/projects";
+import { getProject } from "../../entities/project/projects";
+import { useProjects } from "../../entities/project/ProjectsContext";
 import {
   fmtDuration,
   formatClock,
@@ -14,12 +15,15 @@ type EventCardProps = {
 };
 
 export function EventCard({ event, nowMin, isNextCandidate, onClick }: EventCardProps) {
+  const { projectsById } = useProjects();
   const evStart = minutesOfDay(event.startTime);
   const evEnd = minutesOfDay(event.endTime);
   const isPast = evEnd <= nowMin;
   const isNow = evStart <= nowMin && evEnd > nowMin;
   const isNext = isNextCandidate && !isNow;
-  const evColor = event.projectId ? PROJECTS[event.projectId].color : "#52525b";
+  const evColor = event.projectId
+    ? getProject(projectsById, event.projectId).color
+    : "#52525b";
   const hasAttachments = event.hasAttachments;
   const hasMeet = !!event.meetUrl;
   const meetLabel = event.meetUrl?.includes("zoom") ? "Zoom" : "Meet";

--- a/src/features/day-timeline/TimelineBar.tsx
+++ b/src/features/day-timeline/TimelineBar.tsx
@@ -1,5 +1,6 @@
 import type { EventSlot as EventSlotType, Slot } from "./buildSlots";
-import { PROJECTS } from "../../entities/project/projects";
+import { getProject } from "../../entities/project/projects";
+import { useProjects } from "../../entities/project/ProjectsContext";
 import { fmtDuration } from "../../shared/lib/time";
 
 function computeTimeLabels(dayStart: number, dayEnd: number): number[] {
@@ -22,8 +23,9 @@ type SlotDisplayProps = {
 };
 
 function EventSlot({ slot, widthPct, isPast, isCurrent, nowPct, label }: SlotDisplayProps & { slot: EventSlotType }) {
+  const { projectsById } = useProjects();
   const evColor = slot.event.projectId
-    ? PROJECTS[slot.event.projectId].color
+    ? getProject(projectsById, slot.event.projectId).color
     : "#52525b";
   return (
     <div

--- a/src/features/event-detail/EventDetailPanel.test.tsx
+++ b/src/features/event-detail/EventDetailPanel.test.tsx
@@ -1,7 +1,15 @@
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render as rtlRender } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 import type { Event } from "../../entities/event/types";
+import type { Project } from "../../entities/project/types";
+import { ProjectsProvider } from "../../entities/project/ProjectsContext";
 import { EventDetailPanel } from "./EventDetailPanel";
+
+const projects: Project[] = [
+  { id: "slo", name: "SLO推進", color: "#2D9F45", isPrimary: true, createdAt: "" },
+];
+const render = (ui: React.ReactElement) =>
+  rtlRender(<ProjectsProvider projects={projects}>{ui}</ProjectsProvider>);
 
 const baseEvent: Event = {
   id: "e1",

--- a/src/features/event-detail/EventDetailPanel.tsx
+++ b/src/features/event-detail/EventDetailPanel.tsx
@@ -1,5 +1,6 @@
 import type { Event } from "../../entities/event/types";
-import { PROJECTS } from "../../entities/project/projects";
+import { getProject } from "../../entities/project/projects";
+import { useProjects } from "../../entities/project/ProjectsContext";
 import {
   fmtDuration,
   formatClock,
@@ -13,7 +14,8 @@ type EventDetailPanelProps = {
 };
 
 export function EventDetailPanel({ event, onClose }: EventDetailPanelProps) {
-  const proj = event.projectId ? PROJECTS[event.projectId] : null;
+  const { projectsById } = useProjects();
+  const proj = event.projectId ? getProject(projectsById, event.projectId) : null;
   const evColor = proj ? proj.color : "#52525b";
   const evStart = minutesOfDay(event.startTime);
   const evEnd = minutesOfDay(event.endTime);

--- a/src/features/task-detail/TaskDetailPanel.test.tsx
+++ b/src/features/task-detail/TaskDetailPanel.test.tsx
@@ -1,8 +1,16 @@
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render as rtlRender } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 import type { Task } from "../../entities/task/types";
 import type { Event } from "../../entities/event/types";
+import type { Project } from "../../entities/project/types";
+import { ProjectsProvider } from "../../entities/project/ProjectsContext";
 import { TaskDetailPanel, type TaskDetailPanelProps } from "./TaskDetailPanel";
+
+const projects: Project[] = [
+  { id: "slo", name: "SLO推進", color: "#2D9F45", isPrimary: true, createdAt: "" },
+];
+const render = (ui: React.ReactElement) =>
+  rtlRender(<ProjectsProvider projects={projects}>{ui}</ProjectsProvider>);
 
 const baseTask: Task = {
   id: "t1",

--- a/src/features/task-detail/TaskDetailPanel.tsx
+++ b/src/features/task-detail/TaskDetailPanel.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 import type { Task } from "../../entities/task/types";
 import type { Event } from "../../entities/event/types";
-import { PROJECTS } from "../../entities/project/projects";
+import { getProject } from "../../entities/project/projects";
+import { useProjects } from "../../entities/project/ProjectsContext";
 import { isDone } from "../../shared/lib/task";
 import { fmtDuration, formatClock } from "../../shared/lib/time";
 import { renderMarkdown } from "../../shared/lib/markdown";
@@ -12,12 +13,14 @@ export type TaskDetailPanelProps = {
   onClose: () => void;
   onUpdate: (id: string, body: string) => void;
   onToggleDone: (id: string) => void;
+  onDelete?: (id: string) => void;
 };
 
-export function TaskDetailPanel({ task, events, onClose, onUpdate, onToggleDone }: TaskDetailPanelProps) {
+export function TaskDetailPanel({ task, events, onClose, onUpdate, onToggleDone, onDelete }: TaskDetailPanelProps) {
+  const { projectsById } = useProjects();
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(task.body || "");
-  const proj = PROJECTS[task.projectId];
+  const proj = getProject(projectsById, task.projectId);
   const dep = task.dependsOnEventId
     ? events.find((e) => e.id === task.dependsOnEventId)
     : null;
@@ -89,7 +92,20 @@ export function TaskDetailPanel({ task, events, onClose, onUpdate, onToggleDone 
         <div className="flex-1 overflow-auto px-5 pb-6 pt-3">
           {!editing ? (
             <>
-              <div className="mb-2 flex justify-end">
+              <div className="mb-2 flex justify-end gap-2">
+                {onDelete ? (
+                  <button
+                    onClick={() => {
+                      if (window.confirm("このタスクを削除しますか?")) {
+                        onDelete(task.id);
+                        onClose();
+                      }
+                    }}
+                    className="flex cursor-pointer items-center gap-1 rounded-[4px] border border-bg-divider bg-transparent px-2.5 py-[3px] text-[10px] text-accent-red"
+                  >
+                    削除
+                  </button>
+                ) : null}
                 <button
                   onClick={() => {
                     setDraft(task.body || "");

--- a/src/features/task-stack/TaskRow.tsx
+++ b/src/features/task-stack/TaskRow.tsx
@@ -1,6 +1,7 @@
 import type { Task } from "../../entities/task/types";
 import type { PointerEvent as ReactPointerEvent } from "react";
-import { PROJECTS } from "../../entities/project/projects";
+import { getProject } from "../../entities/project/projects";
+import { useProjects } from "../../entities/project/ProjectsContext";
 import { fmtDuration } from "../../shared/lib/time";
 import { Grip } from "./Grip";
 
@@ -13,7 +14,8 @@ type TaskRowProps = {
 };
 
 export function TaskRow({ task, isBeingDragged, onPointerDown, onClick, onToggleDone }: TaskRowProps) {
-  const proj = PROJECTS[task.projectId];
+  const { projectsById } = useProjects();
+  const proj = getProject(projectsById, task.projectId);
 
   return (
     <div

--- a/src/features/task-stack/TaskStack.test.tsx
+++ b/src/features/task-stack/TaskStack.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render as rtlRender } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 import { DoneList } from "./DoneList";
 import { TaskRow } from "./TaskRow";
@@ -6,6 +6,14 @@ import { TaskStack } from "./TaskStack";
 import { TopTaskCard } from "./TopTaskCard";
 import type { Task } from "../../entities/task/types";
 import type { Event } from "../../entities/event/types";
+import type { Project } from "../../entities/project/types";
+import { ProjectsProvider } from "../../entities/project/ProjectsContext";
+
+const projects: Project[] = [
+  { id: "slo", name: "SLO推進", color: "#2D9F45", isPrimary: true, createdAt: "" },
+];
+const render = (ui: React.ReactElement) =>
+  rtlRender(<ProjectsProvider projects={projects}>{ui}</ProjectsProvider>);
 
 const baseTask: Task = {
   id: "t1",

--- a/src/features/task-stack/TopTaskCard.tsx
+++ b/src/features/task-stack/TopTaskCard.tsx
@@ -1,7 +1,8 @@
 import type { Task } from "../../entities/task/types";
 import type { Event } from "../../entities/event/types";
 import type { PointerEvent as ReactPointerEvent } from "react";
-import { PROJECTS } from "../../entities/project/projects";
+import { getProject } from "../../entities/project/projects";
+import { useProjects } from "../../entities/project/ProjectsContext";
 import { formatClock } from "../../shared/lib/time";
 import { Grip } from "./Grip";
 
@@ -20,7 +21,8 @@ type TopTaskCardProps = {
 };
 
 export function TopTaskCard({ task, events, isBeingDragged, onPointerDown, onClick, onToggleDone }: TopTaskCardProps) {
-  const proj = PROJECTS[task.projectId];
+  const { projectsById } = useProjects();
+  const proj = getProject(projectsById, task.projectId);
   const dep = task.dependsOnEventId
     ? events.find((e) => e.id === task.dependsOnEventId)
     : null;

--- a/src/features/tree-view/DateGroup.tsx
+++ b/src/features/tree-view/DateGroup.tsx
@@ -1,19 +1,20 @@
 import type { HistoryEntry } from "../../entities/task/types";
-import type { ProjectKey } from "../../entities/project/types";
-import { PROJECTS } from "../../entities/project/projects";
+import { getProject } from "../../entities/project/projects";
+import { useProjects } from "../../entities/project/ProjectsContext";
 import { formatDate } from "../../shared/lib/time";
 import { lanesWidthPx, nodeCenterPx } from "./layout";
 
 type DateGroupProps = {
   date: string;
   items: HistoryEntry[];
-  projectOrder: readonly ProjectKey[];
+  projectOrder: readonly string[];
 };
 
 /**
  * 1つの日付に属するタスク群を、日付見出しとノード列で描画する。
  */
 export function DateGroup({ date, items, projectOrder }: DateGroupProps) {
+  const { projectsById } = useProjects();
   const lanesWidth = lanesWidthPx(projectOrder.length);
 
   return (
@@ -35,7 +36,7 @@ export function DateGroup({ date, items, projectOrder }: DateGroupProps) {
               className="absolute top-1/2 z-[3] h-2 w-2 -translate-y-1/2 rounded-full bg-bg-primary"
               style={{
                 left: nodeLeft - 4,
-                border: `2px solid ${PROJECTS[task.projectId].color}`,
+                border: `2px solid ${getProject(projectsById, task.projectId).color}`,
               }}
             />
             <div className="shrink-0" style={{ width: lanesWidth }} />

--- a/src/features/tree-view/ProjectLanes.tsx
+++ b/src/features/tree-view/ProjectLanes.tsx
@@ -1,15 +1,16 @@
-import type { ProjectKey } from "../../entities/project/types";
-import { PROJECTS } from "../../entities/project/projects";
+import { getProject } from "../../entities/project/projects";
+import { useProjects } from "../../entities/project/ProjectsContext";
 import { laneLeftPx } from "./layout";
 
 type ProjectLanesProps = {
-  projectOrder: readonly ProjectKey[];
+  projectOrder: readonly string[];
 };
 
 /**
  * プロジェクトごとの縦線（ブランチ）と上部レジェンド。
  */
 export function ProjectLanes({ projectOrder }: ProjectLanesProps) {
+  const { projectsById } = useProjects();
   return (
     <>
       {projectOrder.map((pk, pi) => (
@@ -18,22 +19,23 @@ export function ProjectLanes({ projectOrder }: ProjectLanesProps) {
           className="pointer-events-none absolute top-0 bottom-0 z-[1] w-0.5 opacity-30"
           style={{
             left: laneLeftPx(pi),
-            background: PROJECTS[pk].color,
+            background: getProject(projectsById, pk).color,
           }}
         />
       ))}
       <div className="relative z-[2] flex gap-3 px-4 pb-1.5 pt-3.5">
-        {projectOrder.map((k) => (
-          <div key={k} className="flex items-center gap-1">
-            <div
-              className="h-1.5 w-1.5 rounded-full"
-              style={{ background: PROJECTS[k].color }}
-            />
-            <span className="font-jp text-[9px] text-fg-weak">
-              {PROJECTS[k].name}
-            </span>
-          </div>
-        ))}
+        {projectOrder.map((k) => {
+          const p = getProject(projectsById, k);
+          return (
+            <div key={k} className="flex items-center gap-1">
+              <div
+                className="h-1.5 w-1.5 rounded-full"
+                style={{ background: p.color }}
+              />
+              <span className="font-jp text-[9px] text-fg-weak">{p.name}</span>
+            </div>
+          );
+        })}
       </div>
     </>
   );

--- a/src/features/tree-view/TreeView.test.tsx
+++ b/src/features/tree-view/TreeView.test.tsx
@@ -1,10 +1,18 @@
 import { render } from "@testing-library/react";
 import { describe, expect, test } from "vitest";
 import type { HistoryEntry } from "../../entities/task/types";
-import type { ProjectKey } from "../../entities/project/types";
+import type { Project } from "../../entities/project/types";
+import { ProjectsProvider } from "../../entities/project/ProjectsContext";
 import { TreeView } from "./TreeView";
 
-const projectOrder: ProjectKey[] = ["career", "loadtest", "slo", "tasuki"];
+const projects: Project[] = [
+  { id: "career", name: "転職活動", color: "#E85D04", isPrimary: false, createdAt: "" },
+  { id: "loadtest", name: "負荷試験", color: "#0096C7", isPrimary: false, createdAt: "" },
+  { id: "slo", name: "SLO推進", color: "#2D9F45", isPrimary: true, createdAt: "" },
+  { id: "tasuki", name: "Tasuki", color: "#9B5DE5", isPrimary: false, createdAt: "" },
+];
+
+const projectOrder: readonly string[] = projects.map((p) => p.id);
 
 const history: HistoryEntry[] = [
   { id: "h1", projectId: "career", title: "転職ドラフト応募完了", date: "2026-04-05" },
@@ -12,16 +20,20 @@ const history: HistoryEntry[] = [
   { id: "h3", projectId: "tasuki", title: "php-parser PoC完了", date: "2026-04-06" },
 ];
 
+function renderWithProjects(ui: React.ReactElement) {
+  return render(<ProjectsProvider projects={projects}>{ui}</ProjectsProvider>);
+}
+
 describe("TreeView", () => {
   test("空 historyData でも crash しない", () => {
-    const { container } = render(
+    const { container } = renderWithProjects(
       <TreeView historyData={[]} projectOrder={projectOrder} />,
     );
     expect(container.firstChild).toBeTruthy();
   });
 
   test("プロジェクトレジェンド（名前）を表示する", () => {
-    const { getByText } = render(
+    const { getByText } = renderWithProjects(
       <TreeView historyData={history} projectOrder={projectOrder} />,
     );
     expect(getByText("転職活動")).toBeTruthy();
@@ -30,7 +42,7 @@ describe("TreeView", () => {
   });
 
   test("各タスクタイトルを表示する", () => {
-    const { getByText } = render(
+    const { getByText } = renderWithProjects(
       <TreeView historyData={history} projectOrder={projectOrder} />,
     );
     expect(getByText("転職ドラフト応募完了")).toBeTruthy();
@@ -39,7 +51,7 @@ describe("TreeView", () => {
   });
 
   test("日付見出し（formatDate）を表示する", () => {
-    const { getByText } = render(
+    const { getByText } = renderWithProjects(
       <TreeView historyData={history} projectOrder={projectOrder} />,
     );
     // 2026-04-05 は日曜、2026-04-06 は月曜
@@ -48,7 +60,7 @@ describe("TreeView", () => {
   });
 
   test("日付は降順で並ぶ", () => {
-    const { container } = render(
+    const { container } = renderWithProjects(
       <TreeView historyData={history} projectOrder={projectOrder} />,
     );
     const text = container.textContent;

--- a/src/features/tree-view/TreeView.tsx
+++ b/src/features/tree-view/TreeView.tsx
@@ -1,12 +1,11 @@
 import type { HistoryEntry } from "../../entities/task/types";
-import type { ProjectKey } from "../../entities/project/types";
 import { DateGroup } from "./DateGroup";
 import { groupByDateDesc } from "./layout";
 import { ProjectLanes } from "./ProjectLanes";
 
 type TreeViewProps = {
   historyData: HistoryEntry[];
-  projectOrder: readonly ProjectKey[];
+  projectOrder: readonly string[];
 };
 
 /**

--- a/src/mocks/seed.ts
+++ b/src/mocks/seed.ts
@@ -1,0 +1,217 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { createEvent } from "@/entities/event/api";
+import { PROJECT_SEEDS } from "@/entities/project/projects";
+import { createProject } from "@/entities/project/api";
+import { createTask, updateTask } from "@/entities/task/api";
+import type { Database } from "@/shared/types/database";
+import { todayIso } from "@/shared/lib/time";
+
+type Sb = SupabaseClient<Database>;
+
+/**
+ * サンプルデータを Supabase に一括投入する。
+ *
+ * 1. projects を先に insert して (slug -> projects.id) のマップを作る
+ * 2. events を insert (slug -> events.id のマップを作る)
+ * 3. tasks を insert。depends_on_event_id はイベント slug を置き換えて渡す
+ *
+ * 冪等性は呼び出し元 (reset/seed 判定) で担保する。
+ */
+export async function seedSampleDataToSupabase(supabase: Sb): Promise<void> {
+  // 1. projects
+  const projectSlugToId = new Map<string, string>();
+  for (const seed of PROJECT_SEEDS) {
+    const p = await createProject(supabase, {
+      name: seed.name,
+      color: seed.color,
+      isPrimary: seed.isPrimary,
+    });
+    projectSlugToId.set(seed.slug, p.id);
+  }
+
+  // 2. events (サンプルは今日を基準に生成)
+  const today = todayIso();
+  const at = (hhmm: string) => `${today}T${hhmm}:00`;
+  const eventSeeds: {
+    slug: string;
+    title: string;
+    startTime: string;
+    endTime: string;
+    projectSlug: string | null;
+    meetUrl: string | null;
+    hasAttachments: boolean;
+    description: string;
+  }[] = [
+    {
+      slug: "e2",
+      title: "SLOレビューMTG",
+      startTime: at("09:30"),
+      endTime: at("10:30"),
+      projectSlug: "slo",
+      meetUrl: "https://meet.google.com/abc-defg-hij",
+      hasAttachments: true,
+      description:
+        "## アジェンダ\n\n1. SLI定義の最終確認\n2. エラーバジェットポリシーのレビュー\n3. New Relicダッシュボードのデモ\n\n## 参加者\n\n- 田中PM\n- インフラチーム\n- 自分",
+    },
+    {
+      slug: "e1",
+      title: "デイリースタンドアップ",
+      startTime: at("11:00"),
+      endTime: at("11:15"),
+      projectSlug: null,
+      meetUrl: null,
+      hasAttachments: false,
+      description: "チーム全体の進捗共有\n- 各自の今日のタスク確認\n- ブロッカーの共有",
+    },
+    {
+      slug: "e3",
+      title: "Dirbato最終面接",
+      startTime: at("14:00"),
+      endTime: at("15:00"),
+      projectSlug: "career",
+      meetUrl: "https://zoom.us/j/123456789",
+      hasAttachments: true,
+      description:
+        "## 面接情報\n\n- 面接官: 執行役員 佐藤氏\n- 形式: オンライン (Zoom)\n\n## 準備\n\n- 志望動機の最終整理\n- 逆質問3つ用意\n- `技術力 × ビジネス理解` の軸で話す",
+    },
+    {
+      slug: "e4",
+      title: "1on1 with マネージャー",
+      startTime: at("17:00"),
+      endTime: at("17:30"),
+      projectSlug: null,
+      meetUrl: "https://meet.google.com/xyz-uvwx-rst",
+      hasAttachments: false,
+      description:
+        "- 今週の振り返り\n- 来週の優先順位確認\n- キャリアの相談（転職活動の進捗共有）",
+    },
+    {
+      slug: "e5",
+      title: "もくもく会",
+      startTime: at("21:00"),
+      endTime: at("23:00"),
+      projectSlug: null,
+      meetUrl: "https://meet.google.com/moku-moku-kai",
+      hasAttachments: false,
+      description: "オンラインもくもく会\n\n- 各自作業\n- 30分ごとに進捗共有",
+    },
+  ];
+
+  const eventSlugToId = new Map<string, string>();
+  for (const seed of eventSeeds) {
+    const projectId = seed.projectSlug
+      ? (projectSlugToId.get(seed.projectSlug) ?? null)
+      : null;
+    const e = await createEvent(supabase, {
+      title: seed.title,
+      startTime: seed.startTime,
+      endTime: seed.endTime,
+      projectId,
+      meetUrl: seed.meetUrl,
+      hasAttachments: seed.hasAttachments,
+      description: seed.description,
+    });
+    eventSlugToId.set(seed.slug, e.id);
+  }
+
+  // 3. tasks
+  const taskSeeds: {
+    projectSlug: string;
+    title: string;
+    estimatedMinutes: number;
+    stackOrder: number;
+    dependsOnEventSlug: string | null;
+    body: string;
+  }[] = [
+    {
+      projectSlug: "career",
+      title: "面接対策：志望動機の最終整理",
+      estimatedMinutes: 45,
+      stackOrder: 0,
+      dependsOnEventSlug: "e3",
+      body:
+        "## やること\n\n- **志望動機**を3パターン用意\n- 技術的な強みの整理\n  - DDD / Clean Architecture\n  - SLI/SLO導入経験\n- 逆質問リストの準備\n\n## 参考\n\n`転職ドラフト`のフィードバックを確認\n\n> 上流工程への関与意欲が伝わる内容にすること",
+    },
+    {
+      projectSlug: "slo",
+      title: "SLI定義ドキュメント更新",
+      estimatedMinutes: 40,
+      stackOrder: 1,
+      dependsOnEventSlug: "e2",
+      body:
+        "## 対象\n\nWeb Cart フロントエンドの SLI\n\n## 更新内容\n\n- Availability SLI: `成功リクエスト / 全リクエスト`\n- Latency SLI: `p99 < 500ms`\n- 計測ポイントをNew Relicの`Transaction`に合わせる",
+    },
+    {
+      projectSlug: "loadtest",
+      title: "WireMock stub定義作成",
+      estimatedMinutes: 35,
+      stackOrder: 2,
+      dependsOnEventSlug: null,
+      body:
+        "chaos test用のstub定義ファイルを作成する\n\n### エンドポイント\n\n1. `/api/v1/orders` — 正常レスポンス\n2. `/api/v1/orders` — 429 レスポンス (rate limit)\n3. `/api/v1/payments` — 500ms遅延",
+    },
+    {
+      projectSlug: "career",
+      title: "職務経歴書PDF最終版を送付",
+      estimatedMinutes: 15,
+      stackOrder: 3,
+      dependsOnEventSlug: null,
+      body:
+        "最終版PDFを浅野さんにメール送付\n\n確認ポイント:\n- 誤字脱字チェック済み\n- BASE在籍期間の記載が正確か",
+    },
+    {
+      projectSlug: "tasuki",
+      title: "AnalyzerContract trait設計",
+      estimatedMinutes: 90,
+      stackOrder: 4,
+      dependsOnEventSlug: null,
+      body:
+        "## 目的\n\ncode-inspector用の抽象化層を設計する\n\n## 設計メモ\n\n```rust\ntrait AnalyzerContract {\n    fn analyze(&self, input: &SourceFile) -> AnalysisResult;\n    fn supports(&self, file_type: &FileType) -> bool;\n}\n```\n\n- php-parser と tree-sitter の両方に対応\n- call chain 解析は別traitに分離",
+    },
+    {
+      projectSlug: "loadtest",
+      title: "Locustシナリオ実装",
+      estimatedMinutes: 120,
+      stackOrder: 5,
+      dependsOnEventSlug: null,
+      body:
+        "ピーク負荷パターンのシナリオを実装\n\n## 要件\n\n- 通常: 100 RPS\n- ピーク: 500 RPS (10分間)\n- ramp-up: 5分\n\n## メモ\n\n分散モードで ECS 上に展開予定",
+    },
+  ];
+
+  for (const seed of taskSeeds) {
+    const projectId = projectSlugToId.get(seed.projectSlug);
+    if (!projectId) continue;
+    const created = await createTask(supabase, {
+      projectId,
+      title: seed.title,
+      body: seed.body,
+      estimatedMinutes: seed.estimatedMinutes,
+      stackOrder: seed.stackOrder,
+    });
+    if (seed.dependsOnEventSlug) {
+      const eventId = eventSlugToId.get(seed.dependsOnEventSlug);
+      if (eventId) {
+        await updateTask(supabase, created.id, { dependsOnEventId: eventId });
+      }
+    }
+  }
+}
+
+/**
+ * 現ユーザーの tasks / events / projects を全削除する。
+ * tasks → events の順で消す (tasks.depends_on_event_id の FK を考慮)。
+ * projects は ON DELETE SET NULL なので最後に消して OK。
+ */
+export async function clearAllUserData(supabase: Sb): Promise<void> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("not authenticated");
+  const uid = user.id;
+  // RLS が効いているので user_id 絞り込みは念押しだが明示しておく
+  await supabase.from("tasks").delete().eq("user_id", uid);
+  await supabase.from("events").delete().eq("user_id", uid);
+  await supabase.from("projects").delete().eq("user_id", uid);
+}

--- a/src/shared/query/QueryProvider.tsx
+++ b/src/shared/query/QueryProvider.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
+
+/**
+ * React Query の QueryClient を全ページで共有する。
+ *
+ * staleTime を短めに、retry を 1 回に絞っているのは「個人用道具であり、
+ * ネットワーク断時は即諦めて最新 UI を出し続ける」方針 (vision.md)。
+ */
+export function QueryProvider({ children }: { children: React.ReactNode }) {
+  const [client] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 30_000,
+            refetchOnWindowFocus: false,
+            retry: 1,
+          },
+          mutations: {
+            retry: 0,
+          },
+        },
+      }),
+  );
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}

--- a/src/shared/theme/tokens.ts
+++ b/src/shared/theme/tokens.ts
@@ -1,5 +1,4 @@
-import { PROJECTS } from "../../entities/project/projects";
-import type { ProjectKey } from "../../entities/project/types";
+import { PROJECT_SEEDS } from "../../entities/project/projects";
 
 export const BG_COLORS = {
   primary: "#0a0a0b",
@@ -37,6 +36,11 @@ export const ACCENT_COLORS = {
   meetBg: "#00AC47",
 } as const;
 
-export const PROJECT_COLORS: Record<ProjectKey, string> = Object.fromEntries(
-  Object.entries(PROJECTS).map(([key, value]) => [key, value.color]),
-) as Record<ProjectKey, string>;
+/**
+ * Tailwind の color palette 用。
+ * ユーザーが追加したプロジェクトは対象外 (動的 class 生成は Tailwind と相性が悪いため)。
+ * 既定シード 4 色のみ Tailwind 経由で参照可能にする。
+ */
+export const PROJECT_COLORS: Record<string, string> = Object.fromEntries(
+  PROJECT_SEEDS.map((seed) => [seed.slug, seed.color]),
+);


### PR DESCRIPTION
- entities/{task,event,project}/api.ts で Supabase CRUD 関数を公開
- AppShell の useState を TanStack Query に置換、DnD / 完了 / 並べ替え / 削除 / 本文更新は optimistic update
- task / event / project 追加フォーム (feature-spec.md Step 3) を実装し右下 + ボタンから起動
- サンプル seed / reset / clear を Supabase 書き込みに変更 (初回ログイン時は自動投入)
- deleteTask 内で task_deleted action_log を記録し、タスク詳細パネルから削除可能に
- ProjectKey を string へ widen、PROJECTS 固定 map → 動的 Project[] + ProjectsContext
- tree view / day-timeline / 各詳細パネルは projects ctx から名前 / 色を解決

https://claude.ai/code/session_01UA2TJSXjxg16KDgWBFZRp9