### PR TITLE
feat(p1-5): task_time_entries と開始/中断/再開/完了 UI (#27)

### DIFF
--- a/docs/adr/0004-time-entry-state-machine.md
+++ b/docs/adr/0004-time-entry-state-machine.md
@@ -1,0 +1,90 @@
+# ADR 0004: タイマーの状態機械と multi-tab 戦略
+
+- **Status**: Accepted
+- **Date**: 2026-04-19
+- **Related**: `docs/design/vision.md` / `docs/design/architecture.md` §2 / Issue #27 (P1-5)
+
+## Context
+
+Phase 1 の P1-5 で「開始 / 中断 / 再開 / 完了」操作を実装するにあたり、
+`task_time_entries` への insert/update のやり方と、以下の論点を決める必要がある。
+
+1. **中断の表現**: 1タスク = 1 entry の `paused_at` 更新で表すか、
+   再開のたびに新規 entry を作って複数行に分割するか。
+2. **リロード時の復元**: 「アクティブ」状態をどう DB から復元するか。
+3. **複数タブで同時に開始された場合の挙動**: 開いた 2 つのブラウザタブそれぞれで
+   同一タスクに「開始」が押された場合どう整合させるか。
+4. **duration_seconds の計算時点**: insert 時か close 時か。
+
+これらは vision.md の差別化の核「行動パターン分析」のためのデータ品質に直結する。
+中断履歴が欠損したり、重複 entry が生まれて合計時間が狂うと、
+Phase 3 の見積もり補正エンジンの学習が不正確になる。
+
+## Decision
+
+**タイマー状態機械** を `tasks.status` (`idle` / `active` / `paused` / `done`) と
+`task_time_entries` の open entry (paused_at = null) の組で表現する。
+具体的には以下のルール:
+
+1. **entry は再開のたびに分割**する。中断すると open entry を close し、
+   再開すると新規 entry を insert する (= 1タスクに複数 entry が並ぶ)。
+2. **`duration_seconds` は close 時点で計算して保存**する
+   (= `paused_at - started_at`)。open entry は null。
+3. **リロード復元**は `tasks.status` と最新 entries を引くだけ。クライアントは
+   open entry が存在すれば active、なければ pauseReason バッジを最終 entry から
+   引いて paused バッジを表示する。
+4. **multi-tab は「後勝ち」**: start 時に既に open entry があれば
+   `pause_reason = voluntary` で強制 close してから新規 entry を開く。
+
+## Consequences
+
+### 肯定的影響
+
+- **中断理由の時系列が保存される**。"meeting で 30 分 → 再開して 15 分 → 割り込みで 10 分"
+  のような粒度の分析ができる (Phase 3-4 で活きる)。
+- **duration_seconds は不変量**。読み出し側で日時差分を毎回計算する必要がなく、
+  Phase 3 の見積もり補正エンジンのクエリがシンプルになる。
+- **後勝ち戦略**は実装が最小。別タブで開いた古い open entry を "voluntary" で
+  強制 close することで、少なくとも合計時間は正しく積める。
+- **リロード復元は DB 参照だけで完結**。localStorage 等の追加レイヤーが要らない。
+
+### 否定的影響・トレードオフ
+
+- **1タスクに entry が増えやすい**。頻繁に中断するユーザーでは 1タスクに 10+ 行もありうる。
+  ただし Supabase で十分捌けるボリュームであり、action_logs 側の粒度とも揃う。
+- **後勝ち** はユーザーが別タブで進めていた作業の中断理由が `voluntary` で上書き
+  される。本当は meeting 由来だったかもしれない。だが Phase 1 のユーザーは著者 1 人で
+  multi-tab の同時操作はレアケース扱いで十分と判断。将来問題になったら警告ダイアログを
+  導入する。
+- **close 時計算**のため、クライアントのクロックがずれていると duration がずれる。
+  server time を使わないトレードオフ。Phase 1 の PoC としては許容。
+
+### 将来的な制約
+
+- Phase 2 の「MTG 開始時の自動 paused」(`pause_reason = meeting`) でも同じ entry 分割モデル
+  を再利用する。meeting 終了後に新規 entry で再開する。
+- Phase 3 の見積もり補正エンジンは `sum(duration_seconds)` で actual を取る前提。
+  ある期間で未 close entry が残っている場合の扱いは別途判断 (当面: 無視して sum)。
+
+## Alternatives considered
+
+- **1 entry = 1 タスクで paused_at を上書き**: 中断履歴が消える。
+  Phase 3-4 の行動分析で「中断理由ごとの時間構成」を見たいのに取れなくなる。不採用。
+- **duration_seconds を insert 時に NULL で入れ、読み出し時に都度計算**:
+  Phase 3 のクエリが「いま動いてる entry を除外して sum」という条件付きになり複雑。
+  保存時に確定する方がシンプル。不採用。
+- **multi-tab で先勝ち (後のタブでは「他のタブで動いています」エラー)**:
+  UI のエラー導線を Phase 1 で作るのは過剰。後勝ちの方が UX としても自然。不採用。
+- **localStorage で active state を先にキャッシュしてリロード復元**:
+  DB が正の原則 (CLAUDE.md 「コードが仕様」) に反する。キャッシュレイヤーが増えると
+  同期バグの温床。不採用。
+
+## Notes
+
+- 実装: `src/entities/task/time-entries.ts` (API 層) と
+  `src/features/task-stack/useTaskTimer.ts` (状態機械 hook)。
+- DB 制約 (`task_time_entries_pause_reason_requires_paused`) により、
+  完了時の close では `paused_at` だけ打って `pause_reason = null` を許容する。
+  これは「完了時の終了」と「中断」を区別するため。
+- 見直し条件: Phase 2 で MTG 連動 paused を入れるとき、meeting 開始時の
+  自動 close が後勝ちと衝突しないか要検証。

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -37,9 +37,12 @@ import { AddPanel } from "@/features/add-forms/AddPanel";
 import { DayTimeline } from "@/features/day-timeline/DayTimeline";
 import { EventDetailPanel } from "@/features/event-detail/EventDetailPanel";
 import { TaskDetailPanel } from "@/features/task-detail/TaskDetailPanel";
-import { TaskStack } from "@/features/task-stack/TaskStack";
+import { PauseReasonModal } from "@/features/task-stack/PauseReasonModal";
+import { TaskStack, type TopTimerBinding } from "@/features/task-stack/TaskStack";
+import { useTaskTimer } from "@/features/task-stack/useTaskTimer";
 import { TreeView } from "@/features/tree-view/TreeView";
 import { UserMenu } from "@/features/user-menu/UserMenu";
+import type { PauseReason } from "@/entities/task/time-entries";
 import { historyData } from "@/mocks/history";
 import { clearAllUserData, seedSampleDataToSupabase } from "@/mocks/seed";
 import {
@@ -317,6 +320,38 @@ export function AppShell({ initialView, user }: AppShellProps) {
   const doneTasks = useMemo(() => tasks.filter((t) => isDone(t)), [tasks]);
   const detailTask = detailId ? tasks.find((t) => t.id === detailId) : null;
 
+  // タスクスタックのトップタスク = タイマー対象。
+  // pendingTasks は stack_order 昇順なので [0] がトップ。
+  const topTask = pendingTasks[0] ?? null;
+  const timer = useTaskTimer(topTask);
+  const [pauseModalOpen, setPauseModalOpen] = useState(false);
+
+  const topTimer = useMemo<TopTimerBinding>(
+    () => ({
+      elapsedSeconds: timer.elapsedSeconds,
+      pauseReason: timer.pauseReason,
+      onStart: () => {
+        void timer.start();
+      },
+      onPauseRequest: () => setPauseModalOpen(true),
+      onResume: () => {
+        void timer.resume();
+      },
+      onComplete: () => {
+        void timer.complete();
+      },
+    }),
+    [timer],
+  );
+
+  const handlePauseSelect = useCallback(
+    (reason: PauseReason) => {
+      setPauseModalOpen(false);
+      void timer.pause(reason);
+    },
+    [timer],
+  );
+
   // Tree View は Phase 1 PoC では現行 mock history をそのまま描画する。
   // 将来: tasks where status='done' から生成する (docs/specs/phase1.md Tree View)
   const projectOrderForTree = useMemo(() => {
@@ -373,6 +408,7 @@ export function AppShell({ initialView, user }: AppShellProps) {
             events={events}
             pendingTasks={pendingTasks}
             doneTasks={doneTasks}
+            topTimer={topTimer}
             toggleDone={toggleDone}
             reorder={reorder}
             nowMin={nowMin}
@@ -427,6 +463,13 @@ export function AppShell({ initialView, user }: AppShellProps) {
             onCreateProject={async (input) => {
               await createProjectMutation.mutateAsync(input);
             }}
+          />
+        ) : null}
+
+        {pauseModalOpen ? (
+          <PauseReasonModal
+            onSelect={handlePauseSelect}
+            onClose={() => setPauseModalOpen(false)}
           />
         ) : null}
 
@@ -485,6 +528,7 @@ type StackViewProps = {
   events: Event[];
   pendingTasks: Task[];
   doneTasks: Task[];
+  topTimer: TopTimerBinding;
   toggleDone: (id: string) => void;
   reorder: (from: number, to: number) => void;
   nowMin: number;
@@ -497,6 +541,7 @@ function StackView({
   events,
   pendingTasks,
   doneTasks,
+  topTimer,
   toggleDone,
   reorder,
   nowMin,
@@ -516,6 +561,7 @@ function StackView({
         events={events}
         pendingTasks={pendingTasks}
         doneTasks={doneTasks}
+        topTimer={topTimer}
         onReorder={reorder}
         onToggleDone={toggleDone}
         onOpenDetail={onOpenDetail}

--- a/src/entities/task/time-entries.test.ts
+++ b/src/entities/task/time-entries.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "vitest";
+
+import { sumDurationSeconds, type TimeEntry } from "./time-entries";
+
+function entry(overrides: Partial<TimeEntry>): TimeEntry {
+  return {
+    id: "e",
+    taskId: "t",
+    startedAt: "2026-04-19T10:00:00.000Z",
+    pausedAt: null,
+    pauseReason: null,
+    durationSeconds: null,
+    ...overrides,
+  };
+}
+
+describe("sumDurationSeconds", () => {
+  test("空配列は 0", () => {
+    expect(sumDurationSeconds([])).toBe(0);
+  });
+
+  test("閉じた entry の duration_seconds を合計する", () => {
+    const entries = [
+      entry({ id: "1", durationSeconds: 60, pausedAt: "x" }),
+      entry({ id: "2", durationSeconds: 120, pausedAt: "y" }),
+    ];
+    expect(sumDurationSeconds(entries)).toBe(180);
+  });
+
+  test("open entry は referenceTime - startedAt の経過秒数を加算する", () => {
+    const startedAt = "2026-04-19T10:00:00.000Z";
+    const reference = new Date("2026-04-19T10:00:30.000Z").getTime();
+    const entries = [entry({ startedAt })];
+    expect(sumDurationSeconds(entries, reference)).toBe(30);
+  });
+
+  test("閉じた entry + open entry を両方カウントする (中断→再開)", () => {
+    const reference = new Date("2026-04-19T10:05:00.000Z").getTime();
+    const entries = [
+      // 1分稼働して中断
+      entry({
+        id: "1",
+        startedAt: "2026-04-19T10:00:00.000Z",
+        pausedAt: "2026-04-19T10:01:00.000Z",
+        durationSeconds: 60,
+        pauseReason: "voluntary",
+      }),
+      // 再開して 4 分経過 (open)
+      entry({
+        id: "2",
+        startedAt: "2026-04-19T10:01:00.000Z",
+      }),
+    ];
+    expect(sumDurationSeconds(entries, reference)).toBe(60 + 240);
+  });
+
+  test("負の経過時間は 0 にクランプする (時刻の巻き戻り防御)", () => {
+    const startedAt = "2026-04-19T10:00:00.000Z";
+    const reference = new Date("2026-04-19T09:00:00.000Z").getTime();
+    expect(sumDurationSeconds([entry({ startedAt })], reference)).toBe(0);
+  });
+});

--- a/src/entities/task/time-entries.ts
+++ b/src/entities/task/time-entries.ts
@@ -1,0 +1,147 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type {
+  Database,
+  Enums,
+  Tables,
+  TablesInsert,
+  TablesUpdate,
+} from "@/shared/types/database";
+
+type Sb = SupabaseClient<Database>;
+
+export type PauseReason = Enums<"pause_reason">;
+
+export type TimeEntry = {
+  id: string;
+  taskId: string;
+  startedAt: string;
+  pausedAt: string | null;
+  pauseReason: PauseReason | null;
+  durationSeconds: number | null;
+};
+
+function fromRow(row: Tables<"task_time_entries">): TimeEntry {
+  return {
+    id: row.id,
+    taskId: row.task_id,
+    startedAt: row.started_at,
+    pausedAt: row.paused_at,
+    pauseReason: row.pause_reason,
+    durationSeconds: row.duration_seconds,
+  };
+}
+
+/**
+ * 指定タスクの全 entry を started_at 昇順で返す。
+ * 実績時間の合計は closed entry (duration_seconds != null) と
+ * open entry (paused_at = null) の経過秒数を足して求める。
+ */
+export async function listTimeEntries(
+  supabase: Sb,
+  taskId: string,
+): Promise<TimeEntry[]> {
+  const { data, error } = await supabase
+    .from("task_time_entries")
+    .select("*")
+    .eq("task_id", taskId)
+    .order("started_at", { ascending: true });
+  if (error) throw error;
+  return (data ?? []).map(fromRow);
+}
+
+/** 現在 open な (paused_at が null の) entry を 1 件返す。無ければ null。 */
+export async function getOpenTimeEntry(
+  supabase: Sb,
+  taskId: string,
+): Promise<TimeEntry | null> {
+  const { data, error } = await supabase
+    .from("task_time_entries")
+    .select("*")
+    .eq("task_id", taskId)
+    .is("paused_at", null)
+    .order("started_at", { ascending: false })
+    .limit(1);
+  if (error) throw error;
+  const row = data?.[0];
+  return row ? fromRow(row) : null;
+}
+
+/** 新規 entry を started_at = now で挿入する。 */
+export async function startTimeEntry(
+  supabase: Sb,
+  taskId: string,
+  startedAt: string = new Date().toISOString(),
+): Promise<TimeEntry> {
+  const payload: TablesInsert<"task_time_entries"> = {
+    task_id: taskId,
+    started_at: startedAt,
+  };
+  const { data, error } = await supabase
+    .from("task_time_entries")
+    .insert(payload)
+    .select("*")
+    .single();
+  if (error) throw error;
+  return fromRow(data);
+}
+
+function computeDurationSeconds(startedAt: string, pausedAt: string): number {
+  const delta = Math.floor(
+    (new Date(pausedAt).getTime() - new Date(startedAt).getTime()) / 1000,
+  );
+  return delta < 0 ? 0 : delta;
+}
+
+/**
+ * open entry を閉じる: paused_at を打刻し duration_seconds を計算する。
+ * pauseReason を与えると pause_reason も保存する。
+ * 既に閉じられている entry (paused_at != null) は no-op として扱う。
+ */
+export async function closeTimeEntry(
+  supabase: Sb,
+  entry: TimeEntry,
+  pauseReason: PauseReason | null,
+  pausedAt: string = new Date().toISOString(),
+): Promise<TimeEntry> {
+  if (entry.pausedAt) return entry;
+  const durationSeconds = computeDurationSeconds(entry.startedAt, pausedAt);
+  const patch: TablesUpdate<"task_time_entries"> = {
+    paused_at: pausedAt,
+    pause_reason: pauseReason,
+    duration_seconds: durationSeconds,
+  };
+  const { data, error } = await supabase
+    .from("task_time_entries")
+    .update(patch)
+    .eq("id", entry.id)
+    .select("*")
+    .single();
+  if (error) throw error;
+  return fromRow(data);
+}
+
+/**
+ * タスクの実績秒数合計。
+ * - 閉じた entry は duration_seconds をそのまま足す
+ * - open entry (= 現在アクティブ) は referenceTime との差分で補う
+ */
+export function sumDurationSeconds(
+  entries: readonly TimeEntry[],
+  referenceTime: number = Date.now(),
+): number {
+  let total = 0;
+  for (const e of entries) {
+    if (e.durationSeconds != null) {
+      total += e.durationSeconds;
+      continue;
+    }
+    if (e.pausedAt == null) {
+      const delta = Math.floor(
+        (referenceTime - new Date(e.startedAt).getTime()) / 1000,
+      );
+      total += delta < 0 ? 0 : delta;
+    }
+  }
+  return total;
+}

--- a/src/features/task-stack/PauseReasonModal.tsx
+++ b/src/features/task-stack/PauseReasonModal.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import type { PauseReason } from "@/entities/task/time-entries";
+
+type PauseReasonModalProps = {
+  onSelect: (reason: PauseReason) => void;
+  onClose: () => void;
+};
+
+const OPTIONS: { value: PauseReason; label: string; hint: string }[] = [
+  { value: "meeting", label: "MTG / 会議", hint: "会議やハドル" },
+  { value: "interruption", label: "割り込み", hint: "急な依頼・質問" },
+  { value: "voluntary", label: "自発的に中断", hint: "休憩・切り替え" },
+];
+
+/**
+ * タスク中断時に pause_reason を選択させるモーダル。
+ * 3択固定 (phase1.md Step 3.3 / types.ts の PauseReason) で、
+ * 将来 meeting 開始時の自動 paused (Phase 2+) でも meeting が既定になるよう
+ * ここで共有する UI パターン。
+ */
+export function PauseReasonModal({ onSelect, onClose }: PauseReasonModalProps) {
+  return (
+    <div className="fixed inset-0 z-[220] flex flex-col">
+      <div
+        onClick={onClose}
+        className="absolute inset-0 bg-black/60 backdrop-blur-[4px]"
+      />
+      <div className="relative mt-auto flex animate-panel-slide-up flex-col rounded-t-2xl bg-bg-surface">
+        <div className="flex justify-center pb-1 pt-2.5">
+          <div className="h-[3px] w-8 rounded-[2px] bg-bg-divider" />
+        </div>
+        <div className="px-5 pb-5 pt-2">
+          <div className="pb-3 font-jp text-[13px] font-semibold text-fg-emphasized">
+            中断の理由
+          </div>
+          <div className="flex flex-col gap-2">
+            {OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => onSelect(opt.value)}
+                className="flex items-center justify-between rounded-lg bg-bg-elevated px-4 py-3 text-left"
+              >
+                <span className="font-jp text-[13px] text-fg-strong">
+                  {opt.label}
+                </span>
+                <span className="font-jp text-[10px] text-fg-weak">
+                  {opt.hint}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function pauseReasonLabel(reason: PauseReason): string {
+  switch (reason) {
+    case "meeting":
+      return "MTG";
+    case "interruption":
+      return "割り込み";
+    case "voluntary":
+      return "休憩";
+  }
+}

--- a/src/features/task-stack/TaskStack.test.tsx
+++ b/src/features/task-stack/TaskStack.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render as rtlRender } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 import { DoneList } from "./DoneList";
 import { TaskRow } from "./TaskRow";
-import { TaskStack } from "./TaskStack";
+import { TaskStack, type TopTimerBinding } from "./TaskStack";
 import { TopTaskCard } from "./TopTaskCard";
 import type { Task } from "../../entities/task/types";
 import type { Event } from "../../entities/event/types";
@@ -46,69 +46,99 @@ const baseEvent: Event = {
 
 const noop = () => {};
 
+const idleTimer: TopTimerBinding = {
+  elapsedSeconds: 0,
+  pauseReason: null,
+  onStart: noop,
+  onPauseRequest: noop,
+  onResume: noop,
+  onComplete: noop,
+};
+
+const topProps = {
+  events: [] as Event[],
+  isBeingDragged: false,
+  elapsedSeconds: 0,
+  pauseReason: null,
+  onPointerDown: noop,
+  onClick: noop,
+  onStart: noop,
+  onPauseRequest: noop,
+  onResume: noop,
+  onComplete: noop,
+};
+
 describe("TopTaskCard", () => {
   test("タイトルとプロジェクト名を表示", () => {
-    const { getByText } = render(
-      <TopTaskCard
-        task={baseTask}
-        events={[]}
-        isBeingDragged={false}
-        onPointerDown={noop}
-        onClick={noop}
-        onToggleDone={noop}
-      />,
-    );
+    const { getByText } = render(<TopTaskCard {...topProps} task={baseTask} />);
     expect(getByText("SLI 定義更新")).toBeTruthy();
     expect(getByText("SLO推進")).toBeTruthy();
   });
 
   test("dependsOnEventId の依存イベントを解決してバッジ表示", () => {
-    const events: Event[] = [baseEvent];
     const { getByText } = render(
       <TopTaskCard
+        {...topProps}
         task={{ ...baseTask, dependsOnEventId: "e1" }}
-        events={events}
-        isBeingDragged={false}
-        onPointerDown={noop}
-        onClick={noop}
-        onToggleDone={noop}
+        events={[baseEvent]}
       />,
     );
     expect(getByText("← 14:00までに")).toBeTruthy();
   });
 
   test("body の先頭非見出し行をプレビュー表示", () => {
-    const { getByText } = render(
-      <TopTaskCard
-        task={baseTask}
-        events={[]}
-        isBeingDragged={false}
-        onPointerDown={noop}
-        onClick={noop}
-        onToggleDone={noop}
-      />,
-    );
+    const { getByText } = render(<TopTaskCard {...topProps} task={baseTask} />);
     expect(getByText("要件整理")).toBeTruthy();
   });
 
-  test("完了ボタンで onToggleDone、body/Grip クリックは伝播しない", () => {
+  test("idle タスクは『開始』ボタンを表示し onStart を呼ぶ", () => {
+    const onStart = vi.fn();
     const onClick = vi.fn();
-    const onToggleDone = vi.fn();
-    const { container } = render(
+    const { getByLabelText } = render(
       <TopTaskCard
+        {...topProps}
         task={baseTask}
-        events={[]}
-        isBeingDragged={false}
-        onPointerDown={noop}
+        onStart={onStart}
         onClick={onClick}
-        onToggleDone={onToggleDone}
       />,
     );
-    const button = container.querySelector("button")!;
-    fireEvent.click(button);
-    expect(onToggleDone).toHaveBeenCalledTimes(1);
-    // stopPropagation により onClick (カード全体) は発火しない
+    fireEvent.click(getByLabelText("開始"));
+    expect(onStart).toHaveBeenCalledTimes(1);
     expect(onClick).not.toHaveBeenCalled();
+  });
+
+  test("active タスクは中断/完了ボタンと経過時間を表示する", () => {
+    const onPauseRequest = vi.fn();
+    const onComplete = vi.fn();
+    const { getByLabelText, getByText } = render(
+      <TopTaskCard
+        {...topProps}
+        task={{ ...baseTask, status: "active" }}
+        elapsedSeconds={125}
+        onPauseRequest={onPauseRequest}
+        onComplete={onComplete}
+      />,
+    );
+    expect(getByText("● 02:05")).toBeTruthy();
+    fireEvent.click(getByLabelText("中断"));
+    expect(onPauseRequest).toHaveBeenCalledTimes(1);
+    fireEvent.click(getByLabelText("完了"));
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  test("paused タスクは『再開』ボタンと中断理由バッジを表示する", () => {
+    const onResume = vi.fn();
+    const { getByLabelText, getByText } = render(
+      <TopTaskCard
+        {...topProps}
+        task={{ ...baseTask, status: "paused" }}
+        pauseReason="meeting"
+        onResume={onResume}
+      />,
+    );
+    expect(getByText("中断: MTG")).toBeTruthy();
+    fireEvent.click(getByLabelText("再開"));
+    expect(onResume).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -191,6 +221,7 @@ describe("TaskStack", () => {
         events={[]}
         pendingTasks={pending}
         doneTasks={[]}
+        topTimer={idleTimer}
         onReorder={noop}
         onToggleDone={noop}
         onOpenDetail={noop}
@@ -211,6 +242,7 @@ describe("TaskStack", () => {
         events={[]}
         pendingTasks={pending}
         doneTasks={doneTasks}
+        topTimer={idleTimer}
         onReorder={noop}
         onToggleDone={noop}
         onOpenDetail={noop}
@@ -227,6 +259,7 @@ describe("TaskStack", () => {
         events={[]}
         pendingTasks={pending}
         doneTasks={[]}
+        topTimer={idleTimer}
         onReorder={noop}
         onToggleDone={noop}
         onOpenDetail={onOpenDetail}

--- a/src/features/task-stack/TaskStack.tsx
+++ b/src/features/task-stack/TaskStack.tsx
@@ -1,5 +1,6 @@
-import type { Task } from "../../entities/task/types";
 import type { Event } from "../../entities/event/types";
+import type { PauseReason } from "../../entities/task/time-entries";
+import type { Task } from "../../entities/task/types";
 import { DoneList } from "./DoneList";
 import { TaskRow } from "./TaskRow";
 import { TopTaskCard } from "./TopTaskCard";
@@ -21,16 +22,34 @@ function DropIndicator() {
   return <div className="mx-4 h-0.5 rounded-[1px] bg-accent-blue" />;
 }
 
+export type TopTimerBinding = {
+  elapsedSeconds: number;
+  pauseReason: PauseReason | null;
+  onStart: () => void;
+  onPauseRequest: () => void;
+  onResume: () => void;
+  onComplete: () => void;
+};
+
 type TaskStackProps = {
   events: Event[];
   pendingTasks: Task[];
   doneTasks: Task[];
+  topTimer: TopTimerBinding;
   onReorder: (from: number, to: number) => void;
   onToggleDone: (id: string) => void;
   onOpenDetail: (id: string) => void;
 };
 
-export function TaskStack({ events, pendingTasks, doneTasks, onReorder, onToggleDone, onOpenDetail }: TaskStackProps) {
+export function TaskStack({
+  events,
+  pendingTasks,
+  doneTasks,
+  topTimer,
+  onReorder,
+  onToggleDone,
+  onOpenDetail,
+}: TaskStackProps) {
   const { dragIdx, overIdx, rowRefs, handlePointerDown } =
     useStackDnD(onReorder);
 
@@ -57,9 +76,14 @@ export function TaskStack({ events, pendingTasks, doneTasks, onReorder, onToggle
                 task={task}
                 events={events}
                 isBeingDragged={isBeingDragged}
+                elapsedSeconds={topTimer.elapsedSeconds}
+                pauseReason={topTimer.pauseReason}
                 onPointerDown={(e) => handlePointerDown(idx, e)}
                 onClick={() => onOpenDetail(task.id)}
-                onToggleDone={() => onToggleDone(task.id)}
+                onStart={topTimer.onStart}
+                onPauseRequest={topTimer.onPauseRequest}
+                onResume={topTimer.onResume}
+                onComplete={topTimer.onComplete}
               />
             ) : (
               <TaskRow

--- a/src/features/task-stack/TopTaskCard.tsx
+++ b/src/features/task-stack/TopTaskCard.tsx
@@ -1,10 +1,14 @@
-import type { Task } from "../../entities/task/types";
-import type { Event } from "../../entities/event/types";
 import type { PointerEvent as ReactPointerEvent } from "react";
+
+import type { Event } from "../../entities/event/types";
 import { getProject } from "../../entities/project/projects";
 import { useProjects } from "../../entities/project/ProjectsContext";
+import type { PauseReason } from "../../entities/task/time-entries";
+import type { Task } from "../../entities/task/types";
 import { formatClock } from "../../shared/lib/time";
 import { Grip } from "./Grip";
+import { pauseReasonLabel } from "./PauseReasonModal";
+import { formatElapsed } from "./useTaskTimer";
 
 function bodyPreview(body: string): string {
   if (!body) return "";
@@ -15,18 +19,37 @@ type TopTaskCardProps = {
   task: Task;
   events: Event[];
   isBeingDragged: boolean;
+  elapsedSeconds: number;
+  pauseReason: PauseReason | null;
   onPointerDown: (e: ReactPointerEvent<HTMLElement>) => void;
   onClick: () => void;
-  onToggleDone: () => void;
+  onStart: () => void;
+  onPauseRequest: () => void;
+  onResume: () => void;
+  onComplete: () => void;
 };
 
-export function TopTaskCard({ task, events, isBeingDragged, onPointerDown, onClick, onToggleDone }: TopTaskCardProps) {
+export function TopTaskCard({
+  task,
+  events,
+  isBeingDragged,
+  elapsedSeconds,
+  pauseReason,
+  onPointerDown,
+  onClick,
+  onStart,
+  onPauseRequest,
+  onResume,
+  onComplete,
+}: TopTaskCardProps) {
   const { projectsById } = useProjects();
   const proj = getProject(projectsById, task.projectId);
   const dep = task.dependsOnEventId
     ? events.find((e) => e.id === task.dependsOnEventId)
     : null;
   const preview = bodyPreview(task.body);
+  const isActive = task.status === "active";
+  const isPaused = task.status === "paused";
 
   return (
     <div
@@ -66,6 +89,19 @@ export function TopTaskCard({ task, events, isBeingDragged, onPointerDown, onCli
                 ← {formatClock(dep.startTime)}までに
               </span>
             )}
+            {isActive && (
+              <span
+                className="rounded-[3px] bg-accent-blue/15 px-1.5 py-px font-jp text-[9px] font-semibold tabular-nums text-accent-blue"
+                aria-label="経過時間"
+              >
+                ● {formatElapsed(elapsedSeconds)}
+              </span>
+            )}
+            {isPaused && pauseReason && (
+              <span className="rounded-[3px] bg-fg-weak/15 px-1.5 py-px font-jp text-[8px] text-fg-weak">
+                中断: {pauseReasonLabel(pauseReason)}
+              </span>
+            )}
           </div>
           <div className="font-jp text-[15px] font-semibold leading-[1.4] text-fg-strong">
             {task.title}
@@ -76,28 +112,120 @@ export function TopTaskCard({ task, events, isBeingDragged, onPointerDown, onCli
             </div>
           )}
         </div>
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            onToggleDone();
-          }}
-          className="flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center rounded-lg bg-transparent"
-          style={{
-            border: `1.5px solid ${proj.color}60`,
-            color: proj.color,
-          }}
-        >
-          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-            <polyline
-              points="3,8 7,12 13,4"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-        </button>
+        <TimerControls
+          task={task}
+          color={proj.color}
+          onStart={onStart}
+          onPauseRequest={onPauseRequest}
+          onResume={onResume}
+          onComplete={onComplete}
+        />
       </div>
     </div>
+  );
+}
+
+type TimerControlsProps = {
+  task: Task;
+  color: string;
+  onStart: () => void;
+  onPauseRequest: () => void;
+  onResume: () => void;
+  onComplete: () => void;
+};
+
+function TimerControls({
+  task,
+  color,
+  onStart,
+  onPauseRequest,
+  onResume,
+  onComplete,
+}: TimerControlsProps) {
+  const stop = (fn: () => void) => (e: React.MouseEvent) => {
+    e.stopPropagation();
+    fn();
+  };
+  if (task.status === "active") {
+    return (
+      <div className="flex shrink-0 items-center gap-1.5">
+        <button
+          type="button"
+          onClick={stop(onPauseRequest)}
+          aria-label="中断"
+          className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-lg bg-transparent"
+          style={{ border: `1.5px solid ${color}40`, color: "currentColor" }}
+        >
+          <PauseIcon />
+        </button>
+        <button
+          type="button"
+          onClick={stop(onComplete)}
+          aria-label="完了"
+          className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-lg bg-transparent"
+          style={{ border: `1.5px solid ${color}60`, color }}
+        >
+          <CheckIcon />
+        </button>
+      </div>
+    );
+  }
+  if (task.status === "paused") {
+    return (
+      <button
+        type="button"
+        onClick={stop(onResume)}
+        aria-label="再開"
+        className="flex h-9 shrink-0 cursor-pointer items-center gap-1 rounded-lg bg-transparent px-2.5 font-jp text-[11px] font-semibold"
+        style={{ border: `1.5px solid ${color}60`, color }}
+      >
+        <PlayIcon />
+        再開
+      </button>
+    );
+  }
+  // idle / done は開始ボタン。done の場合は呼ばれない想定 (TaskStack 側で除外)
+  return (
+    <button
+      type="button"
+      onClick={stop(onStart)}
+      aria-label="開始"
+      className="flex h-9 shrink-0 cursor-pointer items-center gap-1 rounded-lg bg-transparent px-2.5 font-jp text-[11px] font-semibold"
+      style={{ border: `1.5px solid ${color}60`, color }}
+    >
+      <PlayIcon />
+      開始
+    </button>
+  );
+}
+
+function PlayIcon() {
+  return (
+    <svg width="10" height="12" viewBox="0 0 10 12" fill="currentColor">
+      <polygon points="1,1 9,6 1,11" />
+    </svg>
+  );
+}
+
+function PauseIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor">
+      <rect x="2" y="2" width="3" height="8" rx="1" />
+      <rect x="7" y="2" width="3" height="8" rx="1" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+      <polyline
+        points="3,8 7,12 13,4"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
   );
 }

--- a/src/features/task-stack/useTaskTimer.test.tsx
+++ b/src/features/task-stack/useTaskTimer.test.tsx
@@ -1,0 +1,317 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+// supabase / api / logger を hook より前にモックする。
+// vi.mock は hoist されるので、module-scope の const は vi.hoisted で用意する。
+const mocks = vi.hoisted(() => ({
+  startTimeEntry: vi.fn(),
+  closeTimeEntry: vi.fn(),
+  getOpenTimeEntry: vi.fn(),
+  listTimeEntries: vi.fn(),
+  updateTask: vi.fn(),
+  log: vi.fn(),
+}));
+
+vi.mock("@/entities/task/time-entries", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/entities/task/time-entries")
+  >("@/entities/task/time-entries");
+  return {
+    ...actual,
+    startTimeEntry: mocks.startTimeEntry,
+    closeTimeEntry: mocks.closeTimeEntry,
+    getOpenTimeEntry: mocks.getOpenTimeEntry,
+    listTimeEntries: mocks.listTimeEntries,
+  };
+});
+
+vi.mock("@/entities/task/api", () => ({
+  updateTask: mocks.updateTask,
+}));
+
+vi.mock("@/entities/action-log/logger", () => ({
+  ACTION_TYPES: Object.freeze({
+    TASK_STARTED: "task_started",
+    TASK_PAUSED: "task_paused",
+    TASK_RESUMED: "task_resumed",
+    TASK_COMPLETED: "task_completed",
+    TASK_REORDERED: "task_reordered",
+    TASK_DELETED: "task_deleted",
+    TASK_TITLE_CHANGED: "task_title_changed",
+    INTERRUPTION_PUSHED: "interruption_pushed",
+    INTERRUPTION_COMPLETED: "interruption_completed",
+    STACK_PROPOSED: "stack_proposed",
+    STACK_PROPOSAL_ACCEPTED: "stack_proposal_accepted",
+  }),
+  log: mocks.log,
+}));
+
+vi.mock("@/shared/supabase/client", () => ({
+  createClient: () => ({}),
+}));
+
+const {
+  startTimeEntry: startTimeEntryMock,
+  closeTimeEntry: closeTimeEntryMock,
+  getOpenTimeEntry: getOpenTimeEntryMock,
+  listTimeEntries: listTimeEntriesMock,
+  updateTask: updateTaskMock,
+  log: logMock,
+} = mocks;
+
+// hook を import (上記モックが効いた後で読み込む)
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+import type { Task } from "@/entities/task/types";
+
+import { formatElapsed, useTaskTimer } from "./useTaskTimer";
+
+const baseTask: Task = {
+  id: "t1",
+  projectId: "p1",
+  title: "タスクA",
+  body: "",
+  estimatedMinutes: 30,
+  status: "idle",
+  stackOrder: 0,
+  dependsOnEventId: null,
+  isInterruption: false,
+  parentTaskId: null,
+  createdAt: "2026-04-19T09:00:00.000Z",
+  completedAt: null,
+};
+
+function wrap() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return { client, Wrapper };
+}
+
+describe("useTaskTimer", () => {
+  beforeEach(() => {
+    startTimeEntryMock.mockReset();
+    closeTimeEntryMock.mockReset();
+    getOpenTimeEntryMock.mockReset();
+    listTimeEntriesMock.mockReset();
+    updateTaskMock.mockReset();
+    logMock.mockReset();
+    // デフォルトは何もない状態
+    startTimeEntryMock.mockResolvedValue({
+      id: "te-new",
+      taskId: "t1",
+      startedAt: "2026-04-19T10:00:00.000Z",
+      pausedAt: null,
+      pauseReason: null,
+      durationSeconds: null,
+    });
+    closeTimeEntryMock.mockImplementation(async (_sb, entry, reason) => ({
+      ...(entry as Record<string, unknown>),
+      pausedAt: "2026-04-19T10:01:00.000Z",
+      pauseReason: reason ?? null,
+      durationSeconds: 60,
+    }));
+    getOpenTimeEntryMock.mockResolvedValue(null);
+    listTimeEntriesMock.mockResolvedValue([]);
+    updateTaskMock.mockResolvedValue({});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("task=null のとき start/pause/resume/complete は no-op", async () => {
+    const { Wrapper } = wrap();
+    const { result } = renderHook(() => useTaskTimer(null), {
+      wrapper: Wrapper,
+    });
+    await act(async () => {
+      await result.current.start();
+      await result.current.pause("voluntary");
+      await result.current.resume();
+      await result.current.complete();
+    });
+    expect(startTimeEntryMock).not.toHaveBeenCalled();
+    expect(updateTaskMock).not.toHaveBeenCalled();
+    expect(logMock).not.toHaveBeenCalled();
+  });
+
+  test("start: open entry なし → 新規 entry 作成 + status=active + TASK_STARTED ログ", async () => {
+    getOpenTimeEntryMock.mockResolvedValueOnce(null);
+    const { Wrapper } = wrap();
+    const { result } = renderHook(() => useTaskTimer(baseTask), {
+      wrapper: Wrapper,
+    });
+    await act(async () => {
+      await result.current.start();
+    });
+    expect(getOpenTimeEntryMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "t1",
+    );
+    expect(closeTimeEntryMock).not.toHaveBeenCalled();
+    expect(startTimeEntryMock).toHaveBeenCalledWith(expect.anything(), "t1");
+    expect(updateTaskMock).toHaveBeenCalledWith(expect.anything(), "t1", {
+      status: "active",
+    });
+    expect(logMock).toHaveBeenCalledWith("task_started", { task_id: "t1" });
+  });
+
+  test("start: 既存 open entry を voluntary で閉じてから start (後勝ち)", async () => {
+    const existing = {
+      id: "te-old",
+      taskId: "t1",
+      startedAt: "2026-04-19T09:00:00.000Z",
+      pausedAt: null,
+      pauseReason: null,
+      durationSeconds: null,
+    };
+    getOpenTimeEntryMock.mockResolvedValueOnce(existing);
+    const { Wrapper } = wrap();
+    const { result } = renderHook(() => useTaskTimer(baseTask), {
+      wrapper: Wrapper,
+    });
+    await act(async () => {
+      await result.current.start();
+    });
+    expect(closeTimeEntryMock).toHaveBeenCalledWith(
+      expect.anything(),
+      existing,
+      "voluntary",
+    );
+    expect(startTimeEntryMock).toHaveBeenCalled();
+  });
+
+  test("pause: open entry を reason 付きで閉じ、status=paused、TASK_PAUSED ログ", async () => {
+    const open = {
+      id: "te-open",
+      taskId: "t1",
+      startedAt: "2026-04-19T10:00:00.000Z",
+      pausedAt: null,
+      pauseReason: null,
+      durationSeconds: null,
+    };
+    listTimeEntriesMock.mockResolvedValue([open]);
+    // entriesQuery が未解決でも pause 内部の fallback (getOpenTimeEntry) で拾える
+    getOpenTimeEntryMock.mockResolvedValue(open);
+    const activeTask: Task = { ...baseTask, status: "active" };
+    const { Wrapper } = wrap();
+    const { result } = renderHook(() => useTaskTimer(activeTask), {
+      wrapper: Wrapper,
+    });
+    await act(async () => {
+      await result.current.pause("meeting");
+    });
+    expect(closeTimeEntryMock).toHaveBeenCalledWith(
+      expect.anything(),
+      open,
+      "meeting",
+    );
+    expect(updateTaskMock).toHaveBeenCalledWith(expect.anything(), "t1", {
+      status: "paused",
+    });
+    expect(logMock).toHaveBeenCalledWith("task_paused", {
+      task_id: "t1",
+      pause_reason: "meeting",
+    });
+  });
+
+  test("resume: 新規 entry 作成 + status=active + TASK_RESUMED ログ", async () => {
+    const pausedTask: Task = { ...baseTask, status: "paused" };
+    const { Wrapper } = wrap();
+    const { result } = renderHook(() => useTaskTimer(pausedTask), {
+      wrapper: Wrapper,
+    });
+    await act(async () => {
+      await result.current.resume();
+    });
+    expect(startTimeEntryMock).toHaveBeenCalledWith(expect.anything(), "t1");
+    expect(updateTaskMock).toHaveBeenCalledWith(expect.anything(), "t1", {
+      status: "active",
+    });
+    expect(logMock).toHaveBeenCalledWith("task_resumed", { task_id: "t1" });
+  });
+
+  test("complete: open entry を閉じ、actual_minutes を含む TASK_COMPLETED を記録", async () => {
+    const open = {
+      id: "te-open",
+      taskId: "t1",
+      startedAt: "2026-04-19T10:00:00.000Z",
+      pausedAt: null,
+      pauseReason: null,
+      durationSeconds: null,
+    };
+    // 合計 3 分 (180 秒) の履歴を返す (最終 actual_minutes = 3)
+    listTimeEntriesMock.mockResolvedValue([
+      { ...open, pausedAt: "x", durationSeconds: 180 },
+    ]);
+    getOpenTimeEntryMock.mockResolvedValue(open);
+    const activeTask: Task = { ...baseTask, status: "active" };
+    const { Wrapper } = wrap();
+    const { result } = renderHook(() => useTaskTimer(activeTask), {
+      wrapper: Wrapper,
+    });
+    await act(async () => {
+      await result.current.complete();
+    });
+    expect(closeTimeEntryMock).toHaveBeenCalledWith(
+      expect.anything(),
+      open,
+      null,
+    );
+    expect(updateTaskMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "t1",
+      expect.objectContaining({
+        status: "done",
+        completedAt: expect.any(String),
+      }),
+    );
+    expect(logMock).toHaveBeenCalledWith("task_completed", {
+      task_id: "t1",
+      estimated_minutes: 30,
+      actual_minutes: 3,
+    });
+  });
+
+  test("リロード復元: paused タスクの最終 pause_reason を pauseReason で返す", async () => {
+    listTimeEntriesMock.mockResolvedValue([
+      {
+        id: "1",
+        taskId: "t1",
+        startedAt: "2026-04-19T10:00:00.000Z",
+        pausedAt: "2026-04-19T10:01:00.000Z",
+        pauseReason: "interruption",
+        durationSeconds: 60,
+      },
+    ]);
+    const pausedTask: Task = { ...baseTask, status: "paused" };
+    const { Wrapper } = wrap();
+    const { result } = renderHook(() => useTaskTimer(pausedTask), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => {
+      expect(result.current.pauseReason).toBe("interruption");
+    });
+    expect(result.current.isPaused).toBe(true);
+    expect(result.current.isActive).toBe(false);
+    expect(result.current.elapsedSeconds).toBe(60);
+  });
+});
+
+describe("formatElapsed", () => {
+  test("60秒未満は MM:SS", () => {
+    expect(formatElapsed(45)).toBe("00:45");
+  });
+  test("60秒以上 1時間未満も MM:SS", () => {
+    expect(formatElapsed(125)).toBe("02:05");
+  });
+  test("1時間以上は H:MM:SS", () => {
+    expect(formatElapsed(3661)).toBe("1:01:01");
+  });
+  test("負数は 00:00 にクランプ", () => {
+    expect(formatElapsed(-5)).toBe("00:00");
+  });
+});

--- a/src/features/task-stack/useTaskTimer.ts
+++ b/src/features/task-stack/useTaskTimer.ts
@@ -1,0 +1,187 @@
+"use client";
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { ACTION_TYPES, log } from "@/entities/action-log/logger";
+import { updateTask as apiUpdateTask } from "@/entities/task/api";
+import {
+  closeTimeEntry,
+  getOpenTimeEntry,
+  listTimeEntries,
+  type PauseReason,
+  startTimeEntry,
+  sumDurationSeconds,
+  type TimeEntry,
+} from "@/entities/task/time-entries";
+import type { Task } from "@/entities/task/types";
+import { createClient } from "@/shared/supabase/client";
+
+export const TASKS_QUERY_KEY = ["tasks"] as const;
+
+export function timeEntriesKey(taskId: string) {
+  return ["time-entries", taskId] as const;
+}
+
+type TaskTimerApi = {
+  isActive: boolean;
+  isPaused: boolean;
+  isRunning: boolean;
+  elapsedSeconds: number;
+  pauseReason: PauseReason | null;
+  entries: readonly TimeEntry[];
+  start: () => Promise<void>;
+  pause: (reason: PauseReason) => Promise<void>;
+  resume: () => Promise<void>;
+  complete: () => Promise<void>;
+};
+
+/**
+ * タスクのタイマー状態を管理する hook。
+ *
+ * 状態は DB (tasks.status / task_time_entries) が正とし、
+ * - リロード時: task.status と open entry の有無から復元
+ * - 複数タブで同時に start された場合: 後勝ち (既存 open entry を voluntary で閉じる)
+ *   — ADR 0004 を参照
+ *
+ * タイマーは 1 秒ごとに tick し、open entry の経過秒数と閉じた entry の
+ * duration_seconds の合計を elapsedSeconds として返す。
+ */
+export function useTaskTimer(task: Task | null): TaskTimerApi {
+  const supabase = useMemo(() => createClient(), []);
+  const queryClient = useQueryClient();
+  const taskId = task?.id ?? null;
+
+  const entriesQuery = useQuery({
+    queryKey: taskId ? timeEntriesKey(taskId) : ["time-entries", "none"],
+    queryFn: () =>
+      taskId ? listTimeEntries(supabase, taskId) : Promise.resolve([]),
+    enabled: taskId !== null,
+  });
+
+  const entries = useMemo(() => entriesQuery.data ?? [], [entriesQuery.data]);
+  const openEntry = useMemo(
+    () => entries.find((e) => e.pausedAt === null) ?? null,
+    [entries],
+  );
+
+  const isActive = task?.status === "active";
+  const isPaused = task?.status === "paused";
+  const isRunning = isActive && openEntry !== null;
+
+  // アクティブな間は 1 秒間隔で再描画する。停止中は interval を張らない。
+  const [tickMs, setTickMs] = useState<number>(() => Date.now());
+  useEffect(() => {
+    if (!isRunning) return;
+    const id = window.setInterval(() => setTickMs(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, [isRunning]);
+
+  const elapsedSeconds = useMemo(
+    () => sumDurationSeconds(entries, tickMs),
+    [entries, tickMs],
+  );
+
+  const pauseReason = useMemo<PauseReason | null>(() => {
+    if (!isPaused) return null;
+    for (let i = entries.length - 1; i >= 0; i--) {
+      const r = entries[i].pauseReason;
+      if (r) return r;
+    }
+    return null;
+  }, [entries, isPaused]);
+
+  const invalidate = useCallback(async () => {
+    if (!taskId) return;
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: TASKS_QUERY_KEY }),
+      queryClient.invalidateQueries({ queryKey: timeEntriesKey(taskId) }),
+    ]);
+  }, [queryClient, taskId]);
+
+  const start = useCallback(async () => {
+    if (!task) return;
+    // 別タブなどで残存している open entry を voluntary で閉じる (後勝ち)
+    const existingOpen = await getOpenTimeEntry(supabase, task.id);
+    if (existingOpen) {
+      await closeTimeEntry(supabase, existingOpen, "voluntary");
+    }
+    await startTimeEntry(supabase, task.id);
+    await apiUpdateTask(supabase, task.id, { status: "active" });
+    log(ACTION_TYPES.TASK_STARTED, { task_id: task.id });
+    await invalidate();
+  }, [supabase, task, invalidate]);
+
+  const pause = useCallback(
+    async (reason: PauseReason) => {
+      if (!task) return;
+      const open = openEntry ?? (await getOpenTimeEntry(supabase, task.id));
+      if (open) {
+        await closeTimeEntry(supabase, open, reason);
+      }
+      await apiUpdateTask(supabase, task.id, { status: "paused" });
+      log(ACTION_TYPES.TASK_PAUSED, {
+        task_id: task.id,
+        pause_reason: reason,
+      });
+      await invalidate();
+    },
+    [supabase, task, openEntry, invalidate],
+  );
+
+  const resume = useCallback(async () => {
+    if (!task) return;
+    await startTimeEntry(supabase, task.id);
+    await apiUpdateTask(supabase, task.id, { status: "active" });
+    log(ACTION_TYPES.TASK_RESUMED, { task_id: task.id });
+    await invalidate();
+  }, [supabase, task, invalidate]);
+
+  const complete = useCallback(async () => {
+    if (!task) return;
+    const open = openEntry ?? (await getOpenTimeEntry(supabase, task.id));
+    if (open) {
+      // 完了時の close は pause ではないので pause_reason = null
+      await closeTimeEntry(supabase, open, null);
+    }
+    // 合計実績を最新 entries から計算する (複数 entry の合計)
+    const finalEntries = await listTimeEntries(supabase, task.id);
+    const totalSeconds = sumDurationSeconds(finalEntries);
+    const actualMinutes = Math.round(totalSeconds / 60);
+    await apiUpdateTask(supabase, task.id, {
+      status: "done",
+      completedAt: new Date().toISOString(),
+    });
+    log(ACTION_TYPES.TASK_COMPLETED, {
+      task_id: task.id,
+      estimated_minutes: task.estimatedMinutes ?? undefined,
+      actual_minutes: actualMinutes,
+    });
+    await invalidate();
+  }, [supabase, task, openEntry, invalidate]);
+
+  return {
+    isActive,
+    isPaused,
+    isRunning,
+    elapsedSeconds,
+    pauseReason,
+    entries,
+    start,
+    pause,
+    resume,
+    complete,
+  };
+}
+
+/** "HH:MM:SS" または "MM:SS" に整形する。 */
+export function formatElapsed(totalSeconds: number): string {
+  const s = Math.max(0, Math.floor(totalSeconds));
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  const mm = String(m).padStart(2, "0");
+  const ss = String(sec).padStart(2, "0");
+  if (h > 0) return `${h}:${mm}:${ss}`;
+  return `${mm}:${ss}`;
+}


### PR DESCRIPTION
- `task_time_entries` API 層 (`src/entities/task/time-entries.ts`)
  open entry 取得 / close / 合計時間計算
- `useTaskTimer` hook で状態機械を管理 (idle/active/paused/done)
  リロード復元は DB 参照のみ、multi-tab は後勝ち (ADR 0004)
- `TopTaskCard` に開始/中断/完了/再開ボタンと経過時間バッジを追加
- `PauseReasonModal` で meeting / interruption / voluntary を選択
- action_log 連携: task_started / task_paused / task_resumed /
  task_completed (actual_minutes, estimated_minutes を metadata に)