### PR TITLE
fix: iPhone Safari での入力要素フォーカス時の自動ズームを抑止

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,3 +10,12 @@
   background: #27272a;
   border-radius: 2px;
 }
+
+/* iOS Safari は font-size < 16px の入力要素にフォーカスすると自動で拡大するため、iOS のみ 16px に上書きする */
+@supports (-webkit-touch-callout: none) {
+  input,
+  textarea,
+  select {
+    font-size: 16px !important;
+  }
+}


### PR DESCRIPTION
input / textarea / select の font-size が 16px 未満だと iOS Safari が
フォーカス時に自動的にページをズームしてしまうため、@supports
(-webkit-touch-callout: none) で iOS Safari を検出して入力要素のみ
16px に上書きする。PC 側の見た目は維持。

https://claude.ai/code/session_018mVRA66quaQ4S3wgmg7nqn