### PR TITLE
feat(p2-1): Google Calendar API クライアント + provider token refresh 基盤

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -13,3 +13,11 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=
 # (Phase 2 の Google Calendar 連携で再認証回避のため / phase1.md Step 2)
 SUPABASE_AUTH_GOOGLE_CLIENT_ID=
 SUPABASE_AUTH_GOOGLE_SECRET=
+
+# ===== Google Calendar API: provider token refresh (P2-1) =====
+# SUPABASE_AUTH_GOOGLE_* と同じ OAuth client の値を入れる。
+# 用途が違うため別名で保持する:
+#   SUPABASE_AUTH_GOOGLE_* -> supabase/config.toml (ローカル Supabase CLI 用)
+#   GOOGLE_OAUTH_*         -> app runtime から Google OAuth token endpoint に POST する時 (ADR 0009)
+GOOGLE_OAUTH_CLIENT_ID=
+GOOGLE_OAUTH_CLIENT_SECRET=

--- a/src/app/api/calendar/sync/route.test.ts
+++ b/src/app/api/calendar/sync/route.test.ts
@@ -1,0 +1,76 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/shared/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+import { createClient } from "@/shared/supabase/server";
+
+import { POST } from "./route";
+
+type SessionShape = {
+  provider_token?: string | null;
+  provider_refresh_token?: string | null;
+};
+
+function makeSupabase(session: SessionShape | null): SupabaseClient {
+  return {
+    auth: {
+      getSession: vi.fn(async () => ({
+        data: { session },
+        error: null,
+      })),
+    },
+  } as unknown as SupabaseClient;
+}
+
+describe("POST /api/calendar/sync", () => {
+  beforeEach(() => {
+    vi.mocked(createClient).mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("未ログイン時は 401 を返す", async () => {
+    vi.mocked(createClient).mockResolvedValue(makeSupabase(null));
+
+    const response = await POST();
+
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("unauthorized");
+  });
+
+  test("provider_token が無ければ 401 (Google 連携が必要)", async () => {
+    vi.mocked(createClient).mockResolvedValue(
+      makeSupabase({
+        provider_token: null,
+        provider_refresh_token: null,
+      }),
+    );
+
+    const response = await POST();
+
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("provider_token_missing");
+  });
+
+  test("session と provider_token が揃っていれば骨格として 200 を返す", async () => {
+    vi.mocked(createClient).mockResolvedValue(
+      makeSupabase({
+        provider_token: "access-1",
+        provider_refresh_token: "refresh-1",
+      }),
+    );
+
+    const response = await POST();
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body).toMatchObject({ synced: 0, deleted: 0 });
+  });
+});

--- a/src/app/api/calendar/sync/route.ts
+++ b/src/app/api/calendar/sync/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+
+import { ProviderTokenMissingError, getValidAccessToken } from "@/shared/google/token";
+import { createClient } from "@/shared/supabase/server";
+
+/**
+ * Google Calendar 同期エンドポイント。
+ *
+ * 本 issue (P2-1) では骨格のみ。実同期ロジックは P2-2 で埋める。
+ * 401 系の分岐は P2-3 で再ログインバナーを出す側で利用する。
+ */
+export async function POST() {
+  const supabase = await createClient();
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  try {
+    await getValidAccessToken(supabase);
+  } catch (error) {
+    if (error instanceof ProviderTokenMissingError) {
+      return NextResponse.json(
+        {
+          error: "provider_token_missing",
+          message: "Google と連携し直してください",
+        },
+        { status: 401 },
+      );
+    }
+    throw error;
+  }
+
+  // P2-2 で本実装。ここでは骨格として 0 件同期の体を返す。
+  return NextResponse.json({ synced: 0, deleted: 0 });
+}

--- a/src/shared/google/calendar.test.ts
+++ b/src/shared/google/calendar.test.ts
@@ -1,0 +1,169 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+
+import { GoogleApiUnauthorizedError, listEvents } from "./calendar";
+
+describe("listEvents", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  function mockResponse(
+    body: unknown,
+    init: { status?: number; statusText?: string } = {},
+  ) {
+    return new Response(JSON.stringify(body), {
+      status: init.status ?? 200,
+      statusText: init.statusText ?? "OK",
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  test("正常系: レスポンスをそのまま返す", async () => {
+    const payload = {
+      items: [{ id: "evt-1", summary: "meeting" }],
+      nextSyncToken: "sync-1",
+    };
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(payload));
+
+    const result = await listEvents({
+      accessToken: "token",
+      calendarId: "primary",
+      timeMin: "2026-04-01T00:00:00Z",
+      timeMax: "2026-05-01T00:00:00Z",
+      singleEvents: true,
+      orderBy: "startTime",
+    });
+
+    expect(result).toEqual(payload);
+  });
+
+  test("Bearer token を Authorization ヘッダに載せる", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      mockResponse({ items: [] }),
+    );
+
+    await listEvents({ accessToken: "the-token", calendarId: "primary" });
+
+    const [, init] = vi.mocked(globalThis.fetch).mock.calls[0]!;
+    expect(init?.headers).toEqual(
+      expect.objectContaining({ Authorization: "Bearer the-token" }),
+    );
+  });
+
+  test("calendarId を URL に含み、クエリパラメータを組み立てる", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      mockResponse({ items: [] }),
+    );
+
+    await listEvents({
+      accessToken: "token",
+      calendarId: "primary",
+      timeMin: "2026-04-01T00:00:00Z",
+      timeMax: "2026-05-01T00:00:00Z",
+      singleEvents: true,
+      orderBy: "startTime",
+      pageToken: "page-2",
+      maxResults: 250,
+    });
+
+    const [url] = vi.mocked(globalThis.fetch).mock.calls[0]!;
+    const parsed = new URL(String(url));
+    expect(parsed.pathname).toBe("/calendar/v3/calendars/primary/events");
+    expect(parsed.searchParams.get("timeMin")).toBe("2026-04-01T00:00:00Z");
+    expect(parsed.searchParams.get("timeMax")).toBe("2026-05-01T00:00:00Z");
+    expect(parsed.searchParams.get("singleEvents")).toBe("true");
+    expect(parsed.searchParams.get("orderBy")).toBe("startTime");
+    expect(parsed.searchParams.get("pageToken")).toBe("page-2");
+    expect(parsed.searchParams.get("maxResults")).toBe("250");
+  });
+
+  test("calendarId は URL エンコードされる", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      mockResponse({ items: [] }),
+    );
+
+    await listEvents({
+      accessToken: "token",
+      calendarId: "user@example.com",
+    });
+
+    const [url] = vi.mocked(globalThis.fetch).mock.calls[0]!;
+    expect(String(url)).toContain(
+      "/calendar/v3/calendars/user%40example.com/events",
+    );
+  });
+
+  test("syncToken 指定時は timeMin/timeMax を送らない (Google API 仕様)", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      mockResponse({ items: [] }),
+    );
+
+    await listEvents({
+      accessToken: "token",
+      calendarId: "primary",
+      syncToken: "sync-token-xyz",
+      timeMin: "2026-04-01T00:00:00Z",
+      timeMax: "2026-05-01T00:00:00Z",
+    });
+
+    const [url] = vi.mocked(globalThis.fetch).mock.calls[0]!;
+    const parsed = new URL(String(url));
+    expect(parsed.searchParams.get("syncToken")).toBe("sync-token-xyz");
+    expect(parsed.searchParams.has("timeMin")).toBe(false);
+    expect(parsed.searchParams.has("timeMax")).toBe(false);
+  });
+
+  test("401 で GoogleApiUnauthorizedError を投げる", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      mockResponse({ error: "unauthorized" }, { status: 401 }),
+    );
+
+    await expect(
+      listEvents({ accessToken: "expired", calendarId: "primary" }),
+    ).rejects.toBeInstanceOf(GoogleApiUnauthorizedError);
+  });
+
+  test("410 Gone で status 付きの GoogleApiError を投げる (syncToken 失効検知用)", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      mockResponse({ error: "gone" }, { status: 410 }),
+    );
+
+    await expect(
+      listEvents({
+        accessToken: "token",
+        calendarId: "primary",
+        syncToken: "stale",
+      }),
+    ).rejects.toMatchObject({
+      name: "GoogleApiError",
+      status: 410,
+    });
+  });
+
+  test("その他 5xx でも GoogleApiError を投げる", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      mockResponse({ error: "server" }, { status: 500 }),
+    );
+
+    await expect(
+      listEvents({ accessToken: "token", calendarId: "primary" }),
+    ).rejects.toMatchObject({
+      name: "GoogleApiError",
+      status: 500,
+    });
+  });
+});

