### PR TITLE
feat(p2-4): google_calendar イベントの表示区別 + 編集制約 (#52)

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -223,6 +223,27 @@ export function AppShell({ initialView, user }: AppShellProps) {
     },
   });
 
+  // ADR 0010 / P2-4: google_calendar イベントは project_id だけ kozutsumi 側で
+  // 編集可。optimistic に反映し、失敗したら roll back する。
+  const updateEventProjectMutation = useMutation({
+    mutationFn: ({ id, projectId }: { id: string; projectId: string | null }) =>
+      eventGateway.update(id, { projectId }),
+    onMutate: async ({ id, projectId }) => {
+      await queryClient.cancelQueries({ queryKey: keys.events });
+      const previous = queryClient.getQueryData<Event[]>(keys.events);
+      queryClient.setQueryData<Event[]>(keys.events, (prev) =>
+        (prev ?? []).map((e) => (e.id === id ? { ...e, projectId } : e)),
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(keys.events, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: keys.events });
+    },
+  });
+
   const createProjectMutation = useMutation({
     mutationFn: (input: CreateProjectInput) => projectGateway.create(input),
     onSuccess: () => {
@@ -453,6 +474,9 @@ export function AppShell({ initialView, user }: AppShellProps) {
               <EventDetailPanel
                 event={ev}
                 onClose={() => setEventDetailId(null)}
+                onChangeProject={(id, projectId) =>
+                  updateEventProjectMutation.mutate({ id, projectId })
+                }
               />
             ) : null;
           })()}

--- a/src/entities/event/GoogleCalendarBadge.tsx
+++ b/src/entities/event/GoogleCalendarBadge.tsx
@@ -1,0 +1,29 @@
+/**
+ * `source === 'google_calendar'` のイベントに付与する小さな由来バッジ。
+ * ADR 0010: kozutsumi 側で編集できる属性が限られている (Google 側が正) ことを
+ * 視覚的に区別する。
+ */
+type Size = "sm" | "md";
+
+type Props = {
+  size?: Size;
+  className?: string;
+};
+
+export function GoogleCalendarBadge({ size = "sm", className }: Props) {
+  return (
+    <span
+      role="img"
+      aria-label="Google Calendar から同期"
+      title="Google Calendar から同期"
+      className={`inline-flex shrink-0 items-center justify-center rounded-[3px] border border-bg-divider bg-bg-elevated font-jp font-semibold leading-none text-fg-subtle ${
+        size === "md"
+          ? "h-[18px] w-[18px] text-[10px]"
+          : "h-[14px] w-[14px] text-[8px]"
+      } ${className ?? ""}`}
+      data-testid="google-calendar-badge"
+    >
+      G
+    </span>
+  );
+}

