### PR TITLE
feat(p2-2): Google Calendar full sync + events upsert (#50)

### DIFF
--- a/src/app/api/calendar/sync/route.test.ts
+++ b/src/app/api/calendar/sync/route.test.ts
@@ -5,6 +5,15 @@ vi.mock("@/shared/supabase/server", () => ({
   createClient: vi.fn(),
 }));
 
+vi.mock("@/entities/event/sync", () => ({
+  syncGoogleCalendar: vi.fn(),
+}));
+
+import { syncGoogleCalendar } from "@/entities/event/sync";
+import {
+  ProviderTokenMissingError,
+  RefreshTokenExpiredError,
+} from "@/shared/google/token";
 import { createClient } from "@/shared/supabase/server";
 
 import { POST } from "./route";
@@ -28,6 +37,7 @@ function makeSupabase(session: SessionShape | null): SupabaseClient {
 describe("POST /api/calendar/sync", () => {
   beforeEach(() => {
     vi.mocked(createClient).mockReset();
+    vi.mocked(syncGoogleCalendar).mockReset();
   });
 
   afterEach(() => {
@@ -42,14 +52,15 @@ describe("POST /api/calendar/sync", () => {
     expect(response.status).toBe(401);
     const body = (await response.json()) as { error: string };
     expect(body.error).toBe("unauthorized");
+    expect(syncGoogleCalendar).not.toHaveBeenCalled();
   });
 
-  test("provider_token が無ければ 401 (Google 連携が必要)", async () => {
+  test("ProviderTokenMissingError → 401 provider_token_missing (再ログイン誘導)", async () => {
     vi.mocked(createClient).mockResolvedValue(
-      makeSupabase({
-        provider_token: null,
-        provider_refresh_token: null,
-      }),
+      makeSupabase({ provider_token: null, provider_refresh_token: null }),
+    );
+    vi.mocked(syncGoogleCalendar).mockRejectedValue(
+      new ProviderTokenMissingError("no token"),
     );
 
     const response = await POST();
@@ -59,18 +70,64 @@ describe("POST /api/calendar/sync", () => {
     expect(body.error).toBe("provider_token_missing");
   });
 
-  test("session と provider_token が揃っていれば骨格として 200 を返す", async () => {
+  test("RefreshTokenExpiredError → 401 provider_token_missing (再ログイン誘導)", async () => {
+    vi.mocked(createClient).mockResolvedValue(
+      makeSupabase({
+        provider_token: "access-1",
+        provider_refresh_token: "expired",
+      }),
+    );
+    vi.mocked(syncGoogleCalendar).mockRejectedValue(
+      new RefreshTokenExpiredError("refresh failed"),
+    );
+
+    const response = await POST();
+
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("provider_token_missing");
+  });
+
+  test("正常系: syncGoogleCalendar の結果 {synced, deleted, lastSyncedAt} を 200 で返す", async () => {
     vi.mocked(createClient).mockResolvedValue(
       makeSupabase({
         provider_token: "access-1",
         provider_refresh_token: "refresh-1",
       }),
     );
+    vi.mocked(syncGoogleCalendar).mockResolvedValue({
+      synced: 5,
+      deleted: 1,
+      lastSyncedAt: "2026-04-24T00:00:00.000Z",
+    });
 
     const response = await POST();
 
     expect(response.status).toBe(200);
     const body = (await response.json()) as Record<string, unknown>;
-    expect(body).toMatchObject({ synced: 0, deleted: 0 });
+    expect(body).toEqual({
+      synced: 5,
+      deleted: 1,
+      lastSyncedAt: "2026-04-24T00:00:00.000Z",
+    });
+    expect(syncGoogleCalendar).toHaveBeenCalledTimes(1);
+  });
+
+  test("その他の例外は 500 を返す", async () => {
+    vi.mocked(createClient).mockResolvedValue(
+      makeSupabase({
+        provider_token: "access-1",
+        provider_refresh_token: "refresh-1",
+      }),
+    );
+    vi.mocked(syncGoogleCalendar).mockRejectedValue(
+      new Error("unexpected failure"),
+    );
+
+    const response = await POST();
+
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("sync_failed");
   });
 });

--- a/src/app/api/calendar/sync/route.ts
+++ b/src/app/api/calendar/sync/route.ts
@@ -1,13 +1,19 @@
 import { NextResponse } from "next/server";
 
-import { ProviderTokenMissingError, getValidAccessToken } from "@/shared/google/token";
+import { syncGoogleCalendar } from "@/entities/event/sync";
+import {
+  ProviderTokenMissingError,
+  RefreshTokenExpiredError,
+} from "@/shared/google/token";
 import { createClient } from "@/shared/supabase/server";
 
 /**
- * Google Calendar 同期エンドポイント。
+ * Google Calendar 同期エンドポイント (ADR 0005)。
  *
- * 本 issue (P2-1) では骨格のみ。実同期ロジックは P2-2 で埋める。
- * 401 系の分岐は P2-3 で再ログインバナーを出す側で利用する。
+ * 認証層:
+ * - Supabase session 無し → 401 unauthorized
+ * - provider_token / refresh_token が無い or 失効 → 401 provider_token_missing
+ *   (UI 側でバナーを出し、再ログイン (= calendar.readonly scope 再付与) に誘導する。P2-3)
  */
 export async function POST() {
   const supabase = await createClient();
@@ -20,9 +26,13 @@ export async function POST() {
   }
 
   try {
-    await getValidAccessToken(supabase);
+    const result = await syncGoogleCalendar(supabase);
+    return NextResponse.json(result);
   } catch (error) {
-    if (error instanceof ProviderTokenMissingError) {
+    if (
+      error instanceof ProviderTokenMissingError ||
+      error instanceof RefreshTokenExpiredError
+    ) {
       return NextResponse.json(
         {
           error: "provider_token_missing",
@@ -31,9 +41,10 @@ export async function POST() {
         { status: 401 },
       );
     }
-    throw error;
+    console.error("[calendar-sync] unexpected error", error);
+    return NextResponse.json(
+      { error: "sync_failed", message: "同期中にエラーが発生しました" },
+      { status: 500 },
+    );
   }
-
-  // P2-2 で本実装。ここでは骨格として 0 件同期の体を返す。
-  return NextResponse.json({ synced: 0, deleted: 0 });
 }

--- a/src/entities/event/gateway.ts
+++ b/src/entities/event/gateway.ts
@@ -22,10 +22,36 @@ export type UpdateEventInput = {
   description?: string;
 };
 
+/**
+ * Google Calendar から取り込む 1 イベント分の入力。
+ * `project_id` は kozutsumi 側で設定する拡張 (ADR 0010) なので、upsert payload には含めず既存値を保持する。
+ */
+export type UpsertGoogleCalendarEventInput = {
+  externalId: string;
+  title: string;
+  startTime: string;
+  endTime: string;
+  meetUrl: string | null;
+  hasAttachments: boolean;
+  description: string;
+};
+
 export interface EventGateway {
   list(): Promise<Event[]>;
   create(input: CreateEventInput): Promise<Event>;
   update(id: string, patch: UpdateEventInput): Promise<Event>;
   delete(id: string): Promise<void>;
   deleteAllForCurrentUser(): Promise<void>;
+  /**
+   * `(source='google_calendar', external_id)` 単位で upsert。既存行の `project_id` は保持する。
+   * @returns upsert された行数
+   */
+  upsertFromGoogleCalendar(
+    inputs: UpsertGoogleCalendarEventInput[],
+  ): Promise<number>;
+  /**
+   * Google 側で `status='cancelled'` になったイベントをローカルから削除する。
+   * @returns 削除された行数
+   */
+  deleteByGoogleExternalIds(externalIds: string[]): Promise<number>;
 }

--- a/src/entities/event/supabase-gateway.ts
+++ b/src/entities/event/supabase-gateway.ts
@@ -11,8 +11,9 @@ import type {
   CreateEventInput,
   EventGateway,
   UpdateEventInput,
+  UpsertGoogleCalendarEventInput,
 } from "./gateway";
-import type { Event } from "./types";
+import { EVENT_SOURCE, type Event } from "./types";
 
 type Sb = SupabaseClient<Database>;
 
@@ -63,7 +64,7 @@ export class SupabaseEventGateway implements EventGateway {
       meet_url: input.meetUrl ?? null,
       has_attachments: input.hasAttachments ?? false,
       description: input.description ?? "",
-      source: input.source ?? "manual",
+      source: input.source ?? EVENT_SOURCE.MANUAL,
       external_id: input.externalId ?? null,
     };
     const { data, error } = await this.supabase
@@ -107,5 +108,45 @@ export class SupabaseEventGateway implements EventGateway {
       .delete()
       .eq("user_id", uid);
     if (error) throw error;
+  }
+
+  async upsertFromGoogleCalendar(
+    inputs: UpsertGoogleCalendarEventInput[],
+  ): Promise<number> {
+    if (inputs.length === 0) return 0;
+    const user_id = await getUserId(this.supabase);
+    // project_id を payload に含めないことで、ON CONFLICT DO UPDATE SET ... から除外され、
+    // 既存行の project_id は保持される (kozutsumi 側の拡張、ADR 0010)
+    const payloads: TablesInsert<"events">[] = inputs.map((input) => ({
+      user_id,
+      title: input.title,
+      start_time: input.startTime,
+      end_time: input.endTime,
+      meet_url: input.meetUrl,
+      has_attachments: input.hasAttachments,
+      description: input.description,
+      source: EVENT_SOURCE.GOOGLE_CALENDAR,
+      external_id: input.externalId,
+    }));
+    const { error } = await this.supabase
+      .from("events")
+      .upsert(payloads, { onConflict: "source,external_id" });
+    if (error) throw error;
+    // upsert は全 input に対して insert または update を実行するため、affected = inputs.length
+    return inputs.length;
+  }
+
+  async deleteByGoogleExternalIds(externalIds: string[]): Promise<number> {
+    if (externalIds.length === 0) return 0;
+    const uid = await getUserId(this.supabase);
+    // count のみ欲しいので head: true で row を返させない
+    const { error, count } = await this.supabase
+      .from("events")
+      .delete({ count: "exact" })
+      .eq("user_id", uid)
+      .eq("source", EVENT_SOURCE.GOOGLE_CALENDAR)
+      .in("external_id", externalIds);
+    if (error) throw error;
+    return count ?? 0;
   }
 }

--- a/src/entities/event/sync.test.ts
+++ b/src/entities/event/sync.test.ts
@@ -1,0 +1,419 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  GoogleApiUnauthorizedError,
+  type GoogleCalendarEvent,
+  type GoogleCalendarEventsListResponse,
+  type ListEventsParams,
+} from "@/shared/google/calendar";
+import { RefreshTokenExpiredError } from "@/shared/google/token";
+import type { Database } from "@/shared/types/database";
+
+import type {
+  EventGateway,
+  UpsertGoogleCalendarEventInput,
+} from "./gateway";
+import {
+  extractMeetUrl,
+  mapGoogleEventToUpsertInput,
+  partitionEvents,
+  resolveEventTimes,
+  syncGoogleCalendar,
+} from "./sync";
+
+// =====================================================================
+// 純粋関数のテスト
+// =====================================================================
+
+describe("resolveEventTimes", () => {
+  test("dateTime が両端にあれば ISO 文字列に正規化する", () => {
+    const result = resolveEventTimes({
+      id: "e1",
+      start: { dateTime: "2026-04-23T10:00:00+09:00" },
+      end: { dateTime: "2026-04-23T11:00:00+09:00" },
+    });
+
+    expect(result).toEqual({
+      start: "2026-04-23T01:00:00.000Z",
+      end: "2026-04-23T02:00:00.000Z",
+    });
+  });
+
+  test("終日イベントは JST の 00:00 として UTC に変換する", () => {
+    const result = resolveEventTimes({
+      id: "e2",
+      start: { date: "2026-04-23" },
+      end: { date: "2026-04-24" },
+    });
+
+    // 2026-04-23 JST 00:00 = 2026-04-22 15:00 UTC、exclusive end は 2026-04-24 JST 00:00
+    expect(result).toEqual({
+      start: "2026-04-22T15:00:00.000Z",
+      end: "2026-04-23T15:00:00.000Z",
+    });
+  });
+
+  test("start/end が欠けている不正イベントは null を返す", () => {
+    expect(resolveEventTimes({ id: "e3", start: {}, end: {} })).toBeNull();
+  });
+});
+
+describe("extractMeetUrl", () => {
+  test("hangoutLink があればそれを使う", () => {
+    expect(
+      extractMeetUrl({
+        id: "e1",
+        hangoutLink: "https://meet.google.com/abc-defg-hij",
+        conferenceData: {
+          entryPoints: [
+            { entryPointType: "video", uri: "https://other.example/video" },
+          ],
+        },
+      }),
+    ).toBe("https://meet.google.com/abc-defg-hij");
+  });
+
+  test("hangoutLink が無ければ conferenceData の video entryPoint を使う", () => {
+    expect(
+      extractMeetUrl({
+        id: "e1",
+        conferenceData: {
+          entryPoints: [
+            { entryPointType: "phone", uri: "tel:+81-3-1234-5678" },
+            { entryPointType: "video", uri: "https://zoom.example/j/123" },
+          ],
+        },
+      }),
+    ).toBe("https://zoom.example/j/123");
+  });
+
+  test("候補がなければ null を返す", () => {
+    expect(extractMeetUrl({ id: "e1" })).toBeNull();
+  });
+});
+
+describe("mapGoogleEventToUpsertInput", () => {
+  test("必要フィールドをすべてマップする", () => {
+    const result = mapGoogleEventToUpsertInput({
+      id: "evt-1",
+      summary: "1on1",
+      description: "議題: 進捗",
+      start: { dateTime: "2026-04-23T10:00:00+09:00" },
+      end: { dateTime: "2026-04-23T11:00:00+09:00" },
+      hangoutLink: "https://meet.google.com/xyz",
+      attachments: [{ fileUrl: "https://drive.example/abc" }],
+    });
+
+    expect(result).toEqual<UpsertGoogleCalendarEventInput>({
+      externalId: "evt-1",
+      title: "1on1",
+      startTime: "2026-04-23T01:00:00.000Z",
+      endTime: "2026-04-23T02:00:00.000Z",
+      meetUrl: "https://meet.google.com/xyz",
+      hasAttachments: true,
+      description: "議題: 進捗",
+    });
+  });
+
+  test("summary が無い場合はデフォルトタイトル、description / meet_url が無ければ空 / null", () => {
+    const result = mapGoogleEventToUpsertInput({
+      id: "evt-2",
+      start: { dateTime: "2026-04-23T10:00:00Z" },
+      end: { dateTime: "2026-04-23T11:00:00Z" },
+    });
+
+    expect(result).toEqual<UpsertGoogleCalendarEventInput>({
+      externalId: "evt-2",
+      title: "(タイトルなし)",
+      startTime: "2026-04-23T10:00:00.000Z",
+      endTime: "2026-04-23T11:00:00.000Z",
+      meetUrl: null,
+      hasAttachments: false,
+      description: "",
+    });
+  });
+
+  test("時刻が無い壊れたイベントは null を返す", () => {
+    expect(
+      mapGoogleEventToUpsertInput({ id: "bad", start: {}, end: {} }),
+    ).toBeNull();
+  });
+});
+
+describe("partitionEvents", () => {
+  test("cancelled は external_id 配列、それ以外は upsert 入力にまとめる", () => {
+    const events: GoogleCalendarEvent[] = [
+      {
+        id: "active-1",
+        summary: "meeting",
+        start: { dateTime: "2026-04-23T10:00:00Z" },
+        end: { dateTime: "2026-04-23T11:00:00Z" },
+      },
+      { id: "deleted-1", status: "cancelled" },
+      {
+        id: "active-2",
+        summary: "lunch",
+        start: { dateTime: "2026-04-23T12:00:00Z" },
+        end: { dateTime: "2026-04-23T13:00:00Z" },
+      },
+      { id: "deleted-2", status: "cancelled" },
+      // 壊れたイベントは無視する
+      { id: "broken", start: {}, end: {} },
+    ];
+
+    const result = partitionEvents(events);
+
+    expect(result.cancelled).toEqual(["deleted-1", "deleted-2"]);
+    expect(result.upserts.map((u) => u.externalId)).toEqual([
+      "active-1",
+      "active-2",
+    ]);
+  });
+});
+
+// =====================================================================
+// syncGoogleCalendar orchestration
+// =====================================================================
+
+type ListEventsFn = (
+  params: ListEventsParams,
+) => Promise<GoogleCalendarEventsListResponse>;
+
+function makeFakeGateway() {
+  const upsertCalls: UpsertGoogleCalendarEventInput[][] = [];
+  const deleteCalls: string[][] = [];
+  const gateway: EventGateway = {
+    list: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    deleteAllForCurrentUser: vi.fn(),
+    upsertFromGoogleCalendar: vi.fn(async (inputs) => {
+      upsertCalls.push(inputs);
+      return inputs.length;
+    }),
+    deleteByGoogleExternalIds: vi.fn(async (ids) => {
+      deleteCalls.push(ids);
+      return ids.length;
+    }),
+  };
+  return { gateway, upsertCalls, deleteCalls };
+}
+
+function makeActiveEvent(id: string): GoogleCalendarEvent {
+  return {
+    id,
+    summary: `event-${id}`,
+    start: { dateTime: "2026-04-23T10:00:00Z" },
+    end: { dateTime: "2026-04-23T11:00:00Z" },
+  };
+}
+
+const FAKE_SUPABASE = {} as SupabaseClient<Database>;
+const DEFAULT_NOW = () => new Date("2026-04-23T00:00:00.000Z");
+
+/** テスト共通の DI overrides。`listEvents` / `refreshAccessToken` はテスト側で差し替える */
+function makeDeps(overrides: {
+  gateway: EventGateway;
+  listEvents: ListEventsFn;
+  refreshAccessToken?: () => Promise<{
+    accessToken: string;
+    refreshToken: string;
+  }>;
+  now?: () => Date;
+  accessToken?: string;
+}) {
+  return {
+    gateway: overrides.gateway,
+    listEvents: overrides.listEvents,
+    getValidAccessToken: vi.fn(async () => ({
+      accessToken: overrides.accessToken ?? "t",
+      refreshToken: "r",
+    })),
+    refreshAccessToken: overrides.refreshAccessToken
+      ? vi.fn(overrides.refreshAccessToken)
+      : vi.fn(),
+    now: overrides.now ?? DEFAULT_NOW,
+  };
+}
+
+describe("syncGoogleCalendar", () => {
+  test("primary の timeMin/timeMax を now±window で計算し、1 ページで完了", async () => {
+    const { gateway, upsertCalls, deleteCalls } = makeFakeGateway();
+    const listEvents = vi.fn<ListEventsFn>(async () => ({
+      items: [makeActiveEvent("a"), makeActiveEvent("b")],
+    }));
+
+    const result = await syncGoogleCalendar(
+      FAKE_SUPABASE,
+      makeDeps({
+        gateway,
+        listEvents,
+        accessToken: "fresh",
+        now: () => new Date("2026-04-23T12:00:00.000Z"),
+      }),
+    );
+
+    expect(result).toEqual({
+      synced: 2,
+      deleted: 0,
+      lastSyncedAt: "2026-04-23T12:00:00.000Z",
+    });
+    expect(listEvents).toHaveBeenCalledTimes(1);
+    const call = listEvents.mock.calls[0]![0];
+    expect(call).toMatchObject({
+      accessToken: "fresh",
+      calendarId: "primary",
+      singleEvents: true,
+      orderBy: "startTime",
+      timeMin: "2026-04-16T12:00:00.000Z", // now - 7d
+      timeMax: "2026-05-23T12:00:00.000Z", // now + 30d
+    });
+    expect(upsertCalls).toHaveLength(1);
+    expect(upsertCalls[0]!.map((e) => e.externalId)).toEqual(["a", "b"]);
+    expect(deleteCalls).toHaveLength(0);
+  });
+
+  test("ページングで nextPageToken を繰り返し、全件を集約する", async () => {
+    const { gateway, upsertCalls } = makeFakeGateway();
+    const listEvents = vi.fn<ListEventsFn>();
+    listEvents
+      .mockResolvedValueOnce({
+        items: [makeActiveEvent("p1-a"), makeActiveEvent("p1-b")],
+        nextPageToken: "tok-2",
+      })
+      .mockResolvedValueOnce({
+        items: [makeActiveEvent("p2-a")],
+        nextPageToken: "tok-3",
+      })
+      .mockResolvedValueOnce({
+        items: [makeActiveEvent("p3-a")],
+      });
+
+    const result = await syncGoogleCalendar(
+      FAKE_SUPABASE,
+      makeDeps({ gateway, listEvents }),
+    );
+
+    expect(result.synced).toBe(4);
+    expect(listEvents).toHaveBeenCalledTimes(3);
+    expect(listEvents.mock.calls[1]![0].pageToken).toBe("tok-2");
+    expect(listEvents.mock.calls[2]![0].pageToken).toBe("tok-3");
+    expect(upsertCalls[0]!.map((e) => e.externalId)).toEqual([
+      "p1-a",
+      "p1-b",
+      "p2-a",
+      "p3-a",
+    ]);
+  });
+
+  test("cancelled イベントは delete 側に集約される", async () => {
+    const { gateway, upsertCalls, deleteCalls } = makeFakeGateway();
+    const listEvents = vi.fn<ListEventsFn>(async () => ({
+      items: [
+        makeActiveEvent("keep"),
+        { id: "gone-1", status: "cancelled" },
+        { id: "gone-2", status: "cancelled" },
+      ],
+    }));
+
+    const result = await syncGoogleCalendar(
+      FAKE_SUPABASE,
+      makeDeps({ gateway, listEvents }),
+    );
+
+    expect(result.synced).toBe(1);
+    expect(result.deleted).toBe(2);
+    expect(upsertCalls[0]!.map((e) => e.externalId)).toEqual(["keep"]);
+    expect(deleteCalls[0]).toEqual(["gone-1", "gone-2"]);
+  });
+
+  test("空結果の時は upsert/delete を呼ばない", async () => {
+    const { gateway, upsertCalls, deleteCalls } = makeFakeGateway();
+    const listEvents = vi.fn<ListEventsFn>(async () => ({ items: [] }));
+
+    const result = await syncGoogleCalendar(
+      FAKE_SUPABASE,
+      makeDeps({ gateway, listEvents }),
+    );
+
+    expect(result).toMatchObject({ synced: 0, deleted: 0 });
+    expect(upsertCalls).toHaveLength(0);
+    expect(deleteCalls).toHaveLength(0);
+  });
+
+  test("401 を受けたら refresh して 1 回だけ retry する", async () => {
+    const { gateway } = makeFakeGateway();
+    const listEvents = vi.fn<ListEventsFn>();
+    listEvents
+      .mockRejectedValueOnce(new GoogleApiUnauthorizedError())
+      .mockResolvedValueOnce({ items: [makeActiveEvent("after-refresh")] });
+    const refreshAccessToken = async () => ({
+      accessToken: "new-token",
+      refreshToken: "r",
+    });
+
+    const result = await syncGoogleCalendar(
+      FAKE_SUPABASE,
+      makeDeps({
+        gateway,
+        listEvents,
+        accessToken: "stale",
+        refreshAccessToken,
+      }),
+    );
+
+    expect(result.synced).toBe(1);
+    expect(listEvents).toHaveBeenCalledTimes(2);
+    expect(listEvents.mock.calls[0]![0].accessToken).toBe("stale");
+    expect(listEvents.mock.calls[1]![0].accessToken).toBe("new-token");
+  });
+
+  test("401 retry 後も 401 なら throw する (無限ループしない)", async () => {
+    const { gateway } = makeFakeGateway();
+    const listEvents = vi.fn<ListEventsFn>(async () => {
+      throw new GoogleApiUnauthorizedError();
+    });
+    const refreshAccessToken = async () => ({
+      accessToken: "new-token",
+      refreshToken: "r",
+    });
+
+    await expect(
+      syncGoogleCalendar(
+        FAKE_SUPABASE,
+        makeDeps({
+          gateway,
+          listEvents,
+          accessToken: "stale",
+          refreshAccessToken,
+        }),
+      ),
+    ).rejects.toBeInstanceOf(GoogleApiUnauthorizedError);
+
+    expect(listEvents).toHaveBeenCalledTimes(2);
+  });
+
+  test("refresh が RefreshTokenExpiredError を投げたら伝播する", async () => {
+    const { gateway } = makeFakeGateway();
+    const listEvents = vi.fn<ListEventsFn>(async () => {
+      throw new GoogleApiUnauthorizedError();
+    });
+    const refreshAccessToken = async () => {
+      throw new RefreshTokenExpiredError("expired");
+    };
+
+    await expect(
+      syncGoogleCalendar(
+        FAKE_SUPABASE,
+        makeDeps({
+          gateway,
+          listEvents,
+          accessToken: "stale",
+          refreshAccessToken,
+        }),
+      ),
+    ).rejects.toBeInstanceOf(RefreshTokenExpiredError);
+  });
+});

--- a/src/entities/event/sync.ts
+++ b/src/entities/event/sync.ts
@@ -1,0 +1,205 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import {
+  GoogleApiUnauthorizedError,
+  type GoogleCalendarEvent,
+  type GoogleCalendarEventsListResponse,
+  type ListEventsParams,
+  listEvents as defaultListEvents,
+} from "@/shared/google/calendar";
+import {
+  getValidAccessToken as defaultGetValidAccessToken,
+  refreshAccessToken as defaultRefreshAccessToken,
+  type GoogleProviderAccess,
+} from "@/shared/google/token";
+import type { Database } from "@/shared/types/database";
+
+import type {
+  EventGateway,
+  UpsertGoogleCalendarEventInput,
+} from "./gateway";
+import { SupabaseEventGateway } from "./supabase-gateway";
+
+/**
+ * Google Calendar → events テーブル 同期本体 (ADR 0005 / 0006 / 0008 / 0010)。
+ *
+ * - 対象は primary カレンダーのみ (ADR 0008)
+ * - 過去 7 日 〜 未来 30 日 を full sync
+ * - 2 回目以降も idempotent: `(source, external_id)` の unique 制約に upsert
+ * - Google 側で cancelled になったものはローカルからも削除
+ * - 401 を受けたら `refreshAccessToken` → 1 回だけ retry (ADR 0009)
+ */
+
+const SYNC_WINDOW_PAST_DAYS = 7;
+const SYNC_WINDOW_FUTURE_DAYS = 30;
+const PRIMARY_CALENDAR_ID = "primary";
+// 終日イベントを kozutsumi 時刻に落とし込む際のタイムゾーン (JST 固定)。
+// マルチタイムゾーン対応は将来スコープ。
+const ALL_DAY_TZ_OFFSET_MIN = 9 * 60;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const DEFAULT_TITLE = "(タイトルなし)";
+
+export type SyncResult = {
+  synced: number;
+  deleted: number;
+  lastSyncedAt: string;
+};
+
+export type SyncGoogleCalendarDeps = {
+  gateway: EventGateway;
+  listEvents: (
+    params: ListEventsParams,
+  ) => Promise<GoogleCalendarEventsListResponse>;
+  getValidAccessToken: (
+    supabase: SupabaseClient<Database>,
+  ) => Promise<GoogleProviderAccess>;
+  refreshAccessToken: (
+    supabase: SupabaseClient<Database>,
+  ) => Promise<GoogleProviderAccess>;
+  now: () => Date;
+};
+
+export async function syncGoogleCalendar(
+  supabase: SupabaseClient<Database>,
+  overrides: Partial<SyncGoogleCalendarDeps> = {},
+): Promise<SyncResult> {
+  const deps: SyncGoogleCalendarDeps = {
+    gateway: overrides.gateway ?? new SupabaseEventGateway(supabase),
+    listEvents: overrides.listEvents ?? defaultListEvents,
+    getValidAccessToken:
+      overrides.getValidAccessToken ?? defaultGetValidAccessToken,
+    refreshAccessToken:
+      overrides.refreshAccessToken ?? defaultRefreshAccessToken,
+    now: overrides.now ?? (() => new Date()),
+  };
+
+  const nowDate = deps.now();
+  const timeMin = new Date(
+    nowDate.getTime() - SYNC_WINDOW_PAST_DAYS * MS_PER_DAY,
+  ).toISOString();
+  const timeMax = new Date(
+    nowDate.getTime() + SYNC_WINDOW_FUTURE_DAYS * MS_PER_DAY,
+  ).toISOString();
+
+  const initial = await deps.getValidAccessToken(supabase);
+  let accessToken = initial.accessToken;
+  let hasRetriedAuth = false;
+
+  const collected: GoogleCalendarEvent[] = [];
+  let pageToken: string | undefined;
+
+  while (true) {
+    let page: GoogleCalendarEventsListResponse;
+    try {
+      page = await deps.listEvents({
+        accessToken,
+        calendarId: PRIMARY_CALENDAR_ID,
+        timeMin,
+        timeMax,
+        singleEvents: true,
+        orderBy: "startTime",
+        pageToken,
+      });
+    } catch (err) {
+      if (err instanceof GoogleApiUnauthorizedError && !hasRetriedAuth) {
+        hasRetriedAuth = true;
+        const refreshed = await deps.refreshAccessToken(supabase);
+        accessToken = refreshed.accessToken;
+        continue;
+      }
+      throw err;
+    }
+
+    collected.push(...(page.items ?? []));
+    pageToken = page.nextPageToken;
+    if (!pageToken) break;
+  }
+
+  const { upserts, cancelled } = partitionEvents(collected);
+
+  let synced = 0;
+  if (upserts.length > 0) {
+    synced = await deps.gateway.upsertFromGoogleCalendar(upserts);
+  }
+  let deleted = 0;
+  if (cancelled.length > 0) {
+    deleted = await deps.gateway.deleteByGoogleExternalIds(cancelled);
+  }
+
+  return {
+    synced,
+    deleted,
+    lastSyncedAt: nowDate.toISOString(),
+  };
+}
+
+export function partitionEvents(events: GoogleCalendarEvent[]): {
+  upserts: UpsertGoogleCalendarEventInput[];
+  cancelled: string[];
+} {
+  const upserts: UpsertGoogleCalendarEventInput[] = [];
+  const cancelled: string[] = [];
+  for (const ev of events) {
+    if (ev.status === "cancelled") {
+      cancelled.push(ev.id);
+      continue;
+    }
+    const mapped = mapGoogleEventToUpsertInput(ev);
+    if (mapped) upserts.push(mapped);
+  }
+  return { upserts, cancelled };
+}
+
+export function mapGoogleEventToUpsertInput(
+  event: GoogleCalendarEvent,
+): UpsertGoogleCalendarEventInput | null {
+  const times = resolveEventTimes(event);
+  if (!times) return null;
+
+  return {
+    externalId: event.id,
+    title: event.summary ?? DEFAULT_TITLE,
+    startTime: times.start,
+    endTime: times.end,
+    meetUrl: extractMeetUrl(event),
+    hasAttachments:
+      Array.isArray(event.attachments) && event.attachments.length > 0,
+    description: event.description ?? "",
+  };
+}
+
+export function resolveEventTimes(
+  event: GoogleCalendarEvent,
+): { start: string; end: string } | null {
+  if (event.start?.dateTime && event.end?.dateTime) {
+    return {
+      start: new Date(event.start.dateTime).toISOString(),
+      end: new Date(event.end.dateTime).toISOString(),
+    };
+  }
+  if (event.start?.date && event.end?.date) {
+    return {
+      start: allDayDateToJstUtc(event.start.date),
+      end: allDayDateToJstUtc(event.end.date),
+    };
+  }
+  return null;
+}
+
+export function extractMeetUrl(event: GoogleCalendarEvent): string | null {
+  if (event.hangoutLink) return event.hangoutLink;
+  const video = event.conferenceData?.entryPoints?.find(
+    (ep) => ep.entryPointType === "video" && typeof ep.uri === "string",
+  );
+  return video?.uri ?? null;
+}
+
+function allDayDateToJstUtc(yyyymmdd: string): string {
+  const [y, m, d] = yyyymmdd.split("-").map(Number);
+  if (!y || !m || !d) {
+    throw new Error(`Invalid all-day date: ${yyyymmdd}`);
+  }
+  // JST の 00:00 を UTC に変換 (UTC 基準で -9h)
+  const utcMillis = Date.UTC(y, m - 1, d) - ALL_DAY_TZ_OFFSET_MIN * 60 * 1000;
+  return new Date(utcMillis).toISOString();
+}

--- a/src/entities/event/types.ts
+++ b/src/entities/event/types.ts
@@ -1,5 +1,10 @@
 export type EventSource = "manual" | "google_calendar";
 
+export const EVENT_SOURCE = {
+  MANUAL: "manual",
+  GOOGLE_CALENDAR: "google_calendar",
+} as const satisfies Record<string, EventSource>;
+
 /**
  * DB スキーマ (supabase/migrations/..._initial_schema.sql の events) と 1:1 対応。
  * 時刻は ISO 8601 文字列 (timestamptz) として扱う。


### PR DESCRIPTION
## 概要

Phase 2 のコア機能である Google Calendar → `events` テーブル の full sync を実装。
P2-1 (#56) で用意した API クライアント / token refresh 基盤の上に、同期ロジック本体と
Route Handler 統合を載せ、`/api/calendar/sync` を叩くだけで primary の past7d〜future30d が
idempotent に取り込めるようにした。

- 同期ロジック本体 (`src/entities/event/sync.ts`): ページング + 401 → `refreshAccessToken`
  → 1 回 retry、Google 側 cancelled はローカルからも削除、終日イベントは JST 00:00 正規化、
  `meet_url` は hangoutLink → conferenceData.entryPoints[video] の順で抽出
- `EventGateway` 拡張: `project_id` を upsert payload に含めないことで既存値を保持（ADR 0010）
- Route Handler: 正常時 `{ synced, deleted, lastSyncedAt }` / `ProviderTokenMissingError` と
  `RefreshTokenExpiredError` は 401 `provider_token_missing` に寄せ UI 側（P2-3）で再ログイン誘導

<details>
<summary>関連 ADR</summary>

- [ADR 0005](docs/adr/0005-google-calendar-sync-via-route-handler.md) 同期は Route Handler で実行
- [ADR 0006](docs/adr/0006-google-calendar-sync-mode-staged-adoption.md) full sync → syncToken 段階採用
- [ADR 0008](docs/adr/0008-google-calendar-sync-target-primary-only.md) 同期対象は primary のみ
- [ADR 0009](docs/adr/0009-google-provider-token-self-managed-refresh.md) provider token refresh は自前実装
- [ADR 0010](docs/adr/0010-google-calendar-event-edit-scope.md) google_calendar イベントは Google 側 read-only

</details>

## 検証

- [x] \`npm test\` → 21 files / 158 tests passed
- [x] \`npm run lint\` → no errors
- [x] \`npm run typecheck\` → no errors
- [ ] E2E: 本番 Google アカウントでの手動確認はマージ後に実施

Closes #50