### PR TITLE
feat(p2-3): Google Calendar 同期トリガー UI (手動ボタン + 起動時遅延)

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -24,6 +24,7 @@ import { EventDetailPanel } from "@/features/event-detail/EventDetailPanel";
 import { CalendarSyncButton } from "@/features/sync/CalendarSyncButton";
 import { ReauthBanner } from "@/features/sync/ReauthBanner";
 import { useCalendarSync } from "@/features/sync/useCalendarSync";
+import { useLazyCalendarSync } from "@/features/sync/useLazyCalendarSync";
 import { TaskDetailPanel } from "@/features/task-detail/TaskDetailPanel";
 import { PauseReasonModal } from "@/features/task-stack/PauseReasonModal";
 import { TaskStack, type TopTimerBinding } from "@/features/task-stack/TaskStack";
@@ -325,6 +326,7 @@ export function AppShell({ initialView, user }: AppShellProps) {
   const [pauseModalOpen, setPauseModalOpen] = useState(false);
 
   const calendarSync = useCalendarSync();
+  useLazyCalendarSync({ triggerSync: calendarSync.triggerSync });
 
   const topTimer = useMemo<TopTimerBinding>(
     () => ({

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -21,6 +21,9 @@ import { AddButton } from "@/features/add-forms/AddButton";
 import { AddPanel } from "@/features/add-forms/AddPanel";
 import { DayTimeline } from "@/features/day-timeline/DayTimeline";
 import { EventDetailPanel } from "@/features/event-detail/EventDetailPanel";
+import { CalendarSyncButton } from "@/features/sync/CalendarSyncButton";
+import { ReauthBanner } from "@/features/sync/ReauthBanner";
+import { useCalendarSync } from "@/features/sync/useCalendarSync";
 import { TaskDetailPanel } from "@/features/task-detail/TaskDetailPanel";
 import { PauseReasonModal } from "@/features/task-stack/PauseReasonModal";
 import { TaskStack, type TopTimerBinding } from "@/features/task-stack/TaskStack";
@@ -321,6 +324,8 @@ export function AppShell({ initialView, user }: AppShellProps) {
   const timer = useTaskTimer(topTask);
   const [pauseModalOpen, setPauseModalOpen] = useState(false);
 
+  const calendarSync = useCalendarSync();
+
   const topTimer = useMemo<TopTimerBinding>(
     () => ({
       elapsedSeconds: timer.elapsedSeconds,
@@ -390,6 +395,11 @@ export function AppShell({ initialView, user }: AppShellProps) {
               );
             })}
           </div>
+          <CalendarSyncButton
+            isPending={calendarSync.isPending}
+            lastSyncedAt={calendarSync.lastSyncedAt}
+            onClick={() => calendarSync.triggerSync("manual")}
+          />
           <UserMenu
             email={user.email}
             avatarUrl={user.avatarUrl}
@@ -397,6 +407,11 @@ export function AppShell({ initialView, user }: AppShellProps) {
             onClearAll={clearAll}
           />
         </div>
+
+        <ReauthBanner
+          visible={calendarSync.needsReauth}
+          onDismiss={calendarSync.dismissReauth}
+        />
 
         {view === "stack" ? (
           <StackView

--- a/src/entities/action-log/logger.test.ts
+++ b/src/entities/action-log/logger.test.ts
@@ -146,7 +146,7 @@ describe("clearLog()", () => {
 });
 
 describe("ACTION_TYPES", () => {
-  test("phase1.md に記載の action_type をすべて含む", () => {
+  test("Phase 1 / Phase 2 の action_type をすべて含む", () => {
     expect(ACTION_TYPES).toEqual({
       TASK_STARTED: "task_started",
       TASK_PAUSED: "task_paused",
@@ -159,6 +159,37 @@ describe("ACTION_TYPES", () => {
       INTERRUPTION_COMPLETED: "interruption_completed",
       STACK_PROPOSED: "stack_proposed",
       STACK_PROPOSAL_ACCEPTED: "stack_proposal_accepted",
+      CALENDAR_SYNCED: "calendar_synced",
+    });
+  });
+});
+
+describe("log(calendar_synced)", () => {
+  beforeEach(() => {
+    clearLog();
+    __resetLoggerClientForTest();
+    insertMock.mockClear();
+    fromMock.mockClear();
+    getUserMock.mockClear();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("metadata に synced / deleted / trigger を含めて insert する (task_id は null)", async () => {
+    log(ACTION_TYPES.CALENDAR_SYNCED, {
+      synced: 5,
+      deleted: 1,
+      trigger: "manual",
+    });
+    await flushMicrotasks();
+    expect(insertMock).toHaveBeenCalledWith({
+      user_id: "user-1",
+      action_type: "calendar_synced",
+      task_id: null,
+      metadata: { synced: 5, deleted: 1, trigger: "manual" },
     });
   });
 });

--- a/src/entities/action-log/logger.ts
+++ b/src/entities/action-log/logger.ts
@@ -32,6 +32,7 @@ export const ACTION_TYPES = Object.freeze({
   INTERRUPTION_COMPLETED: "interruption_completed",
   STACK_PROPOSED: "stack_proposed",
   STACK_PROPOSAL_ACCEPTED: "stack_proposal_accepted",
+  CALENDAR_SYNCED: "calendar_synced",
 }) satisfies Readonly<Record<string, ActionType>>;
 
 const KNOWN_TYPES = new Set<ActionType>(Object.values(ACTION_TYPES));

--- a/src/entities/action-log/types.ts
+++ b/src/entities/action-log/types.ts
@@ -9,9 +9,13 @@ export type ActionType =
   | "interruption_pushed"
   | "interruption_completed"
   | "stack_proposed"
-  | "stack_proposal_accepted";
+  | "stack_proposal_accepted"
+  | "calendar_synced";
 
 export type PauseReason = "meeting" | "interruption" | "voluntary";
+
+/** Google Calendar 同期がどの経路でトリガーされたか。Phase 4 の頻度分析に使う (#51)。 */
+export type CalendarSyncTrigger = "manual" | "lazy";
 
 export type ActionMetadataMap = {
   task_started: { task_id: string };
@@ -37,6 +41,11 @@ export type ActionMetadataMap = {
   interruption_completed: { task_id: string };
   stack_proposed: Record<string, unknown>;
   stack_proposal_accepted: Record<string, unknown>;
+  calendar_synced: {
+    synced: number;
+    deleted: number;
+    trigger: CalendarSyncTrigger;
+  };
 };
 
 export type ActionLogEntry<T extends ActionType = ActionType> = {

--- a/src/entities/calendar-sync/gateway.ts
+++ b/src/entities/calendar-sync/gateway.ts
@@ -1,0 +1,17 @@
+/**
+ * Google Calendar 同期状態 (最終同期時刻・syncToken 予約) の永続化 Gateway。
+ *
+ * ADR 0007 の「起動時 15 分閾値で遅延同期するか」を判定するために `lastSyncedAt` を使う。
+ * `syncToken` は ADR 0006 の P2-6 差分同期で使う予約枠で、P2-3 時点では読み書きしない。
+ */
+export type CalendarSyncState = {
+  lastSyncedAt: string;
+  syncToken: string | null;
+};
+
+export interface CalendarSyncStateGateway {
+  /** 現在ユーザーの同期状態を取得。未同期なら null。 */
+  get(): Promise<CalendarSyncState | null>;
+  /** 同期成功時に最終同期時刻を upsert する (`sync_token` は触らない)。 */
+  upsertLastSyncedAt(lastSyncedAt: string): Promise<void>;
+}

--- a/src/entities/calendar-sync/supabase-gateway.test.ts
+++ b/src/entities/calendar-sync/supabase-gateway.test.ts
@@ -1,0 +1,148 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { describe, expect, test, vi } from "vitest";
+
+import type { Database } from "@/shared/types/database";
+
+import { SupabaseCalendarSyncStateGateway } from "./supabase-gateway";
+
+type Sb = SupabaseClient<Database>;
+
+function makeSupabase(overrides: {
+  getUserId?: string | null;
+  selectResult?: {
+    data: {
+      user_id: string;
+      last_synced_at: string;
+      sync_token: string | null;
+      updated_at: string;
+    } | null;
+    error: { code?: string; message?: string } | null;
+  };
+  upsertError?: { message: string } | null;
+}) {
+  const userId = overrides.getUserId === undefined ? "user-1" : overrides.getUserId;
+  const maybeSingle = vi.fn(async () =>
+    overrides.selectResult ?? { data: null, error: null },
+  );
+  const eqSelect = vi.fn(() => ({ maybeSingle }));
+  const select = vi.fn(() => ({ eq: eqSelect }));
+  const upsert = vi.fn<
+    (
+      payload: Record<string, unknown>,
+      options: { onConflict: string },
+    ) => Promise<{ error: { message: string } | null }>
+  >(async () => ({ error: overrides.upsertError ?? null }));
+  const from = vi.fn(() => ({ select, upsert }));
+  const supabase = {
+    auth: {
+      getUser: vi.fn(async () => ({
+        data: { user: userId ? { id: userId } : null },
+        error: null,
+      })),
+    },
+    from,
+  } as unknown as Sb;
+  return { supabase, from, select, eqSelect, maybeSingle, upsert };
+}
+
+describe("SupabaseCalendarSyncStateGateway.get", () => {
+  test("行があれば CalendarSyncState を返す", async () => {
+    const { supabase, from, select, eqSelect } = makeSupabase({
+      selectResult: {
+        data: {
+          user_id: "user-1",
+          last_synced_at: "2026-04-24T10:00:00.000Z",
+          sync_token: null,
+          updated_at: "2026-04-24T10:00:00.000Z",
+        },
+        error: null,
+      },
+    });
+
+    const gw = new SupabaseCalendarSyncStateGateway(supabase);
+    const state = await gw.get();
+
+    expect(state).toEqual({
+      lastSyncedAt: "2026-04-24T10:00:00.000Z",
+      syncToken: null,
+    });
+    expect(from).toHaveBeenCalledWith("user_calendar_sync_state");
+    expect(select).toHaveBeenCalledWith(
+      "user_id, last_synced_at, sync_token, updated_at",
+    );
+    expect(eqSelect).toHaveBeenCalledWith("user_id", "user-1");
+  });
+
+  test("行がなければ null を返す", async () => {
+    const { supabase } = makeSupabase({
+      selectResult: { data: null, error: null },
+    });
+
+    const gw = new SupabaseCalendarSyncStateGateway(supabase);
+    const state = await gw.get();
+
+    expect(state).toBeNull();
+  });
+
+  test("未ログイン時は null を返す (RLS に到達させず先に弾く)", async () => {
+    const { supabase, from } = makeSupabase({ getUserId: null });
+    const gw = new SupabaseCalendarSyncStateGateway(supabase);
+
+    const state = await gw.get();
+
+    expect(state).toBeNull();
+    expect(from).not.toHaveBeenCalled();
+  });
+
+  test("Supabase が error を返したら throw する", async () => {
+    const { supabase } = makeSupabase({
+      selectResult: {
+        data: null,
+        error: { code: "500", message: "db down" },
+      },
+    });
+    const gw = new SupabaseCalendarSyncStateGateway(supabase);
+
+    await expect(gw.get()).rejects.toMatchObject({ message: "db down" });
+  });
+});
+
+describe("SupabaseCalendarSyncStateGateway.upsertLastSyncedAt", () => {
+  test("user_id + last_synced_at を on conflict user_id で upsert する", async () => {
+    const { supabase, from, upsert } = makeSupabase({});
+    const gw = new SupabaseCalendarSyncStateGateway(supabase);
+
+    await gw.upsertLastSyncedAt("2026-04-24T10:00:00.000Z");
+
+    expect(from).toHaveBeenCalledWith("user_calendar_sync_state");
+    expect(upsert).toHaveBeenCalledTimes(1);
+    const [payload, options] = upsert.mock.calls[0]!;
+    expect(payload).toMatchObject({
+      user_id: "user-1",
+      last_synced_at: "2026-04-24T10:00:00.000Z",
+    });
+    // sync_token は触らない (P2-6 予約枠、既存値を保持)
+    expect(payload).not.toHaveProperty("sync_token");
+    expect(options).toEqual({ onConflict: "user_id" });
+  });
+
+  test("未ログイン時は throw する (Route Handler 以外からの呼び出しを防ぐ)", async () => {
+    const { supabase } = makeSupabase({ getUserId: null });
+    const gw = new SupabaseCalendarSyncStateGateway(supabase);
+
+    await expect(
+      gw.upsertLastSyncedAt("2026-04-24T10:00:00.000Z"),
+    ).rejects.toThrow(/not authenticated/i);
+  });
+
+  test("Supabase が error を返したら throw する", async () => {
+    const { supabase } = makeSupabase({
+      upsertError: { message: "insert failed" },
+    });
+    const gw = new SupabaseCalendarSyncStateGateway(supabase);
+
+    await expect(
+      gw.upsertLastSyncedAt("2026-04-24T10:00:00.000Z"),
+    ).rejects.toMatchObject({ message: "insert failed" });
+  });
+});

--- a/src/entities/calendar-sync/supabase-gateway.ts
+++ b/src/entities/calendar-sync/supabase-gateway.ts
@@ -1,0 +1,52 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { Database, TablesInsert } from "@/shared/types/database";
+
+import type {
+  CalendarSyncState,
+  CalendarSyncStateGateway,
+} from "./gateway";
+
+type Sb = SupabaseClient<Database>;
+
+export class SupabaseCalendarSyncStateGateway
+  implements CalendarSyncStateGateway
+{
+  constructor(private readonly supabase: Sb) {}
+
+  async get(): Promise<CalendarSyncState | null> {
+    const {
+      data: { user },
+    } = await this.supabase.auth.getUser();
+    if (!user) return null;
+
+    const { data, error } = await this.supabase
+      .from("user_calendar_sync_state")
+      .select("user_id, last_synced_at, sync_token, updated_at")
+      .eq("user_id", user.id)
+      .maybeSingle();
+    if (error) throw error;
+    if (!data) return null;
+    return {
+      lastSyncedAt: data.last_synced_at,
+      syncToken: data.sync_token,
+    };
+  }
+
+  async upsertLastSyncedAt(lastSyncedAt: string): Promise<void> {
+    const {
+      data: { user },
+    } = await this.supabase.auth.getUser();
+    if (!user) throw new Error("not authenticated");
+
+    // sync_token は payload から外すことで既存値を保持する (P2-6 で使う予約枠)。
+    const payload: TablesInsert<"user_calendar_sync_state"> = {
+      user_id: user.id,
+      last_synced_at: lastSyncedAt,
+    };
+    const { error } = await this.supabase
+      .from("user_calendar_sync_state")
+      .upsert(payload, { onConflict: "user_id" });
+    if (error) throw error;
+  }
+}

--- a/src/entities/event/sync.test.ts
+++ b/src/entities/event/sync.test.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { describe, expect, test, vi } from "vitest";
 
+import type { CalendarSyncStateGateway } from "@/entities/calendar-sync/gateway";
 import {
   GoogleApiUnauthorizedError,
   type GoogleCalendarEvent,
@@ -201,6 +202,17 @@ function makeFakeGateway() {
   return { gateway, upsertCalls, deleteCalls };
 }
 
+function makeFakeSyncStateGateway() {
+  const upsertLastSyncedAt = vi.fn<(iso: string) => Promise<void>>(
+    async () => {},
+  );
+  const gateway: CalendarSyncStateGateway = {
+    get: vi.fn(async () => null),
+    upsertLastSyncedAt,
+  };
+  return { gateway, upsertLastSyncedAt };
+}
+
 function makeActiveEvent(id: string): GoogleCalendarEvent {
   return {
     id,
@@ -216,6 +228,7 @@ const DEFAULT_NOW = () => new Date("2026-04-23T00:00:00.000Z");
 /** テスト共通の DI overrides。`listEvents` / `refreshAccessToken` はテスト側で差し替える */
 function makeDeps(overrides: {
   gateway: EventGateway;
+  syncStateGateway?: CalendarSyncStateGateway;
   listEvents: ListEventsFn;
   refreshAccessToken?: () => Promise<{
     accessToken: string;
@@ -226,6 +239,8 @@ function makeDeps(overrides: {
 }) {
   return {
     gateway: overrides.gateway,
+    syncStateGateway:
+      overrides.syncStateGateway ?? makeFakeSyncStateGateway().gateway,
     listEvents: overrides.listEvents,
     getValidAccessToken: vi.fn(async () => ({
       accessToken: overrides.accessToken ?? "t",
@@ -415,5 +430,55 @@ describe("syncGoogleCalendar", () => {
         }),
       ),
     ).rejects.toBeInstanceOf(RefreshTokenExpiredError);
+  });
+
+  test("成功時は last_synced_at を永続化する", async () => {
+    const { gateway } = makeFakeGateway();
+    const { gateway: syncStateGateway, upsertLastSyncedAt } =
+      makeFakeSyncStateGateway();
+    const listEvents = vi.fn<ListEventsFn>(async () => ({
+      items: [makeActiveEvent("a")],
+    }));
+
+    const result = await syncGoogleCalendar(
+      FAKE_SUPABASE,
+      makeDeps({
+        gateway,
+        syncStateGateway,
+        listEvents,
+        now: () => new Date("2026-04-24T01:30:00.000Z"),
+      }),
+    );
+
+    expect(result.lastSyncedAt).toBe("2026-04-24T01:30:00.000Z");
+    expect(upsertLastSyncedAt).toHaveBeenCalledTimes(1);
+    expect(upsertLastSyncedAt).toHaveBeenCalledWith("2026-04-24T01:30:00.000Z");
+  });
+
+  test("401 retry 後も失敗する場合は last_synced_at を記録しない", async () => {
+    const { gateway } = makeFakeGateway();
+    const { gateway: syncStateGateway, upsertLastSyncedAt } =
+      makeFakeSyncStateGateway();
+    const listEvents = vi.fn<ListEventsFn>(async () => {
+      throw new GoogleApiUnauthorizedError();
+    });
+    const refreshAccessToken = async () => ({
+      accessToken: "new-token",
+      refreshToken: "r",
+    });
+
+    await expect(
+      syncGoogleCalendar(
+        FAKE_SUPABASE,
+        makeDeps({
+          gateway,
+          syncStateGateway,
+          listEvents,
+          refreshAccessToken,
+        }),
+      ),
+    ).rejects.toBeInstanceOf(GoogleApiUnauthorizedError);
+
+    expect(upsertLastSyncedAt).not.toHaveBeenCalled();
   });
 });

--- a/src/entities/event/sync.ts
+++ b/src/entities/event/sync.ts
@@ -1,5 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 
+import type { CalendarSyncStateGateway } from "@/entities/calendar-sync/gateway";
+import { SupabaseCalendarSyncStateGateway } from "@/entities/calendar-sync/supabase-gateway";
 import {
   GoogleApiUnauthorizedError,
   type GoogleCalendarEvent,
@@ -47,6 +49,7 @@ export type SyncResult = {
 
 export type SyncGoogleCalendarDeps = {
   gateway: EventGateway;
+  syncStateGateway: CalendarSyncStateGateway;
   listEvents: (
     params: ListEventsParams,
   ) => Promise<GoogleCalendarEventsListResponse>;
@@ -65,6 +68,9 @@ export async function syncGoogleCalendar(
 ): Promise<SyncResult> {
   const deps: SyncGoogleCalendarDeps = {
     gateway: overrides.gateway ?? new SupabaseEventGateway(supabase),
+    syncStateGateway:
+      overrides.syncStateGateway ??
+      new SupabaseCalendarSyncStateGateway(supabase),
     listEvents: overrides.listEvents ?? defaultListEvents,
     getValidAccessToken:
       overrides.getValidAccessToken ?? defaultGetValidAccessToken,
@@ -126,10 +132,15 @@ export async function syncGoogleCalendar(
     deleted = await deps.gateway.deleteByGoogleExternalIds(cancelled);
   }
 
+  const lastSyncedAt = nowDate.toISOString();
+  // 成功したときだけ記録する (listEvents/refresh が throw した経路では呼ばれない)。
+  // ADR 0007 の起動時 15 分閾値判定、ADR 0006 の syncToken 保持の両方をこの 1 行で繋ぐ。
+  await deps.syncStateGateway.upsertLastSyncedAt(lastSyncedAt);
+
   return {
     synced,
     deleted,
-    lastSyncedAt: nowDate.toISOString(),
+    lastSyncedAt,
   };
 }
 

--- a/src/features/sync/CalendarSyncButton.test.tsx
+++ b/src/features/sync/CalendarSyncButton.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import { CalendarSyncButton } from "./CalendarSyncButton";
+
+describe("CalendarSyncButton", () => {
+  test("デフォルトではクリック可能でラベルは「同期」", () => {
+    const onClick = vi.fn();
+    render(
+      <CalendarSyncButton
+        isPending={false}
+        lastSyncedAt={null}
+        onClick={onClick}
+      />,
+    );
+
+    const button = screen.getByRole("button", {
+      name: "カレンダーを同期",
+    }) as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+    expect(button.textContent).toContain("同期");
+
+    fireEvent.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test("isPending=true のときは disabled / スピナー表示で「同期中...」", () => {
+    const onClick = vi.fn();
+    render(
+      <CalendarSyncButton
+        isPending={true}
+        lastSyncedAt={null}
+        onClick={onClick}
+      />,
+    );
+
+    const button = screen.getByRole("button", {
+      name: "カレンダーを同期",
+    }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(button.textContent).toContain("同期中...");
+
+    fireEvent.click(button);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  test("lastSyncedAt があれば tooltip に最終同期時刻を出す", () => {
+    render(
+      <CalendarSyncButton
+        isPending={false}
+        lastSyncedAt={new Date().toISOString()}
+        onClick={() => {}}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "カレンダーを同期" });
+    // 厳密な文言は formatRelative 依存なので prefix だけ検査する
+    expect(button.getAttribute("title")).toMatch(/^最終同期:/);
+  });
+});

--- a/src/features/sync/CalendarSyncButton.tsx
+++ b/src/features/sync/CalendarSyncButton.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+type CalendarSyncButtonProps = {
+  isPending: boolean;
+  lastSyncedAt: string | null;
+  onClick: () => void;
+};
+
+/**
+ * ヘッダーに置くカレンダー同期ボタン。押下で `useCalendarSync.triggerSync('manual')` を呼ぶ前提。
+ * 実行中はスピナー + disabled、成功時は最終同期時刻を tooltip として表示する。
+ */
+export function CalendarSyncButton({
+  isPending,
+  lastSyncedAt,
+  onClick,
+}: CalendarSyncButtonProps) {
+  const tooltip = lastSyncedAt
+    ? `最終同期: ${formatRelative(lastSyncedAt)}`
+    : "カレンダーを同期";
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={isPending}
+      aria-label="カレンダーを同期"
+      title={tooltip}
+      className="flex h-7 items-center gap-1.5 rounded-md border border-bg-divider bg-bg-elevated px-2.5 text-[11px] font-medium text-fg-muted transition-colors hover:text-fg-emphasized disabled:opacity-60"
+    >
+      <SyncIcon spinning={isPending} />
+      <span>{isPending ? "同期中..." : "同期"}</span>
+    </button>
+  );
+}
+
+function SyncIcon({ spinning }: { spinning: boolean }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      width="12"
+      height="12"
+      aria-hidden="true"
+      className={spinning ? "animate-spin" : undefined}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M2 7a6 6 0 0 1 10.24-4.24" />
+      <path d="M14 2v4h-4" />
+      <path d="M14 9a6 6 0 0 1-10.24 4.24" />
+      <path d="M2 14v-4h4" />
+    </svg>
+  );
+}
+
+function formatRelative(iso: string): string {
+  const now = Date.now();
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return iso;
+  const diffSec = Math.max(0, Math.round((now - then) / 1000));
+  if (diffSec < 60) return "たった今";
+  const diffMin = Math.round(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}分前`;
+  const diffHour = Math.round(diffMin / 60);
+  if (diffHour < 24) return `${diffHour}時間前`;
+  const diffDay = Math.round(diffHour / 24);
+  return `${diffDay}日前`;
+}

--- a/src/features/sync/ReauthBanner.test.tsx
+++ b/src/features/sync/ReauthBanner.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+type SignInWithOAuthArgs = {
+  provider: string;
+  options: {
+    redirectTo: string;
+    scopes: string;
+    queryParams: Record<string, string>;
+  };
+};
+const signInWithOAuthMock = vi.fn<
+  (args: SignInWithOAuthArgs) => Promise<{ error: null }>
+>(async () => ({ error: null }));
+vi.mock("@/shared/supabase/client", () => ({
+  createClient: () => ({
+    auth: {
+      signInWithOAuth: signInWithOAuthMock,
+    },
+  }),
+}));
+
+import { ReauthBanner } from "./ReauthBanner";
+
+describe("ReauthBanner", () => {
+  beforeEach(() => {
+    signInWithOAuthMock.mockClear();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("visible=false のときは何も描画しない", () => {
+    const { container } = render(
+      <ReauthBanner visible={false} onDismiss={() => {}} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("visible=true のとき alert と再連携ボタンを出す", () => {
+    render(<ReauthBanner visible={true} onDismiss={() => {}} />);
+    expect(screen.getByRole("alert")).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: /Google と連携し直す/ }),
+    ).not.toBeNull();
+  });
+
+  test("再連携ボタンで signInWithOAuth を Google + calendar.readonly scope で起動する", () => {
+    render(<ReauthBanner visible={true} onDismiss={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /Google と連携し直す/ }));
+
+    expect(signInWithOAuthMock).toHaveBeenCalledTimes(1);
+    const args = signInWithOAuthMock.mock.calls[0]![0];
+    expect(args.provider).toBe("google");
+    expect(args.options.scopes).toContain(
+      "https://www.googleapis.com/auth/calendar.readonly",
+    );
+    expect(args.options.queryParams).toEqual({
+      access_type: "offline",
+      prompt: "consent",
+    });
+    expect(args.options.redirectTo).toMatch(/\/auth\/callback$/);
+  });
+
+  test("閉じるボタンで onDismiss を呼ぶ", () => {
+    const onDismiss = vi.fn();
+    render(<ReauthBanner visible={true} onDismiss={onDismiss} />);
+    fireEvent.click(screen.getByRole("button", { name: "バナーを閉じる" }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/sync/ReauthBanner.tsx
+++ b/src/features/sync/ReauthBanner.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState } from "react";
+
+import { createClient } from "@/shared/supabase/client";
+
+// ログイン時と同じ scope を指定して再同意させる。
+// LoginButton.tsx と重複するが、単一コンポーネントに畳むと認証/バナーの責務が混ざるので分けておく。
+const GOOGLE_SCOPES = [
+  "openid",
+  "email",
+  "profile",
+  "https://www.googleapis.com/auth/calendar.readonly",
+].join(" ");
+
+type ReauthBannerProps = {
+  visible: boolean;
+  onDismiss: () => void;
+};
+
+/**
+ * `provider_token_missing` (401) を受けたときに出す再ログインバナー。
+ * 「再連携」ボタンで `signInWithOAuth` を起動して OAuth 再同意へ誘導する。
+ */
+export function ReauthBanner({ visible, onDismiss }: ReauthBannerProps) {
+  const [pending, setPending] = useState(false);
+  if (!visible) return null;
+
+  async function onReauth() {
+    setPending(true);
+    const supabase = createClient();
+    const origin = window.location.origin;
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: {
+        redirectTo: `${origin}/auth/callback`,
+        scopes: GOOGLE_SCOPES,
+        queryParams: {
+          access_type: "offline",
+          prompt: "consent",
+        },
+      },
+    });
+    if (error) {
+      console.error("[reauth] signInWithOAuth failed", error);
+      setPending(false);
+    }
+  }
+
+  return (
+    <div
+      role="alert"
+      className="flex items-center gap-3 border-b border-accent-red/40 bg-accent-red/10 px-4 py-2 text-[12px] text-fg-emphasized"
+    >
+      <span className="flex-1">
+        Google カレンダーの連携が失効しました。再連携すると同期が再開します。
+      </span>
+      <button
+        type="button"
+        onClick={onReauth}
+        disabled={pending}
+        className="rounded bg-accent-red px-3 py-1 text-[11px] font-medium text-fg-invert transition-colors hover:opacity-90 disabled:opacity-60"
+      >
+        {pending ? "リダイレクト中..." : "Google と連携し直す"}
+      </button>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="バナーを閉じる"
+        className="text-fg-muted transition-colors hover:text-fg-emphasized"
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/src/features/sync/constants.ts
+++ b/src/features/sync/constants.ts
@@ -1,0 +1,6 @@
+/**
+ * 起動時遅延同期 (ADR 0007) の閾値。
+ * 前回同期から `SYNC_STALE_THRESHOLD_MINUTES` 分以上経過していたら
+ * アプリ起動時にバックグラウンドで `/api/calendar/sync` を叩く。
+ */
+export const SYNC_STALE_THRESHOLD_MINUTES = 15;

--- a/src/features/sync/useCalendarSync.test.tsx
+++ b/src/features/sync/useCalendarSync.test.tsx
@@ -1,0 +1,164 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  log: vi.fn(),
+}));
+
+vi.mock("@/entities/action-log/logger", () => ({
+  ACTION_TYPES: Object.freeze({
+    TASK_STARTED: "task_started",
+    TASK_PAUSED: "task_paused",
+    TASK_RESUMED: "task_resumed",
+    TASK_COMPLETED: "task_completed",
+    TASK_REORDERED: "task_reordered",
+    TASK_DELETED: "task_deleted",
+    TASK_TITLE_CHANGED: "task_title_changed",
+    INTERRUPTION_PUSHED: "interruption_pushed",
+    INTERRUPTION_COMPLETED: "interruption_completed",
+    STACK_PROPOSED: "stack_proposed",
+    STACK_PROPOSAL_ACCEPTED: "stack_proposal_accepted",
+    CALENDAR_SYNCED: "calendar_synced",
+  }),
+  log: mocks.log,
+}));
+
+import { useCalendarSync } from "./useCalendarSync";
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+  return { Wrapper, queryClient, invalidateSpy };
+}
+
+function mockFetchOnce(init: {
+  status: number;
+  body?: unknown;
+}): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn<typeof fetch>(
+    async () =>
+      new Response(init.body ? JSON.stringify(init.body) : null, {
+        status: init.status,
+        headers: { "content-type": "application/json" },
+      }),
+  );
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+describe("useCalendarSync", () => {
+  beforeEach(() => {
+    mocks.log.mockClear();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("200 成功: lastSyncedAt を保持し events を invalidate し action_log を記録する", async () => {
+    const { Wrapper, invalidateSpy } = makeWrapper();
+    const fetchMock = mockFetchOnce({
+      status: 200,
+      body: { synced: 3, deleted: 1, lastSyncedAt: "2026-04-24T04:00:00.000Z" },
+    });
+
+    const { result } = renderHook(() => useCalendarSync(), { wrapper: Wrapper });
+
+    act(() => {
+      result.current.triggerSync("manual");
+    });
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(result.current.lastSyncedAt).toBe("2026-04-24T04:00:00.000Z");
+    expect(result.current.needsReauth).toBe(false);
+    expect(fetchMock).toHaveBeenCalledWith("/api/calendar/sync", {
+      method: "POST",
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["events"] });
+    expect(mocks.log).toHaveBeenCalledWith("calendar_synced", {
+      synced: 3,
+      deleted: 1,
+      trigger: "manual",
+    });
+  });
+
+  test("lazy trigger でも同じ経路を通り action_log に trigger='lazy' を渡す", async () => {
+    const { Wrapper } = makeWrapper();
+    mockFetchOnce({
+      status: 200,
+      body: { synced: 0, deleted: 0, lastSyncedAt: "2026-04-24T04:00:00.000Z" },
+    });
+
+    const { result } = renderHook(() => useCalendarSync(), { wrapper: Wrapper });
+
+    act(() => {
+      result.current.triggerSync("lazy");
+    });
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(mocks.log).toHaveBeenCalledWith("calendar_synced", {
+      synced: 0,
+      deleted: 0,
+      trigger: "lazy",
+    });
+  });
+
+  test("401 を受けたら needsReauth=true になり、events は invalidate しない", async () => {
+    const { Wrapper, invalidateSpy } = makeWrapper();
+    mockFetchOnce({
+      status: 401,
+      body: { error: "provider_token_missing" },
+    });
+
+    const { result } = renderHook(() => useCalendarSync(), { wrapper: Wrapper });
+
+    act(() => {
+      result.current.triggerSync("manual");
+    });
+    await waitFor(() => expect(result.current.needsReauth).toBe(true));
+
+    expect(result.current.lastSyncedAt).toBeNull();
+    expect(invalidateSpy).not.toHaveBeenCalled();
+    expect(mocks.log).not.toHaveBeenCalled();
+  });
+
+  test("dismissReauth で needsReauth を false に戻せる", async () => {
+    const { Wrapper } = makeWrapper();
+    mockFetchOnce({ status: 401 });
+
+    const { result } = renderHook(() => useCalendarSync(), { wrapper: Wrapper });
+
+    act(() => {
+      result.current.triggerSync("manual");
+    });
+    await waitFor(() => expect(result.current.needsReauth).toBe(true));
+
+    act(() => {
+      result.current.dismissReauth();
+    });
+    expect(result.current.needsReauth).toBe(false);
+  });
+
+  test("500 失敗時は needsReauth は立たず pending が解除されるだけ (ユーザー側で再試行)", async () => {
+    const { Wrapper, invalidateSpy } = makeWrapper();
+    mockFetchOnce({ status: 500, body: { error: "sync_failed" } });
+
+    const { result } = renderHook(() => useCalendarSync(), { wrapper: Wrapper });
+
+    act(() => {
+      result.current.triggerSync("manual");
+    });
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(result.current.needsReauth).toBe(false);
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/sync/useCalendarSync.ts
+++ b/src/features/sync/useCalendarSync.ts
@@ -1,0 +1,104 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useState } from "react";
+
+import {
+  ACTION_TYPES,
+  log,
+} from "@/entities/action-log/logger";
+import type { CalendarSyncTrigger } from "@/entities/action-log/types";
+
+const SYNC_ENDPOINT = "/api/calendar/sync";
+const EVENTS_QUERY_KEY = ["events"] as const;
+
+export type CalendarSyncResult = {
+  synced: number;
+  deleted: number;
+  lastSyncedAt: string;
+};
+
+/**
+ * `/api/calendar/sync` が返す 401 のうち、再ログイン (OAuth 再同意) が必要な
+ * provider_token_missing だけを識別する目印。UI はこれを見て Reauth バナーを出す。
+ */
+export const CALENDAR_SYNC_REAUTH_REQUIRED = "reauth_required" as const;
+
+export type UseCalendarSyncResult = {
+  /** 同期を発火する (fire-and-forget)。結果は hook の state で観測する。 */
+  triggerSync: (trigger: CalendarSyncTrigger) => void;
+  isPending: boolean;
+  /** `provider_token_missing` (401) を受けた場合に true。Reauth バナー表示に使う。 */
+  needsReauth: boolean;
+  dismissReauth: () => void;
+  /** 直近の同期成功時刻 (ISO8601)。まだ一度も成功していなければ null。 */
+  lastSyncedAt: string | null;
+};
+
+/**
+ * カレンダー同期を発火するフック。
+ * ADR 0007 の「手動 + 起動時遅延」どちらの経路からも同じ実装を通す。
+ *
+ * AppShell で 1 回だけ呼び、`CalendarSyncButton` / `ReauthBanner` / 起動時遅延
+ * (Phase 5) へ result を props 渡しする想定。
+ */
+export function useCalendarSync(): UseCalendarSyncResult {
+  const queryClient = useQueryClient();
+  const [needsReauth, setNeedsReauth] = useState(false);
+  const [lastSyncedAt, setLastSyncedAt] = useState<string | null>(null);
+
+  const mutation = useMutation<CalendarSyncResult, Error, CalendarSyncTrigger>({
+    mutationFn: async (trigger) => {
+      const res = await fetch(SYNC_ENDPOINT, { method: "POST" });
+      if (res.status === 401) {
+        throw new Error(CALENDAR_SYNC_REAUTH_REQUIRED);
+      }
+      if (!res.ok) {
+        const body = (await safeJson(res)) as { message?: string } | null;
+        throw new Error(body?.message ?? `sync_failed: ${res.status}`);
+      }
+      const body = (await res.json()) as CalendarSyncResult;
+      log(ACTION_TYPES.CALENDAR_SYNCED, {
+        synced: body.synced,
+        deleted: body.deleted,
+        trigger,
+      });
+      return body;
+    },
+    onSuccess: (data) => {
+      setNeedsReauth(false);
+      setLastSyncedAt(data.lastSyncedAt);
+      void queryClient.invalidateQueries({ queryKey: EVENTS_QUERY_KEY });
+    },
+    onError: (err) => {
+      if (err.message === CALENDAR_SYNC_REAUTH_REQUIRED) {
+        setNeedsReauth(true);
+      }
+    },
+  });
+
+  const triggerSync = useCallback(
+    (trigger: CalendarSyncTrigger) => {
+      mutation.mutate(trigger);
+    },
+    [mutation],
+  );
+
+  const dismissReauth = useCallback(() => setNeedsReauth(false), []);
+
+  return {
+    triggerSync,
+    isPending: mutation.isPending,
+    needsReauth,
+    dismissReauth,
+    lastSyncedAt,
+  };
+}
+
+async function safeJson(res: Response): Promise<unknown> {
+  try {
+    return await res.json();
+  } catch {
+    return null;
+  }
+}

--- a/src/features/sync/useLazyCalendarSync.test.tsx
+++ b/src/features/sync/useLazyCalendarSync.test.tsx
@@ -1,0 +1,117 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import type { CalendarSyncState } from "@/entities/calendar-sync/gateway";
+
+import { shouldTriggerLazy, useLazyCalendarSync } from "./useLazyCalendarSync";
+
+const FIXED_NOW = new Date("2026-04-24T10:00:00.000Z");
+
+function now() {
+  return FIXED_NOW;
+}
+
+describe("shouldTriggerLazy", () => {
+  test("state が null なら未同期として true", () => {
+    expect(shouldTriggerLazy(null, FIXED_NOW)).toBe(true);
+  });
+
+  test("前回同期から 15 分以上経過していたら true", () => {
+    const state: CalendarSyncState = {
+      lastSyncedAt: new Date(FIXED_NOW.getTime() - 16 * 60_000).toISOString(),
+      syncToken: null,
+    };
+    expect(shouldTriggerLazy(state, FIXED_NOW)).toBe(true);
+  });
+
+  test("ちょうど 15 分前 (閾値の境界) なら true", () => {
+    const state: CalendarSyncState = {
+      lastSyncedAt: new Date(FIXED_NOW.getTime() - 15 * 60_000).toISOString(),
+      syncToken: null,
+    };
+    expect(shouldTriggerLazy(state, FIXED_NOW)).toBe(true);
+  });
+
+  test("15 分未満なら false", () => {
+    const state: CalendarSyncState = {
+      lastSyncedAt: new Date(FIXED_NOW.getTime() - 5 * 60_000).toISOString(),
+      syncToken: null,
+    };
+    expect(shouldTriggerLazy(state, FIXED_NOW)).toBe(false);
+  });
+
+  test("lastSyncedAt が ISO として壊れている場合は stale 扱いで true (fail-open)", () => {
+    expect(
+      shouldTriggerLazy(
+        { lastSyncedAt: "garbage", syncToken: null },
+        FIXED_NOW,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("useLazyCalendarSync", () => {
+  test("stale ならマウント時に triggerSync('lazy') を 1 回呼ぶ", async () => {
+    const triggerSync = vi.fn();
+    const getState = vi.fn(async () => null);
+
+    renderHook(() =>
+      useLazyCalendarSync({ triggerSync, deps: { getState, now } }),
+    );
+
+    await waitFor(() => expect(triggerSync).toHaveBeenCalledTimes(1));
+    expect(triggerSync).toHaveBeenCalledWith("lazy");
+  });
+
+  test("fresh なら triggerSync を呼ばない", async () => {
+    const triggerSync = vi.fn();
+    const getState = vi.fn(
+      async (): Promise<CalendarSyncState | null> => ({
+        lastSyncedAt: new Date(FIXED_NOW.getTime() - 60_000).toISOString(),
+        syncToken: null,
+      }),
+    );
+
+    renderHook(() =>
+      useLazyCalendarSync({ triggerSync, deps: { getState, now } }),
+    );
+
+    // 1 tick 待って triggerSync が呼ばれないことを確認
+    await new Promise((r) => setTimeout(r, 0));
+    expect(triggerSync).not.toHaveBeenCalled();
+  });
+
+  test("親の再レンダリングで 2 回目以降は fire しない (ref ガード)", async () => {
+    const triggerSync = vi.fn();
+    const getState = vi.fn(async () => null);
+
+    const { rerender } = renderHook(() =>
+      useLazyCalendarSync({ triggerSync, deps: { getState, now } }),
+    );
+
+    await waitFor(() => expect(triggerSync).toHaveBeenCalledTimes(1));
+
+    rerender();
+    rerender();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(triggerSync).toHaveBeenCalledTimes(1);
+    expect(getState).toHaveBeenCalledTimes(1);
+  });
+
+  test("getState が throw しても例外は握りつぶし triggerSync も呼ばない", async () => {
+    const triggerSync = vi.fn();
+    const getState = vi.fn(async () => {
+      throw new Error("network down");
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    renderHook(() =>
+      useLazyCalendarSync({ triggerSync, deps: { getState, now } }),
+    );
+
+    await waitFor(() => expect(errorSpy).toHaveBeenCalled());
+    expect(triggerSync).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/src/features/sync/useLazyCalendarSync.ts
+++ b/src/features/sync/useLazyCalendarSync.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import type {
+  CalendarSyncState,
+  CalendarSyncStateGateway,
+} from "@/entities/calendar-sync/gateway";
+import { SupabaseCalendarSyncStateGateway } from "@/entities/calendar-sync/supabase-gateway";
+import type { CalendarSyncTrigger } from "@/entities/action-log/types";
+import { createClient } from "@/shared/supabase/client";
+
+import { SYNC_STALE_THRESHOLD_MINUTES } from "./constants";
+
+export type UseLazyCalendarSyncDeps = {
+  getState: () => Promise<CalendarSyncState | null>;
+  now: () => Date;
+};
+
+export type UseLazyCalendarSyncOptions = {
+  triggerSync: (trigger: CalendarSyncTrigger) => void;
+  deps?: Partial<UseLazyCalendarSyncDeps>;
+};
+
+/**
+ * 起動時遅延同期 (ADR 0007) の副作用フック。
+ *
+ * マウント時に最終同期時刻を 1 回だけ読み取り、{@link SYNC_STALE_THRESHOLD_MINUTES} 分
+ * 以上経過していれば `triggerSync('lazy')` をバックグラウンドで呼ぶ。
+ * ref ガードで React.StrictMode の 2 重 fire と、親の再レンダリングによる再実行を防ぐ。
+ */
+export function useLazyCalendarSync({
+  triggerSync,
+  deps,
+}: UseLazyCalendarSyncOptions): void {
+  const hasRunRef = useRef(false);
+
+  useEffect(() => {
+    if (hasRunRef.current) return;
+    hasRunRef.current = true;
+
+    const getState = deps?.getState ?? defaultGetState;
+    const now = deps?.now ?? (() => new Date());
+
+    void (async () => {
+      try {
+        const state = await getState();
+        if (shouldTriggerLazy(state, now())) {
+          triggerSync("lazy");
+        }
+      } catch (err) {
+        // 状態取得に失敗したらユーザー操作 (手動ボタン) に任せる。
+        console.error("[lazy-sync] failed to read sync state", err);
+      }
+    })();
+  }, [triggerSync, deps]);
+}
+
+export function shouldTriggerLazy(
+  state: CalendarSyncState | null,
+  now: Date,
+): boolean {
+  if (!state) return true;
+  const then = new Date(state.lastSyncedAt).getTime();
+  if (Number.isNaN(then)) return true;
+  const elapsedMin = (now.getTime() - then) / 60000;
+  return elapsedMin >= SYNC_STALE_THRESHOLD_MINUTES;
+}
+
+async function defaultGetState(): Promise<CalendarSyncState | null> {
+  const supabase = createClient();
+  const gateway: CalendarSyncStateGateway = new SupabaseCalendarSyncStateGateway(
+    supabase,
+  );
+  return gateway.get();
+}

--- a/src/shared/types/database.ts
+++ b/src/shared/types/database.ts
@@ -194,6 +194,27 @@ export type Database = {
         };
         Relationships: [];
       };
+      user_calendar_sync_state: {
+        Row: {
+          user_id: string;
+          last_synced_at: string;
+          sync_token: string | null;
+          updated_at: string;
+        };
+        Insert: {
+          user_id: string;
+          last_synced_at: string;
+          sync_token?: string | null;
+          updated_at?: string;
+        };
+        Update: {
+          user_id?: string;
+          last_synced_at?: string;
+          sync_token?: string | null;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
     };
     Views: Record<string, never>;
     Functions: Record<string, never>;

--- a/supabase/migrations/20260424120000_user_calendar_sync_state.sql
+++ b/supabase/migrations/20260424120000_user_calendar_sync_state.sql
@@ -1,0 +1,30 @@
+-- kozutsumi Phase 2 (P2-3): Google Calendar 同期状態の永続化
+--
+-- References:
+-- * docs/adr/0007-google-calendar-sync-trigger-manual-and-lazy.md
+--   (最終同期時刻を元に「15 分以上経過していれば起動時遅延同期」を判定する)
+-- * docs/adr/0006-google-calendar-sync-mode-staged-adoption.md
+--   (P2-6 で `sync_token` に syncToken を保存する器を先に作る)
+
+create table public.user_calendar_sync_state (
+  user_id uuid primary key references auth.users (id) on delete cascade,
+  last_synced_at timestamptz not null,
+  sync_token text,
+  updated_at timestamptz not null default now()
+);
+
+alter table public.user_calendar_sync_state enable row level security;
+
+create policy "user_calendar_sync_state: owner can select"
+  on public.user_calendar_sync_state for select
+  using (user_id = auth.uid());
+create policy "user_calendar_sync_state: owner can insert"
+  on public.user_calendar_sync_state for insert
+  with check (user_id = auth.uid());
+create policy "user_calendar_sync_state: owner can update"
+  on public.user_calendar_sync_state for update
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+create policy "user_calendar_sync_state: owner can delete"
+  on public.user_calendar_sync_state for delete
+  using (user_id = auth.uid());


### PR DESCRIPTION
## Summary

- #51 (P2-3) 対応。`/api/calendar/sync` を **手動ボタン** + **起動時 15 分閾値の遅延実行** の 2 経路から叩けるようにした
- 401 (`provider_token_missing`) 受信時に `ReauthBanner` で Google 再同意 (calendar.readonly scope) に誘導
- `user_calendar_sync_state` テーブルで最終同期時刻を永続化、`calendar_synced` action_log（metadata: synced / deleted / trigger）も記録
- 関連 ADR: [0007](docs/adr/0007-google-calendar-sync-trigger-manual-and-lazy.md)（手動 + 起動時遅延）/ [0006](docs/adr/0006-google-calendar-sync-mode-staged-adoption.md)（`sync_token` 予約枠）

<details>
<summary>Phase 別コミット</summary>

| Phase | 内容 | Commit |
|---|---|---|
| 1 | `user_calendar_sync_state` テーブル + `CalendarSyncStateGateway` | `ba041fc` |
| 2 | `syncGoogleCalendar` に `last_synced_at` 永続化を接続 | `92245ac` |
| 3 | `calendar_synced` action_type 追加 | `3883c0c` |
| 4 | `useCalendarSync` hook + `CalendarSyncButton` + `ReauthBanner` + AppShell 組込 | `b1be1df` |
| 5 | `useLazyCalendarSync` hook + `SYNC_STALE_THRESHOLD_MINUTES=15` | `90d7ca5` |

全 Phase 自動コミット経路（critical/high 懸念・必達要件逸脱・judgment_flag すべて false）。
</details>

<details>
<summary>主要な設計判断</summary>

- sync state テーブルは P2-6 (#54) の差分同期で使う `sync_token` カラムを先に確保。upsert payload からは外すことで既存値を保持する。
- 401 は `provider_token_missing` / `unauthorized` を区別せず両方 Reauth 誘導扱い。AppShell は認証済みでのみレンダリングされる前提。
- 遅延自動同期は `ref` ガードで StrictMode の 2 重 fire と親再レンダリングでの再実行を防ぐ（既存 seed effect と同じパターン）。
- `last_synced_at` の upsert は `syncGoogleCalendar` 成功経路でのみ呼び、401 retry 失敗などの経路では書かない（古い値が残ることで次回 lazy sync が発火する）。

</details>

## Test plan

- [x] `npm test` (189 tests) / `npm run lint` / `npm run typecheck` すべて緑
- [x] 本番 Supabase 接続での E2E: ログイン → ヘッダーの「同期」ボタン → Google Calendar の予定が `events` に反映される
- [x] 本番: `provider_token` を expire させた状態で同期 → `ReauthBanner` が出て「Google と連携し直す」で再同意できる
- [x] 本番: 15 分以上経過したセッション再開で lazy sync が non-blocking で走り、15 分未満なら走らない
- [x] 本番: `action_logs` に `calendar_synced` が `trigger: 'manual' | 'lazy'` 付きで記録される

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)