--- a/src/entities/event/supabase-gateway.test.ts
+++ b/src/entities/event/supabase-gateway.test.ts
@@ -1,0 +1,236 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { describe, expect, test, vi } from "vitest";
+
+import type { Database, Tables } from "@/shared/types/database";
+
+import type { UpdateEventInput } from "./gateway";
+import { SupabaseEventGateway } from "./supabase-gateway";
+
+type Sb = SupabaseClient<Database>;
+type EventRow = Tables<"events">;
+
+function makeRow(overrides: Partial<EventRow> = {}): EventRow {
+  return {
+    id: "e1",
+    user_id: "user-1",
+    title: "Test",
+    start_time: "2026-04-23T01:00:00.000Z",
+    end_time: "2026-04-23T02:00:00.000Z",
+    project_id: null,
+    meet_url: null,
+    has_attachments: false,
+    description: "",
+    source: "manual",
+    external_id: null,
+    created_at: "2026-04-23T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+/**
+ * Supabase fluent client のテスト用モック。
+ * `from(table)` を呼ぶと chain ビルダーを返し、終端 (single / maybeSingle / そのまま await) で
+ * `nextResults` の先頭を取り出す。テストごとに必要なレスポンスを順番に積む。
+ *
+ * - `select(...).eq(...).maybeSingle()` -> nextResults から { data, error }
+ * - `update(...).eq(...).select(...).single()` -> nextResults から { data, error }
+ * - `delete().eq(...)` -> nextResults から { error }
+ */
+function makeSupabase(opts: {
+  userId?: string;
+  results: Array<{
+    data?: unknown;
+    error?: { message: string } | null;
+  }>;
+}) {
+  const userId = opts.userId ?? "user-1";
+  const results = [...opts.results];
+
+  function takeResult() {
+    const next = results.shift();
+    if (!next) throw new Error("supabase mock: no more results queued");
+    return { data: next.data ?? null, error: next.error ?? null };
+  }
+
+  const calls: { table: string; method: string; args: unknown[] }[] = [];
+
+  function record(table: string, method: string, args: unknown[]) {
+    calls.push({ table, method, args });
+  }
+
+  function makeBuilder(table: string) {
+    const builder: Record<string, (...args: unknown[]) => unknown> = {};
+    builder.select = (...args) => {
+      record(table, "select", args);
+      return builder;
+    };
+    builder.update = (...args) => {
+      record(table, "update", args);
+      return builder;
+    };
+    builder.delete = (...args) => {
+      record(table, "delete", args);
+      return builder;
+    };
+    builder.eq = (...args) => {
+      record(table, "eq", args);
+      return builder;
+    };
+    builder.single = async () => {
+      record(table, "single", []);
+      return takeResult();
+    };
+    builder.maybeSingle = async () => {
+      record(table, "maybeSingle", []);
+      return takeResult();
+    };
+    // delete().eq(...) はそのまま await されるので thenable にする
+    (builder as { then?: unknown }).then = (
+      onFulfilled: (value: unknown) => unknown,
+    ) => {
+      record(table, "await", []);
+      return Promise.resolve(takeResult()).then(onFulfilled);
+    };
+    return builder;
+  }
+
+  const from = vi.fn((table: string) => makeBuilder(table));
+
+  const supabase = {
+    auth: {
+      getUser: vi.fn(async () => ({
+        data: { user: { id: userId } },
+        error: null,
+      })),
+    },
+    from,
+  } as unknown as Sb;
+
+  return { supabase, from, calls };
+}
+
+// ---------------------------------------------------------------------------
+// update: ADR 0010 / P2-4 — google_calendar の Google 側属性は read-only
+// ---------------------------------------------------------------------------
+describe("SupabaseEventGateway.update", () => {
+  test("manual: title など Google 由来属性も更新できる", async () => {
+    const updated = makeRow({ title: "Renamed", source: "manual" });
+    const { supabase, calls } = makeSupabase({
+      results: [
+        { data: { source: "manual" } }, // fetchSource
+        { data: updated }, // update().eq().select().single()
+      ],
+    });
+    const gw = new SupabaseEventGateway(supabase);
+
+    const result = await gw.update("e1", { title: "Renamed" });
+
+    expect(result.title).toBe("Renamed");
+    // fetchSource → update の順で events テーブルを叩いている
+    const eventsCalls = calls.filter((c) => c.table === "events");
+    expect(eventsCalls[0]).toMatchObject({ method: "select", args: ["source"] });
+    expect(
+      eventsCalls.some(
+        (c) =>
+          c.method === "update" &&
+          (c.args[0] as Record<string, unknown>).title === "Renamed",
+      ),
+    ).toBe(true);
+  });
+
+  test("google_calendar: projectId のみの更新は許可 (source 確認すらスキップ)", async () => {
+    const updated = makeRow({
+      project_id: "slo",
+      source: "google_calendar",
+      external_id: "ext-1",
+    });
+    const { supabase, calls } = makeSupabase({
+      results: [
+        { data: updated }, // update のみ。fetchSource は呼ばれない
+      ],
+    });
+    const gw = new SupabaseEventGateway(supabase);
+
+    const result = await gw.update("g1", { projectId: "slo" });
+
+    expect(result.projectId).toBe("slo");
+    // select("source") は呼ばれていない (touchesGoogleOwned が false なので)
+    const sourceSelects = calls.filter(
+      (c) => c.method === "select" && (c.args[0] as string) === "source",
+    );
+    expect(sourceSelects).toHaveLength(0);
+  });
+
+  test("google_calendar: title の更新は throw する", async () => {
+    const { supabase } = makeSupabase({
+      results: [
+        { data: { source: "google_calendar" } }, // fetchSource
+      ],
+    });
+    const gw = new SupabaseEventGateway(supabase);
+
+    await expect(gw.update("g1", { title: "Hijack" })).rejects.toThrow(
+      /google_calendar event is read-only/,
+    );
+  });
+
+  test("google_calendar: meetUrl / description / startTime なども throw する", async () => {
+    const cases: UpdateEventInput[] = [
+      { meetUrl: "https://evil.example/" },
+      { description: "tampered" },
+      { startTime: "2099-01-01T00:00:00.000Z" },
+      { endTime: "2099-01-01T01:00:00.000Z" },
+      { hasAttachments: true },
+    ];
+    for (const patch of cases) {
+      const { supabase } = makeSupabase({
+        results: [{ data: { source: "google_calendar" } }],
+      });
+      const gw = new SupabaseEventGateway(supabase);
+      await expect(gw.update("g1", patch)).rejects.toThrow(
+        /google_calendar event is read-only/,
+      );
+    }
+  });
+
+  test("google_calendar: projectId と title を同時更新も throw (Google 側属性が混ざっていれば NG)", async () => {
+    const { supabase } = makeSupabase({
+      results: [{ data: { source: "google_calendar" } }],
+    });
+    const gw = new SupabaseEventGateway(supabase);
+
+    await expect(
+      gw.update("g1", { projectId: "slo", title: "x" }),
+    ).rejects.toThrow(/google_calendar event is read-only/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// delete: ADR 0010 / P2-4 — google_calendar は UI から削除不可
+// ---------------------------------------------------------------------------
+describe("SupabaseEventGateway.delete", () => {
+  test("manual: 削除できる", async () => {
+    const { supabase } = makeSupabase({
+      results: [
+        { data: { source: "manual" } }, // fetchSource
+        { data: null }, // delete().eq() の await
+      ],
+    });
+    const gw = new SupabaseEventGateway(supabase);
+
+    await expect(gw.delete("e1")).resolves.toBeUndefined();
+  });
+
+  test("google_calendar: 削除は throw する", async () => {
+    const { supabase } = makeSupabase({
+      results: [
+        { data: { source: "google_calendar" } }, // fetchSource
+      ],
+    });
+    const gw = new SupabaseEventGateway(supabase);
+
+    await expect(gw.delete("g1")).rejects.toThrow(
+      /google_calendar event cannot be deleted/,
+    );
+  });
+});

--- a/src/entities/event/supabase-gateway.ts
+++ b/src/entities/event/supabase-gateway.ts
@@ -77,6 +77,23 @@ export class SupabaseEventGateway implements EventGateway {
   }
 
   async update(id: string, patch: UpdateEventInput): Promise<Event> {
+    // ADR 0010: source='google_calendar' の行は project_id 以外を kozutsumi 側で更新不可。
+    // UI を bypass されてもガードできるよう、ここでも source を確認する。
+    const touchesGoogleOwned =
+      patch.title !== undefined ||
+      patch.startTime !== undefined ||
+      patch.endTime !== undefined ||
+      patch.meetUrl !== undefined ||
+      patch.hasAttachments !== undefined ||
+      patch.description !== undefined;
+    if (touchesGoogleOwned) {
+      const source = await this.fetchSource(id);
+      if (source === EVENT_SOURCE.GOOGLE_CALENDAR) {
+        throw new Error(
+          "google_calendar event is read-only (only project_id can be updated)",
+        );
+      }
+    }
     const update: TablesUpdate<"events"> = {};
     if (patch.title !== undefined) update.title = patch.title;
     if (patch.startTime !== undefined) update.start_time = patch.startTime;
@@ -97,8 +114,29 @@ export class SupabaseEventGateway implements EventGateway {
   }
 
   async delete(id: string): Promise<void> {
+    // ADR 0010: source='google_calendar' の行は UI からは削除不可
+    // (Google 側で削除すれば次回同期で消える)。
+    const source = await this.fetchSource(id);
+    if (source === EVENT_SOURCE.GOOGLE_CALENDAR) {
+      throw new Error(
+        "google_calendar event cannot be deleted from kozutsumi (delete it on Google Calendar)",
+      );
+    }
     const { error } = await this.supabase.from("events").delete().eq("id", id);
     if (error) throw error;
+  }
+
+  /**
+   * 単一行の source だけを取得する。RLS 違反 / 行未発見時は null を返す。
+   */
+  private async fetchSource(id: string): Promise<Event["source"] | null> {
+    const { data, error } = await this.supabase
+      .from("events")
+      .select("source")
+      .eq("id", id)
+      .maybeSingle();
+    if (error) throw error;
+    return data?.source ?? null;
   }
 
   async deleteAllForCurrentUser(): Promise<void> {

--- a/src/features/day-timeline/EventCard.test.tsx
+++ b/src/features/day-timeline/EventCard.test.tsx
@@ -66,4 +66,28 @@ describe("EventCard", () => {
     );
     expect(getByText("NOW")).toBeTruthy();
   });
+
+  test("source=manual なら Google バッジは表示しない", () => {
+    const { queryByTestId } = render(
+      <EventCard
+        event={baseEvent}
+        nowMin={0}
+        isNextCandidate={false}
+        onClick={() => {}}
+      />,
+    );
+    expect(queryByTestId("google-calendar-badge")).toBeNull();
+  });
+
+  test("source=google_calendar なら Google バッジを表示する", () => {
+    const { getByTestId } = render(
+      <EventCard
+        event={{ ...baseEvent, source: "google_calendar", externalId: "g1" }}
+        nowMin={0}
+        isNextCandidate={false}
+        onClick={() => {}}
+      />,
+    );
+    expect(getByTestId("google-calendar-badge")).toBeTruthy();
+  });
 });

--- a/src/features/day-timeline/EventCard.tsx
+++ b/src/features/day-timeline/EventCard.tsx
@@ -1,4 +1,4 @@
-import type { Event } from "../../entities/event/types";
+import { EVENT_SOURCE, type Event } from "../../entities/event/types";
 import { getProject } from "../../entities/project/projects";
 import { useProjects } from "../../entities/project/ProjectsContext";
 import {
@@ -6,6 +6,7 @@ import {
   formatClock,
   minutesOfDay,
 } from "../../shared/lib/time";
+import { GoogleCalendarBadge } from "../../entities/event/GoogleCalendarBadge";
 
 type EventCardProps = {
   event: Event;
@@ -28,6 +29,7 @@ export function EventCard({ event, nowMin, isNextCandidate, onClick }: EventCard
   const hasMeet = !!event.meetUrl;
   const meetLabel = event.meetUrl?.includes("zoom") ? "Zoom" : "Meet";
   const isZoom = !!event.meetUrl?.includes("zoom");
+  const isGoogleCalendar = event.source === EVENT_SOURCE.GOOGLE_CALENDAR;
 
   return (
     <div
@@ -55,6 +57,7 @@ export function EventCard({ event, nowMin, isNextCandidate, onClick }: EventCard
         >
           {event.title}
         </span>
+        {isGoogleCalendar && <GoogleCalendarBadge />}
         {hasAttachments && (
           <svg
             width="12"

--- a/src/features/event-detail/EventDetailPanel.test.tsx
+++ b/src/features/event-detail/EventDetailPanel.test.tsx
@@ -7,6 +7,7 @@ import { EventDetailPanel } from "./EventDetailPanel";
 
 const projects: Project[] = [
   { id: "slo", name: "SLO推進", color: "#2D9F45", isPrimary: true, createdAt: "" },
+  { id: "career", name: "転職活動", color: "#E85D04", isPrimary: false, createdAt: "" },
 ];
 const render = (ui: React.ReactElement) =>
   rtlRender(<ProjectsProvider projects={projects}>{ui}</ProjectsProvider>);
@@ -25,9 +26,22 @@ const baseEvent: Event = {
   createdAt: "2026-04-11T00:00:00",
 };
 
+const googleEvent: Event = {
+  ...baseEvent,
+  id: "g1",
+  source: "google_calendar",
+  externalId: "ext-1",
+};
+
 const noop = () => {};
 
-function renderPanel(overrides: Partial<{ event: Event; onClose: () => void }> = {}) {
+function renderPanel(
+  overrides: Partial<{
+    event: Event;
+    onClose: () => void;
+    onChangeProject: (id: string, projectId: string | null) => void;
+  }> = {},
+) {
   const props = { event: baseEvent, onClose: noop, ...overrides };
   return render(<EventDetailPanel {...props} />);
 }
@@ -97,5 +111,75 @@ describe("EventDetailPanel", () => {
     const backdrop = container.firstElementChild!.firstElementChild!;
     fireEvent.click(backdrop);
     expect(onClose).toHaveBeenCalled();
+  });
+
+  // ADR 0010 / P2-4: source 別の編集制約
+  describe("source による表示・編集制約", () => {
+    test("manual: Google バッジ・補足テキスト・project 編集 UI を出さない", () => {
+      const { queryByTestId, queryByText } = renderPanel({
+        onChangeProject: vi.fn(),
+      });
+      expect(queryByTestId("google-calendar-badge")).toBeNull();
+      expect(
+        queryByText(/Google Calendar で編集した内容は次回同期で反映されます/),
+      ).toBeNull();
+      expect(queryByText(/を変更$/)).toBeNull();
+    });
+
+    test("google_calendar: Google バッジと同期補足テキストを出す", () => {
+      const { getByTestId, getByText } = renderPanel({ event: googleEvent });
+      expect(getByTestId("google-calendar-badge")).toBeTruthy();
+      expect(
+        getByText(/Google Calendar で編集した内容は次回同期で反映されます/),
+      ).toBeTruthy();
+    });
+
+    test("google_calendar: onChangeProject 未指定なら project 編集 UI を出さない", () => {
+      const { queryByText } = renderPanel({ event: googleEvent });
+      expect(queryByText(/を変更$/)).toBeNull();
+    });
+
+    test("google_calendar: project 変更ボタンから select に切り替わる", () => {
+      const onChangeProject = vi.fn();
+      const { getByText, getByRole } = renderPanel({
+        event: googleEvent,
+        onChangeProject,
+      });
+      fireEvent.click(getByText(/を変更$/));
+      const select = getByRole("combobox") as HTMLSelectElement;
+      expect(select.value).toBe("slo");
+    });
+
+    test("google_calendar: select で project を変えると onChangeProject が呼ばれる", () => {
+      const onChangeProject = vi.fn();
+      const { getByText, getByRole } = renderPanel({
+        event: googleEvent,
+        onChangeProject,
+      });
+      fireEvent.click(getByText(/を変更$/));
+      fireEvent.change(getByRole("combobox"), { target: { value: "career" } });
+      expect(onChangeProject).toHaveBeenCalledWith("g1", "career");
+    });
+
+    test("google_calendar: project を「なし」にすると null で呼ばれる", () => {
+      const onChangeProject = vi.fn();
+      const { getByText, getByRole } = renderPanel({
+        event: googleEvent,
+        onChangeProject,
+      });
+      fireEvent.click(getByText(/を変更$/));
+      fireEvent.change(getByRole("combobox"), { target: { value: "" } });
+      expect(onChangeProject).toHaveBeenCalledWith("g1", null);
+    });
+
+    test("どの source でも「削除」ボタンは表示されない", () => {
+      const m = renderPanel();
+      expect(m.queryByText("削除")).toBeNull();
+      const g = renderPanel({
+        event: googleEvent,
+        onChangeProject: vi.fn(),
+      });
+      expect(g.queryByText("削除")).toBeNull();
+    });
   });
 });

--- a/src/features/event-detail/EventDetailPanel.tsx
+++ b/src/features/event-detail/EventDetailPanel.tsx
@@ -1,4 +1,7 @@
-import type { Event } from "../../entities/event/types";
+import { useState } from "react";
+
+import { EVENT_SOURCE, type Event } from "../../entities/event/types";
+import { GoogleCalendarBadge } from "../../entities/event/GoogleCalendarBadge";
 import { getProject } from "../../entities/project/projects";
 import { useProjects } from "../../entities/project/ProjectsContext";
 import {
@@ -11,10 +14,19 @@ import { renderMarkdown } from "../../shared/lib/markdown";
 type EventDetailPanelProps = {
   event: Event;
   onClose: () => void;
+  /**
+   * `source === 'google_calendar'` のイベントで `project_id` を変更したい時に呼ぶ。
+   * 未指定なら project_id 編集 UI も表示しない (省略可で既存呼び出しを壊さない)。
+   */
+  onChangeProject?: (id: string, projectId: string | null) => void;
 };
 
-export function EventDetailPanel({ event, onClose }: EventDetailPanelProps) {
-  const { projectsById } = useProjects();
+export function EventDetailPanel({
+  event,
+  onClose,
+  onChangeProject,
+}: EventDetailPanelProps) {
+  const { projects, projectsById } = useProjects();
   const proj = event.projectId ? getProject(projectsById, event.projectId) : null;
   const evColor = proj ? proj.color : "#52525b";
   const evStart = minutesOfDay(event.startTime);
@@ -26,6 +38,11 @@ export function EventDetailPanel({ event, onClose }: EventDetailPanelProps) {
     : event.meetUrl?.includes("meet.google")
       ? "Google Meet"
       : "会議リンク";
+  const isGoogleCalendar = event.source === EVENT_SOURCE.GOOGLE_CALENDAR;
+  // ADR 0010: google_calendar イベントは project_id だけ kozutsumi 側で編集可。
+  // onChangeProject が渡されている時のみ編集 UI を出す (テストや特殊呼び出しで省略可)。
+  const canEditProject = isGoogleCalendar && !!onChangeProject;
+  const [editingProject, setEditingProject] = useState(false);
 
   return (
     <div className="fixed inset-0 z-[200] flex flex-col">
@@ -59,6 +76,7 @@ export function EventDetailPanel({ event, onClose }: EventDetailPanelProps) {
             <span className="text-[10px] tabular-nums text-fg-weak">
               {formatClock(event.startTime)}–{formatClock(event.endTime)} ({fmtDuration(duration)})
             </span>
+            {isGoogleCalendar && <GoogleCalendarBadge size="md" />}
           </div>
           <h2 className="m-0 font-jp text-[16px] font-bold leading-[1.4] text-fg-strong">
             {event.title}
@@ -126,6 +144,44 @@ export function EventDetailPanel({ event, onClose }: EventDetailPanelProps) {
           </div>
         )}
 
+        {canEditProject && (
+          <div className="px-5 pb-2">
+            <div className="flex items-center gap-2">
+              <span className="font-jp text-[10px] text-fg-weak">
+                プロジェクト
+              </span>
+              {editingProject ? (
+                <select
+                  autoFocus
+                  value={event.projectId ?? ""}
+                  onChange={(e) => {
+                    const next = e.target.value === "" ? null : e.target.value;
+                    onChangeProject!(event.id, next);
+                    setEditingProject(false);
+                  }}
+                  onBlur={() => setEditingProject(false)}
+                  className="flex-1 rounded border border-bg-divider bg-bg-elevated px-2 py-1 text-[11px] text-fg-default outline-none focus:border-accent-blue"
+                >
+                  <option value="">なし</option>
+                  {projects.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setEditingProject(true)}
+                  className="cursor-pointer rounded-[4px] border border-bg-divider bg-transparent px-2 py-[3px] font-jp text-[10px] text-fg-subtle"
+                >
+                  {proj ? proj.name : "未設定"} を変更
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+
         <div className="mx-5 h-px bg-bg-border" />
 
         <div className="flex-1 overflow-auto px-5 pb-6 pt-3">
@@ -134,6 +190,11 @@ export function EventDetailPanel({ event, onClose }: EventDetailPanelProps) {
           ) : (
             <div className="py-5 text-center font-jp text-[12px] italic text-fg-faint">
               詳細なし
+            </div>
+          )}
+          {isGoogleCalendar && (
+            <div className="mt-4 font-jp text-[10px] leading-[1.6] text-fg-faint">
+              Google Calendar で編集した内容は次回同期で反映されます
             </div>
           )}
         </div>


### PR DESCRIPTION
ADR 0010 に従い、google_calendar 由来イベントを kozutsumi 側で誤って
編集・削除できないようガードする。

- EventCard / EventDetailPanel に Google Calendar バッジ ("G")
- EventDetailPanel: source=google_calendar の時だけ project_id 編集 UI
  と「Google Calendar で編集した内容は次回同期で反映されます」を表示
- SupabaseEventGateway.update: google_calendar 行の Google 側属性
  (title / start_time / end_time / meet_url / has_attachments / description)
  への変更を throw する
- SupabaseEventGateway.delete: google_calendar 行の単体削除を throw する
- manual イベントの挙動は変更なし