--- a/src/shared/google/calendar.ts
+++ b/src/shared/google/calendar.ts
@@ -1,0 +1,120 @@
+/**
+ * Google Calendar API v3 `events.list` の薄いラッパー。
+ *
+ * 加工は呼び出し側に任せる。401 検出時は GoogleApiUnauthorizedError を投げるので、
+ * 呼び出し側は refreshAccessToken → 1 回 retry する (ADR 0009)。
+ */
+
+const CALENDAR_API_BASE = "https://www.googleapis.com/calendar/v3";
+
+export type GoogleCalendarEvent = {
+  id: string;
+  status?: "confirmed" | "tentative" | "cancelled";
+  summary?: string;
+  description?: string;
+  start?: { dateTime?: string; date?: string; timeZone?: string };
+  end?: { dateTime?: string; date?: string; timeZone?: string };
+  hangoutLink?: string;
+  conferenceData?: {
+    entryPoints?: Array<{ entryPointType?: string; uri?: string }>;
+  };
+  attachments?: Array<unknown>;
+};
+
+export type GoogleCalendarEventsListResponse = {
+  items?: GoogleCalendarEvent[];
+  nextPageToken?: string;
+  nextSyncToken?: string;
+};
+
+export type ListEventsParams = {
+  accessToken: string;
+  calendarId: string;
+  /** syncToken と併用不可 (併用時は syncToken が優先され、timeMin/Max は送信しない) */
+  timeMin?: string;
+  timeMax?: string;
+  syncToken?: string;
+  pageToken?: string;
+  singleEvents?: boolean;
+  orderBy?: "startTime" | "updated";
+  maxResults?: number;
+};
+
+export class GoogleApiUnauthorizedError extends Error {
+  readonly name = "GoogleApiUnauthorizedError";
+  constructor(message = "Google API returned 401") {
+    super(message);
+  }
+}
+
+export class GoogleApiError extends Error {
+  readonly name = "GoogleApiError";
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly body: unknown,
+  ) {
+    super(message);
+  }
+}
+
+export async function listEvents(
+  params: ListEventsParams,
+): Promise<GoogleCalendarEventsListResponse> {
+  const url = buildListEventsUrl(params);
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${params.accessToken}`,
+      Accept: "application/json",
+    },
+  });
+
+  if (response.status === 401) {
+    throw new GoogleApiUnauthorizedError();
+  }
+
+  if (!response.ok) {
+    const body = await safeJson(response);
+    throw new GoogleApiError(
+      `Google API error: ${response.status} ${response.statusText}`,
+      response.status,
+      body,
+    );
+  }
+
+  return (await response.json()) as GoogleCalendarEventsListResponse;
+}
+
+function buildListEventsUrl(params: ListEventsParams): string {
+  const url = new URL(
+    `${CALENDAR_API_BASE}/calendars/${encodeURIComponent(params.calendarId)}/events`,
+  );
+
+  // syncToken 指定時は timeMin/timeMax を付けない (Google API の制約)
+  if (params.syncToken) {
+    url.searchParams.set("syncToken", params.syncToken);
+  } else {
+    if (params.timeMin) url.searchParams.set("timeMin", params.timeMin);
+    if (params.timeMax) url.searchParams.set("timeMax", params.timeMax);
+  }
+  if (params.singleEvents !== undefined) {
+    url.searchParams.set("singleEvents", String(params.singleEvents));
+  }
+  if (params.orderBy) url.searchParams.set("orderBy", params.orderBy);
+  if (params.pageToken) url.searchParams.set("pageToken", params.pageToken);
+  if (params.maxResults !== undefined) {
+    url.searchParams.set("maxResults", String(params.maxResults));
+  }
+
+  return url.toString();
+}
+
+async function safeJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return undefined;
+  }
+}

--- a/src/shared/google/env.test.ts
+++ b/src/shared/google/env.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { getGoogleOAuthEnv } from "./env";
+
+describe("getGoogleOAuthEnv", () => {
+  const original = {
+    clientId: process.env.GOOGLE_OAUTH_CLIENT_ID,
+    clientSecret: process.env.GOOGLE_OAUTH_CLIENT_SECRET,
+  };
+
+  beforeEach(() => {
+    delete process.env.GOOGLE_OAUTH_CLIENT_ID;
+    delete process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+  });
+
+  afterEach(() => {
+    if (original.clientId === undefined) {
+      delete process.env.GOOGLE_OAUTH_CLIENT_ID;
+    } else {
+      process.env.GOOGLE_OAUTH_CLIENT_ID = original.clientId;
+    }
+    if (original.clientSecret === undefined) {
+      delete process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+    } else {
+      process.env.GOOGLE_OAUTH_CLIENT_SECRET = original.clientSecret;
+    }
+  });
+
+  test("両方揃っていれば値を返す", () => {
+    process.env.GOOGLE_OAUTH_CLIENT_ID = "id-123";
+    process.env.GOOGLE_OAUTH_CLIENT_SECRET = "secret-xyz";
+
+    expect(getGoogleOAuthEnv()).toEqual({
+      clientId: "id-123",
+      clientSecret: "secret-xyz",
+    });
+  });
+
+  test("GOOGLE_OAUTH_CLIENT_ID が無ければ throw", () => {
+    process.env.GOOGLE_OAUTH_CLIENT_SECRET = "secret-xyz";
+    expect(() => getGoogleOAuthEnv()).toThrow(/GOOGLE_OAUTH_CLIENT_ID/);
+  });
+
+  test("GOOGLE_OAUTH_CLIENT_SECRET が無ければ throw", () => {
+    process.env.GOOGLE_OAUTH_CLIENT_ID = "id-123";
+    expect(() => getGoogleOAuthEnv()).toThrow(/GOOGLE_OAUTH_CLIENT_SECRET/);
+  });
+});

--- a/src/shared/google/env.ts
+++ b/src/shared/google/env.ts
@@ -1,0 +1,28 @@
+/**
+ * Google OAuth の client_id / client_secret を読み取る。
+ *
+ * provider_token の refresh で Google OAuth token endpoint を直接叩くために必要
+ * (ADR 0009)。同じ OAuth client の値だが supabase/config.toml 用の
+ * SUPABASE_AUTH_GOOGLE_* とは別名で扱う (あちらは Supabase CLI 用で runtime では未使用)。
+ */
+function required(name: string, value: string | undefined): string {
+  if (!value) {
+    throw new Error(
+      `[kozutsumi] Missing env: ${name}. See .env.local.example`,
+    );
+  }
+  return value;
+}
+
+export function getGoogleOAuthEnv() {
+  return {
+    clientId: required(
+      "GOOGLE_OAUTH_CLIENT_ID",
+      process.env.GOOGLE_OAUTH_CLIENT_ID,
+    ),
+    clientSecret: required(
+      "GOOGLE_OAUTH_CLIENT_SECRET",
+      process.env.GOOGLE_OAUTH_CLIENT_SECRET,
+    ),
+  };
+}

--- a/src/shared/google/token.test.ts
+++ b/src/shared/google/token.test.ts
@@ -1,0 +1,195 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+
+import {
+  getValidAccessToken,
+  ProviderTokenMissingError,
+  RefreshTokenExpiredError,
+  refreshAccessToken,
+} from "./token";
+
+type SessionShape = {
+  provider_token?: string | null;
+  provider_refresh_token?: string | null;
+};
+
+function makeSupabase(session: SessionShape | null): SupabaseClient {
+  return {
+    auth: {
+      getSession: vi.fn(async () => ({
+        data: { session },
+        error: null,
+      })),
+    },
+  } as unknown as SupabaseClient;
+}
+
+const original = {
+  clientId: process.env.GOOGLE_OAUTH_CLIENT_ID,
+  clientSecret: process.env.GOOGLE_OAUTH_CLIENT_SECRET,
+  fetch: globalThis.fetch,
+};
+
+beforeEach(() => {
+  process.env.GOOGLE_OAUTH_CLIENT_ID = "test-client-id";
+  process.env.GOOGLE_OAUTH_CLIENT_SECRET = "test-client-secret";
+  globalThis.fetch = vi.fn();
+});
+
+afterEach(() => {
+  if (original.clientId === undefined) {
+    delete process.env.GOOGLE_OAUTH_CLIENT_ID;
+  } else {
+    process.env.GOOGLE_OAUTH_CLIENT_ID = original.clientId;
+  }
+  if (original.clientSecret === undefined) {
+    delete process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+  } else {
+    process.env.GOOGLE_OAUTH_CLIENT_SECRET = original.clientSecret;
+  }
+  globalThis.fetch = original.fetch;
+  vi.restoreAllMocks();
+});
+
+describe("getValidAccessToken", () => {
+  test("session に provider_token と refresh_token があれば返す", async () => {
+    const supabase = makeSupabase({
+      provider_token: "access-1",
+      provider_refresh_token: "refresh-1",
+    });
+
+    await expect(getValidAccessToken(supabase)).resolves.toEqual({
+      accessToken: "access-1",
+      refreshToken: "refresh-1",
+    });
+  });
+
+  test("session が無ければ ProviderTokenMissingError", async () => {
+    const supabase = makeSupabase(null);
+    await expect(getValidAccessToken(supabase)).rejects.toBeInstanceOf(
+      ProviderTokenMissingError,
+    );
+  });
+
+  test("provider_token が無ければ ProviderTokenMissingError", async () => {
+    const supabase = makeSupabase({
+      provider_token: null,
+      provider_refresh_token: "refresh-1",
+    });
+    await expect(getValidAccessToken(supabase)).rejects.toBeInstanceOf(
+      ProviderTokenMissingError,
+    );
+  });
+
+  test("provider_refresh_token が無ければ ProviderTokenMissingError", async () => {
+    const supabase = makeSupabase({
+      provider_token: "access-1",
+      provider_refresh_token: null,
+    });
+    await expect(getValidAccessToken(supabase)).rejects.toBeInstanceOf(
+      ProviderTokenMissingError,
+    );
+  });
+});
+
+describe("refreshAccessToken", () => {
+  test("Google OAuth token endpoint に refresh_token で POST し、新 access_token を返す", async () => {
+    const supabase = makeSupabase({
+      provider_token: "old-access",
+      provider_refresh_token: "refresh-1",
+    });
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          access_token: "new-access",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const result = await refreshAccessToken(supabase);
+
+    expect(result).toEqual({
+      accessToken: "new-access",
+      refreshToken: "refresh-1",
+    });
+
+    const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0]!;
+    expect(String(url)).toBe("https://oauth2.googleapis.com/token");
+    expect(init?.method).toBe("POST");
+    const body = new URLSearchParams(String(init?.body));
+    expect(body.get("grant_type")).toBe("refresh_token");
+    expect(body.get("refresh_token")).toBe("refresh-1");
+    expect(body.get("client_id")).toBe("test-client-id");
+    expect(body.get("client_secret")).toBe("test-client-secret");
+  });
+
+  test("Google がローテーションで新 refresh_token を返したら置き換える", async () => {
+    const supabase = makeSupabase({
+      provider_token: "old-access",
+      provider_refresh_token: "refresh-1",
+    });
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          access_token: "new-access",
+          refresh_token: "refresh-2",
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const result = await refreshAccessToken(supabase);
+    expect(result).toEqual({
+      accessToken: "new-access",
+      refreshToken: "refresh-2",
+    });
+  });
+
+  test("refresh が 400 (invalid_grant) で RefreshTokenExpiredError", async () => {
+    const supabase = makeSupabase({
+      provider_token: "old-access",
+      provider_refresh_token: "refresh-1",
+    });
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ error: "invalid_grant" }),
+        { status: 400 },
+      ),
+    );
+
+    await expect(refreshAccessToken(supabase)).rejects.toBeInstanceOf(
+      RefreshTokenExpiredError,
+    );
+  });
+
+  test("session が無ければ ProviderTokenMissingError で Google を叩かない", async () => {
+    const supabase = makeSupabase(null);
+
+    await expect(refreshAccessToken(supabase)).rejects.toBeInstanceOf(
+      ProviderTokenMissingError,
+    );
+    expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled();
+  });
+
+  test("provider_refresh_token が無ければ ProviderTokenMissingError で Google を叩かない", async () => {
+    const supabase = makeSupabase({
+      provider_token: "old-access",
+      provider_refresh_token: null,
+    });
+
+    await expect(refreshAccessToken(supabase)).rejects.toBeInstanceOf(
+      ProviderTokenMissingError,
+    );
+    expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/google/token.ts
+++ b/src/shared/google/token.ts
@@ -1,0 +1,95 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { getGoogleOAuthEnv } from "./env";
+
+/**
+ * Google provider token の取得と refresh。
+ *
+ * Supabase Auth の session に格納された Google OAuth token を扱う。
+ * 401 を受けた呼び出し側が refreshAccessToken で新しい access_token を得て 1 回 retry する (ADR 0009)。
+ *
+ * 新しい access_token は in-memory で使う想定。Supabase session への書き戻しは
+ * 現時点では見送り、次回同期で再度 refresh する。
+ */
+
+const GOOGLE_OAUTH_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+
+export type GoogleProviderAccess = {
+  accessToken: string;
+  refreshToken: string;
+};
+
+export class ProviderTokenMissingError extends Error {
+  readonly name = "ProviderTokenMissingError";
+}
+
+export class RefreshTokenExpiredError extends Error {
+  readonly name = "RefreshTokenExpiredError";
+}
+
+export async function getValidAccessToken(
+  supabase: SupabaseClient,
+): Promise<GoogleProviderAccess> {
+  const { accessToken, refreshToken } = await readProviderTokens(supabase);
+  if (!accessToken) {
+    throw new ProviderTokenMissingError(
+      "No Google provider_token in Supabase session",
+    );
+  }
+  return { accessToken, refreshToken };
+}
+
+export async function refreshAccessToken(
+  supabase: SupabaseClient,
+): Promise<GoogleProviderAccess> {
+  const { refreshToken } = await readProviderTokens(supabase);
+  const { clientId, clientSecret } = getGoogleOAuthEnv();
+
+  const response = await fetch(GOOGLE_OAUTH_TOKEN_ENDPOINT, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      client_id: clientId,
+      client_secret: clientSecret,
+    }).toString(),
+  });
+
+  if (!response.ok) {
+    // 400 invalid_grant 等は refresh_token 自体が expired / revoked。
+    // 呼び出し側は再ログインバナー (P2-3) に誘導する。
+    throw new RefreshTokenExpiredError(
+      `Google OAuth refresh failed: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const json = (await response.json()) as {
+    access_token: string;
+    refresh_token?: string;
+  };
+
+  return {
+    accessToken: json.access_token,
+    refreshToken: json.refresh_token ?? refreshToken,
+  };
+}
+
+async function readProviderTokens(
+  supabase: SupabaseClient,
+): Promise<{ accessToken: string | null; refreshToken: string }> {
+  const { data, error } = await supabase.auth.getSession();
+  if (error || !data.session) {
+    throw new ProviderTokenMissingError("No Supabase session");
+  }
+  const refreshToken = data.session.provider_refresh_token;
+  if (!refreshToken) {
+    throw new ProviderTokenMissingError(
+      "No Google provider_refresh_token in Supabase session",
+    );
+  }
+  return {
+    accessToken: data.session.provider_token ?? null,
+    refreshToken,
+  };
+}


### PR DESCRIPTION
## 概要

Phase 2 の同期ロジック（P2-2）が乗るための基盤を 3 レイヤーで整備。

- `src/shared/google/` に env util / `events.list` ラッパー / provider token refresh util
- `/api/calendar/sync` の Route Handler 骨格（未ログイン・provider_token 無しは 401 を区別して返す）

実同期ロジック (events.list + upsert) は空のまま。P2-2 で埋める。

<details>
<summary>関連 ADR</summary>

- [ADR 0005](docs/adr/0005-google-calendar-sync-via-route-handler.md) 同期は Route Handler で実行
- [ADR 0009](docs/adr/0009-google-provider-token-self-managed-refresh.md) provider token refresh は自前実装
- [ADR 0002](docs/adr/0002-oauth-calendar-scope-preauth.md) calendar.readonly scope は Phase 1 で先行付与済み

</details>

<details>
<summary>env の扱い</summary>

既存の `SUPABASE_AUTH_GOOGLE_CLIENT_ID` / `SUPABASE_AUTH_GOOGLE_SECRET` は `supabase/config.toml` 経由の Supabase CLI 専用で、app runtime では未参照。
本 PR では runtime 用に `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET` を別名で追加し、`.env.local.example` に注釈を付けた（値は同じ OAuth client）。

</details>

## 検証

- [x] \`npm test\` → 20 files / 139 tests passed
- [x] \`npm run lint\` → no errors
- [x] \`npm run typecheck\` → no errors

Closes #49