### PR TITLE
feat(p2-5): タスクの依存イベント設定 UI (#53)

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -44,7 +44,7 @@ import {
   writeSampleDataMode,
 } from "@/shared/lib/sample-data";
 import { isDone } from "@/shared/lib/task";
-import { nowMinutesOfDay, todayIso } from "@/shared/lib/time";
+import { todayIso } from "@/shared/lib/time";
 
 type View = "stack" | "tree";
 
@@ -100,17 +100,25 @@ export function AppShell({ initialView, user }: AppShellProps) {
   const [detailId, setDetailId] = useState<string | null>(null);
   const [eventDetailId, setEventDetailId] = useState<string | null>(null);
   const [addOpen, setAddOpen] = useState(false);
-  const [nowMin, setNowMin] = useState<number>(9 * 60);
+  // ms 表現の「今」。SSR は 0 placeholder で hydration mismatch を回避し、
+  // mount 後に実時刻へ差し替える。nowMin (タイムライン用) と依存イベント比較用に共用する。
+  const [nowMs, setNowMs] = useState<number>(0);
   const today = useMemo(() => todayIso(), []);
 
   useEffect(() => {
     // マウント後にローカル時刻と同期する。SSR 時 nowMinutesOfDay() はブラウザ API 依存のため不可。
     /* eslint-disable react-hooks/set-state-in-effect */
-    setNowMin(nowMinutesOfDay());
+    setNowMs(Date.now());
     /* eslint-enable react-hooks/set-state-in-effect */
-    const id = window.setInterval(() => setNowMin(nowMinutesOfDay()), 60_000);
+    const id = window.setInterval(() => setNowMs(Date.now()), 60_000);
     return () => window.clearInterval(id);
   }, []);
+
+  const nowMin = useMemo(() => {
+    if (nowMs === 0) return 9 * 60;
+    const d = new Date(nowMs);
+    return d.getHours() * 60 + d.getMinutes();
+  }, [nowMs]);
 
   // 初回ログイン時に自動 seed: 全テーブル空かつ「cleared」フラグ無しなら投入する。
   // ref ガードでストリクトモードでの 2 重 fire を防ぎつつ、ローディング完了後 1 回だけ実行。
@@ -192,6 +200,47 @@ export function AppShell({ initialView, user }: AppShellProps) {
       const previous = queryClient.getQueryData<Task[]>(keys.tasks);
       queryClient.setQueryData<Task[]>(keys.tasks, (prev) =>
         (prev ?? []).map((t) => (t.id === id ? { ...t, body } : t)),
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(keys.tasks, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: keys.tasks });
+    },
+  });
+
+  // P2-5 (#53): タスクの依存イベント設定。set / cleared を action_log に残し、
+  // Phase 4 で「依存設定が着手順に効いたか」の分析データに使う。
+  const updateDependencyMutation = useMutation({
+    mutationFn: ({
+      id,
+      dependsOnEventId,
+    }: {
+      id: string;
+      dependsOnEventId: string | null;
+    }) => taskGateway.update(id, { dependsOnEventId }),
+    onMutate: async ({ id, dependsOnEventId }) => {
+      await queryClient.cancelQueries({ queryKey: keys.tasks });
+      const previous = queryClient.getQueryData<Task[]>(keys.tasks);
+      const target = previous?.find((t) => t.id === id);
+      const was = target?.dependsOnEventId ?? null;
+      if (was !== dependsOnEventId) {
+        if (dependsOnEventId) {
+          log(ACTION_TYPES.TASK_DEPENDENCY_SET, {
+            task_id: id,
+            event_id: dependsOnEventId,
+            was,
+          });
+        } else if (was) {
+          log(ACTION_TYPES.TASK_DEPENDENCY_CLEARED, { task_id: id, was });
+        }
+      }
+      queryClient.setQueryData<Task[]>(keys.tasks, (prev) =>
+        (prev ?? []).map((t) =>
+          t.id === id ? { ...t, dependsOnEventId } : t,
+        ),
       );
       return { previous };
     },
@@ -445,6 +494,7 @@ export function AppShell({ initialView, user }: AppShellProps) {
             toggleDone={toggleDone}
             reorder={reorder}
             nowMin={nowMin}
+            now={nowMs}
             today={today}
             onOpenDetail={setDetailId}
             onOpenEvent={setEventDetailId}
@@ -460,10 +510,14 @@ export function AppShell({ initialView, user }: AppShellProps) {
           <TaskDetailPanel
             task={detailTask}
             events={events}
+            now={nowMs}
             onClose={() => setDetailId(null)}
             onUpdate={updateBody}
             onToggleDone={toggleDone}
             onDelete={(id) => deleteTaskMutation.mutate(id)}
+            onChangeDependency={(id, dependsOnEventId) =>
+              updateDependencyMutation.mutate({ id, dependsOnEventId })
+            }
           />
         )}
 
@@ -568,6 +622,7 @@ type StackViewProps = {
   toggleDone: (id: string) => void;
   reorder: (from: number, to: number) => void;
   nowMin: number;
+  now: number;
   today: string;
   onOpenDetail: (id: string) => void;
   onOpenEvent: (id: string) => void;
@@ -581,6 +636,7 @@ function StackView({
   toggleDone,
   reorder,
   nowMin,
+  now,
   today,
   onOpenDetail,
   onOpenEvent,
@@ -598,6 +654,7 @@ function StackView({
         pendingTasks={pendingTasks}
         doneTasks={doneTasks}
         topTimer={topTimer}
+        now={now}
         onReorder={reorder}
         onToggleDone={toggleDone}
         onOpenDetail={onOpenDetail}

--- a/src/entities/action-log/logger.test.ts
+++ b/src/entities/action-log/logger.test.ts
@@ -155,6 +155,8 @@ describe("ACTION_TYPES", () => {
       TASK_REORDERED: "task_reordered",
       TASK_DELETED: "task_deleted",
       TASK_TITLE_CHANGED: "task_title_changed",
+      TASK_DEPENDENCY_SET: "task_dependency_set",
+      TASK_DEPENDENCY_CLEARED: "task_dependency_cleared",
       INTERRUPTION_PUSHED: "interruption_pushed",
       INTERRUPTION_COMPLETED: "interruption_completed",
       STACK_PROPOSED: "stack_proposed",

--- a/src/entities/action-log/logger.ts
+++ b/src/entities/action-log/logger.ts
@@ -28,6 +28,8 @@ export const ACTION_TYPES = Object.freeze({
   TASK_REORDERED: "task_reordered",
   TASK_DELETED: "task_deleted",
   TASK_TITLE_CHANGED: "task_title_changed",
+  TASK_DEPENDENCY_SET: "task_dependency_set",
+  TASK_DEPENDENCY_CLEARED: "task_dependency_cleared",
   INTERRUPTION_PUSHED: "interruption_pushed",
   INTERRUPTION_COMPLETED: "interruption_completed",
   STACK_PROPOSED: "stack_proposed",

--- a/src/entities/action-log/types.ts
+++ b/src/entities/action-log/types.ts
@@ -6,6 +6,8 @@ export type ActionType =
   | "task_reordered"
   | "task_deleted"
   | "task_title_changed"
+  | "task_dependency_set"
+  | "task_dependency_cleared"
   | "interruption_pushed"
   | "interruption_completed"
   | "stack_proposed"
@@ -36,6 +38,16 @@ export type ActionMetadataMap = {
     task_id: string;
     old_title: string;
     new_title: string;
+  };
+  // Phase 2 #53: 依存イベントの設定 / 解除。Phase 4 で「依存設定が着手順に効いたか」の分析データに使う。
+  task_dependency_set: {
+    task_id: string;
+    event_id: string;
+    was: string | null;
+  };
+  task_dependency_cleared: {
+    task_id: string;
+    was: string;
   };
   interruption_pushed: { task_id: string };
   interruption_completed: { task_id: string };

--- a/src/features/add-forms/TaskForm.tsx
+++ b/src/features/add-forms/TaskForm.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import type { CreateTaskInput } from "@/entities/task/gateway";
 import type { Event } from "@/entities/event/types";
 import type { Project } from "@/entities/project/types";
-import { formatClock } from "@/shared/lib/time";
+import { formatRelativeTime } from "@/shared/lib/time";
 
 type TaskFormProps = {
   projects: readonly Project[];
@@ -25,6 +25,21 @@ export function TaskForm({ projects, events, onSubmit, onClose }: TaskFormProps)
   const [dependsOnEventId, setDependsOnEventId] = useState<string>("");
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // フォーム open 時刻を「今」として固定する。フォーム滞在中に分跨ぎしても候補が
+  // ばたつかないようにする。manual / google_calendar 両対応。
+  const [openedAt] = useState<number>(() => Date.now());
+
+  // 依存イベントは「未来 (現在時刻以降に開始する)」イベントのみを候補に出す。
+  // 過去のイベントを依存先に新規設定しても意味がないため。
+  const futureEvents = useMemo(() => {
+    return [...events]
+      .filter((ev) => new Date(ev.startTime).getTime() >= openedAt)
+      .sort(
+        (a, b) =>
+          new Date(a.startTime).getTime() - new Date(b.startTime).getTime(),
+      );
+  }, [events, openedAt]);
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -111,9 +126,9 @@ export function TaskForm({ projects, events, onSubmit, onClose }: TaskFormProps)
           className="rounded border border-bg-divider bg-bg-elevated px-3 py-2 text-[13px] text-fg-default outline-none focus:border-accent-blue"
         >
           <option value="">なし</option>
-          {events.map((ev) => (
+          {futureEvents.map((ev) => (
             <option key={ev.id} value={ev.id}>
-              {formatClock(ev.startTime)} {ev.title}
+              {formatRelativeTime(ev.startTime, new Date(openedAt))}  {ev.title}
             </option>
           ))}
         </select>

--- a/src/features/task-detail/TaskDetailPanel.test.tsx
+++ b/src/features/task-detail/TaskDetailPanel.test.tsx
@@ -1,10 +1,20 @@
 import { fireEvent, render as rtlRender } from "@testing-library/react";
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { Task } from "../../entities/task/types";
 import type { Event } from "../../entities/event/types";
 import type { Project } from "../../entities/project/types";
 import { ProjectsProvider } from "../../entities/project/ProjectsContext";
 import { TaskDetailPanel, type TaskDetailPanelProps } from "./TaskDetailPanel";
+
+// 依存イベント表示は現在時刻依存。テストは固定時刻 2026-04-11T09:00 で評価する。
+const FIXED_NOW = new Date("2026-04-11T09:00:00");
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(FIXED_NOW);
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 const projects: Project[] = [
   { id: "slo", name: "SLO推進", color: "#2D9F45", isPrimary: true, createdAt: "" },
@@ -96,7 +106,7 @@ describe("TaskDetailPanel", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  test("dependsOnEventId がある場合、依存イベントの時刻バッジを表示", () => {
+  test("dependsOnEventId がある場合、依存イベントの相対時刻 + タイトルバッジを表示", () => {
     const events: Event[] = [
       {
         id: "e1",
@@ -116,7 +126,155 @@ describe("TaskDetailPanel", () => {
       task: { ...baseTask, dependsOnEventId: "e1" },
       events,
     });
-    expect(getByText("← 14:00までに")).toBeTruthy();
+    expect(getByText(/今日 14:00 MTG/)).toBeTruthy();
+  });
+
+  test("onChangeDependency 未指定なら依存編集 UI を表示しない", () => {
+    const { queryByText } = renderPanel();
+    expect(queryByText("依存イベント")).toBeNull();
+  });
+
+  test("onChangeDependency 指定時は依存編集ボタンを表示する", () => {
+    const { getByText } = renderPanel({ onChangeDependency: vi.fn() });
+    expect(getByText("依存イベント")).toBeTruthy();
+    expect(getByText(/なし.*を変更/)).toBeTruthy();
+  });
+
+  test("依存編集 → 未来イベントを選択すると onChangeDependency(taskId, eventId) を呼ぶ", () => {
+    const onChangeDependency = vi.fn();
+    const events: Event[] = [
+      {
+        id: "e1",
+        title: "MTG",
+        startTime: "2026-04-11T14:00:00",
+        endTime: "2026-04-11T15:00:00",
+        projectId: "slo",
+        meetUrl: null,
+        hasAttachments: false,
+        description: "",
+        source: "manual",
+        externalId: null,
+        createdAt: "2026-04-11T00:00:00",
+      },
+    ];
+    const { getByText, getByRole } = renderPanel({
+      events,
+      onChangeDependency,
+    });
+    fireEvent.click(getByText(/なし.*を変更/));
+    fireEvent.change(getByRole("combobox"), { target: { value: "e1" } });
+    expect(onChangeDependency).toHaveBeenCalledWith("t1", "e1");
+  });
+
+  test("依存設定済 → 「なし」を選ぶと onChangeDependency(taskId, null) を呼ぶ", () => {
+    const onChangeDependency = vi.fn();
+    const events: Event[] = [
+      {
+        id: "e1",
+        title: "MTG",
+        startTime: "2026-04-11T14:00:00",
+        endTime: "2026-04-11T15:00:00",
+        projectId: "slo",
+        meetUrl: null,
+        hasAttachments: false,
+        description: "",
+        source: "manual",
+        externalId: null,
+        createdAt: "2026-04-11T00:00:00",
+      },
+    ];
+    const { getByText, getByRole } = renderPanel({
+      task: { ...baseTask, dependsOnEventId: "e1" },
+      events,
+      onChangeDependency,
+    });
+    fireEvent.click(getByText(/MTG.*を変更/));
+    fireEvent.change(getByRole("combobox"), { target: { value: "" } });
+    expect(onChangeDependency).toHaveBeenCalledWith("t1", null);
+  });
+
+  test("依存先未設定の編集候補に過去イベントは出ない", () => {
+    const past: Event = {
+      id: "past",
+      title: "過去MTG",
+      startTime: "2026-04-10T14:00:00",
+      endTime: "2026-04-10T15:00:00",
+      projectId: "slo",
+      meetUrl: null,
+      hasAttachments: false,
+      description: "",
+      source: "manual",
+      externalId: null,
+      createdAt: "2026-04-09T00:00:00",
+    };
+    const future: Event = {
+      id: "future",
+      title: "未来MTG",
+      startTime: "2026-04-12T10:00:00",
+      endTime: "2026-04-12T11:00:00",
+      projectId: "slo",
+      meetUrl: null,
+      hasAttachments: false,
+      description: "",
+      source: "manual",
+      externalId: null,
+      createdAt: "2026-04-09T00:00:00",
+    };
+    const { getByText, queryByText } = renderPanel({
+      events: [past, future],
+      onChangeDependency: vi.fn(),
+    });
+    fireEvent.click(getByText(/なし.*を変更/));
+    expect(queryByText(/過去MTG/)).toBeNull();
+    expect(getByText(/未来MTG/)).toBeTruthy();
+  });
+
+  test("依存先が過去イベント (削除されず残ってる) の場合は候補に保持される", () => {
+    const past: Event = {
+      id: "past",
+      title: "過去MTG",
+      startTime: "2026-04-10T14:00:00",
+      endTime: "2026-04-10T15:00:00",
+      projectId: "slo",
+      meetUrl: null,
+      hasAttachments: false,
+      description: "",
+      source: "manual",
+      externalId: null,
+      createdAt: "2026-04-09T00:00:00",
+    };
+    const future: Event = {
+      id: "future",
+      title: "未来MTG",
+      startTime: "2026-04-12T10:00:00",
+      endTime: "2026-04-12T11:00:00",
+      projectId: "slo",
+      meetUrl: null,
+      hasAttachments: false,
+      description: "",
+      source: "manual",
+      externalId: null,
+      createdAt: "2026-04-09T00:00:00",
+    };
+    const { getByText, getAllByRole } = renderPanel({
+      task: { ...baseTask, dependsOnEventId: "past" },
+      events: [past, future],
+      onChangeDependency: vi.fn(),
+    });
+    fireEvent.click(getByText(/過去MTG.*を変更/));
+    const options = getAllByRole("option");
+    const labels = options.map((o) => o.textContent ?? "");
+    expect(labels.some((l) => l.includes("過去MTG"))).toBe(true);
+    expect(labels.some((l) => l.includes("未来MTG"))).toBe(true);
+  });
+
+  test("dependsOnEventId が events に無い (削除済) 場合は依存表示を出さない", () => {
+    const { queryByText } = renderPanel({
+      task: { ...baseTask, dependsOnEventId: "missing" },
+      events: [],
+    });
+    // ヘッダの依存バッジは出ない (event 解決失敗 → null)
+    expect(queryByText(/MTG/)).toBeNull();
   });
 
   test("body が空なら「詳細を追加...」プレースホルダー", () => {

--- a/src/features/task-detail/TaskDetailPanel.tsx
+++ b/src/features/task-detail/TaskDetailPanel.tsx
@@ -1,30 +1,66 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import type { Task } from "../../entities/task/types";
 import type { Event } from "../../entities/event/types";
 import { getProject } from "../../entities/project/projects";
 import { useProjects } from "../../entities/project/ProjectsContext";
 import { isDone } from "../../shared/lib/task";
-import { fmtDuration, formatClock } from "../../shared/lib/time";
+import { fmtDuration, formatRelativeTime } from "../../shared/lib/time";
 import { renderMarkdown } from "../../shared/lib/markdown";
 
 export type TaskDetailPanelProps = {
   task: Task;
   events: Event[];
+  /** 現在時刻 (ms)。依存イベントの相対時刻 / 候補絞り込みに使う。省略時は呼び出し時刻。 */
+  now?: number;
   onClose: () => void;
   onUpdate: (id: string, body: string) => void;
   onToggleDone: (id: string) => void;
   onDelete?: (id: string) => void;
+  /**
+   * 依存イベント (`tasks.depends_on_event_id`) の更新。null は「依存なし」。
+   * 未指定なら依存編集 UI も表示しない (テストや特殊呼び出しで省略可)。
+   */
+  onChangeDependency?: (id: string, eventId: string | null) => void;
 };
 
-export function TaskDetailPanel({ task, events, onClose, onUpdate, onToggleDone, onDelete }: TaskDetailPanelProps) {
+export function TaskDetailPanel({
+  task,
+  events,
+  now,
+  onClose,
+  onUpdate,
+  onToggleDone,
+  onDelete,
+  onChangeDependency,
+}: TaskDetailPanelProps) {
   const { projectsById } = useProjects();
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(task.body || "");
+  const [editingDep, setEditingDep] = useState(false);
+  // パネル open 時刻を「今」として固定する。パネル中に分跨ぎしても候補や相対時刻が
+  // ばたつかないようにするのが目的 (相対時刻はあくまで判断補助)。
+  const [openedAt] = useState<number>(() => now ?? Date.now());
+  const nowMs = now && now > 0 ? now : openedAt;
+  const nowDate = useMemo(() => new Date(nowMs), [nowMs]);
   const proj = getProject(projectsById, task.projectId);
   const dep = task.dependsOnEventId
     ? events.find((e) => e.id === task.dependsOnEventId)
     : null;
   const done = isDone(task);
+
+  // 依存先候補は「未来のイベント + 現在選択中のイベント (過去でも保持表示)」。
+  // 過去のイベントを新規依存先にしても意味がないが、既存の依存先を勝手に外すと混乱するため残す。
+  const depCandidates = useMemo(() => {
+    const future = events.filter(
+      (ev) => new Date(ev.startTime).getTime() >= nowMs,
+    );
+    const includesCurrent = dep ? future.some((ev) => ev.id === dep.id) : true;
+    const merged = includesCurrent && dep ? future : dep ? [dep, ...future] : future;
+    return [...merged].sort(
+      (a, b) =>
+        new Date(a.startTime).getTime() - new Date(b.startTime).getTime(),
+    );
+  }, [events, dep, nowMs]);
 
   const handleSave = () => {
     onUpdate(task.id, draft);
@@ -64,7 +100,7 @@ export function TaskDetailPanel({ task, events, onClose, onUpdate, onToggleDone,
             )}
             {dep && (
               <span className="rounded-[3px] bg-[#E85D0415] px-1.5 py-px font-jp text-[9px] text-accent-amber">
-                ← {formatClock(dep.startTime)}までに
+                ← {formatRelativeTime(dep.startTime, nowDate)} {dep.title}
               </span>
             )}
             <div className="flex-1" />
@@ -86,6 +122,47 @@ export function TaskDetailPanel({ task, events, onClose, onUpdate, onToggleDone,
             {task.title}
           </h2>
         </div>
+
+        {onChangeDependency && (
+          <div className="px-5 pb-2">
+            <div className="flex items-center gap-2">
+              <span className="font-jp text-[10px] text-fg-weak">
+                依存イベント
+              </span>
+              {editingDep ? (
+                <select
+                  autoFocus
+                  value={task.dependsOnEventId ?? ""}
+                  onChange={(e) => {
+                    const next = e.target.value === "" ? null : e.target.value;
+                    onChangeDependency(task.id, next);
+                    setEditingDep(false);
+                  }}
+                  onBlur={() => setEditingDep(false)}
+                  className="flex-1 rounded border border-bg-divider bg-bg-elevated px-2 py-1 text-[11px] text-fg-default outline-none focus:border-accent-blue"
+                >
+                  <option value="">なし</option>
+                  {depCandidates.map((ev) => (
+                    <option key={ev.id} value={ev.id}>
+                      {formatRelativeTime(ev.startTime, nowDate)}  {ev.title}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setEditingDep(true)}
+                  className="cursor-pointer rounded-[4px] border border-bg-divider bg-transparent px-2 py-[3px] font-jp text-[10px] text-fg-subtle"
+                >
+                  {dep
+                    ? `${formatRelativeTime(dep.startTime, nowDate)} ${dep.title}`
+                    : "なし"}{" "}
+                  を変更
+                </button>
+              )}
+            </div>
+          </div>
+        )}
 
         <div className="mx-5 h-px bg-bg-border" />
 

--- a/src/features/task-stack/TaskRow.tsx
+++ b/src/features/task-stack/TaskRow.tsx
@@ -1,21 +1,45 @@
 import type { Task } from "../../entities/task/types";
+import type { Event } from "../../entities/event/types";
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { getProject } from "../../entities/project/projects";
 import { useProjects } from "../../entities/project/ProjectsContext";
-import { fmtDuration } from "../../shared/lib/time";
+import {
+  IMMINENT_THRESHOLD_MS,
+  fmtDuration,
+  formatRelativeTime,
+} from "../../shared/lib/time";
 import { Grip } from "./Grip";
 
 type TaskRowProps = {
   task: Task;
+  events: readonly Event[];
+  /** 現在時刻 (ms)。依存イベントの相対時刻 / 直近判定で使う。0 は SSR placeholder。 */
+  now: number;
   isBeingDragged: boolean;
   onPointerDown: (e: ReactPointerEvent<HTMLElement>) => void;
   onClick: () => void;
   onToggleDone: () => void;
 };
 
-export function TaskRow({ task, isBeingDragged, onPointerDown, onClick, onToggleDone }: TaskRowProps) {
+export function TaskRow({
+  task,
+  events,
+  now,
+  isBeingDragged,
+  onPointerDown,
+  onClick,
+  onToggleDone,
+}: TaskRowProps) {
   const { projectsById } = useProjects();
   const proj = getProject(projectsById, task.projectId);
+  const dep = task.dependsOnEventId
+    ? events.find((e) => e.id === task.dependsOnEventId)
+    : null;
+  const depImminent =
+    dep !== null &&
+    dep !== undefined &&
+    now > 0 &&
+    new Date(dep.startTime).getTime() - now <= IMMINENT_THRESHOLD_MS;
 
   return (
     <div
@@ -40,8 +64,17 @@ export function TaskRow({ task, isBeingDragged, onPointerDown, onClick, onToggle
       <span className="flex-1 truncate font-jp text-[12px] text-fg-muted">
         {task.title}
       </span>
-      {task.dependsOnEventId && (
-        <span className="text-[8px] text-fg-subtle">⏱</span>
+      {dep && (
+        <span
+          className={`max-w-[140px] shrink-0 truncate rounded-[3px] px-1 py-px font-jp text-[8px] text-accent-amber ${
+            depImminent
+              ? "bg-[#E85D0440] font-semibold"
+              : "bg-[#E85D0415]"
+          }`}
+          title={`${dep.title} (${formatRelativeTime(dep.startTime, new Date(now))})`}
+        >
+          ← {formatRelativeTime(dep.startTime, new Date(now))} {dep.title}
+        </span>
       )}
       {task.estimatedMinutes !== null && (
         <span className="text-[9px] tabular-nums text-fg-faint">

--- a/src/features/task-stack/TaskStack.test.tsx
+++ b/src/features/task-stack/TaskStack.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render as rtlRender } from "@testing-library/react";
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { DoneList } from "./DoneList";
 import { TaskRow } from "./TaskRow";
 import { TaskStack, type TopTimerBinding } from "./TaskStack";
@@ -8,6 +8,16 @@ import type { Task } from "../../entities/task/types";
 import type { Event } from "../../entities/event/types";
 import type { Project } from "../../entities/project/types";
 import { ProjectsProvider } from "../../entities/project/ProjectsContext";
+
+// 依存イベントの相対時刻表現は「現在時刻」依存。テストは固定時刻 2026-04-11T09:00 で評価する。
+const FIXED_NOW = new Date("2026-04-11T09:00:00");
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(FIXED_NOW);
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 const projects: Project[] = [
   { id: "slo", name: "SLO推進", color: "#2D9F45", isPrimary: true, createdAt: "" },
@@ -55,8 +65,11 @@ const idleTimer: TopTimerBinding = {
   onComplete: noop,
 };
 
+const NOW_MS = FIXED_NOW.getTime();
+
 const topProps = {
   events: [] as Event[],
+  now: NOW_MS,
   isBeingDragged: false,
   elapsedSeconds: 0,
   pauseReason: null,
@@ -75,7 +88,8 @@ describe("TopTaskCard", () => {
     expect(getByText("SLO推進")).toBeTruthy();
   });
 
-  test("dependsOnEventId の依存イベントを解決してバッジ表示", () => {
+  test("dependsOnEventId の依存イベントを解決してバッジ表示 (相対時刻 + タイトル)", () => {
+    // FIXED_NOW=09:00, event=14:00 → 5時間後 → 「今日 14:00 MTG」
     const { getByText } = render(
       <TopTaskCard
         {...topProps}
@@ -83,7 +97,7 @@ describe("TopTaskCard", () => {
         events={[baseEvent]}
       />,
     );
-    expect(getByText("← 14:00までに")).toBeTruthy();
+    expect(getByText(/今日 14:00 MTG/)).toBeTruthy();
   });
 
   test("body の先頭非見出し行をプレビュー表示", () => {
@@ -147,6 +161,8 @@ describe("TaskRow", () => {
     const { getByText } = render(
       <TaskRow
         task={baseTask}
+        events={[]}
+        now={NOW_MS}
         isBeingDragged={false}
         onPointerDown={noop}
         onClick={noop}
@@ -158,17 +174,35 @@ describe("TaskRow", () => {
     expect(getByText("45m")).toBeTruthy();
   });
 
-  test("dependsOnEventId があれば ⏱ アイコンを表示", () => {
+  test("dependsOnEventId があれば「相対時刻 + タイトル」のバッジを表示", () => {
     const { getByText } = render(
       <TaskRow
         task={{ ...baseTask, dependsOnEventId: "e1" }}
+        events={[baseEvent]}
+        now={NOW_MS}
         isBeingDragged={false}
         onPointerDown={noop}
         onClick={noop}
         onToggleDone={noop}
       />,
     );
-    expect(getByText("⏱")).toBeTruthy();
+    expect(getByText(/今日 14:00 MTG/)).toBeTruthy();
+  });
+
+  test("依存イベントが events に無い (削除済) 場合はバッジを表示しない", () => {
+    const { queryByText } = render(
+      <TaskRow
+        task={{ ...baseTask, dependsOnEventId: "missing" }}
+        events={[]}
+        now={NOW_MS}
+        isBeingDragged={false}
+        onPointerDown={noop}
+        onClick={noop}
+        onToggleDone={noop}
+      />,
+    );
+    expect(queryByText(/MTG/)).toBeNull();
+    expect(queryByText(/今日/)).toBeNull();
   });
 });
 
@@ -219,6 +253,7 @@ describe("TaskStack", () => {
     const { getByText, getAllByText } = render(
       <TaskStack
         events={[]}
+        now={NOW_MS}
         pendingTasks={pending}
         doneTasks={[]}
         topTimer={idleTimer}
@@ -240,6 +275,7 @@ describe("TaskStack", () => {
     const { getByText } = render(
       <TaskStack
         events={[]}
+        now={NOW_MS}
         pendingTasks={pending}
         doneTasks={doneTasks}
         topTimer={idleTimer}
@@ -257,6 +293,7 @@ describe("TaskStack", () => {
     const { getByText } = render(
       <TaskStack
         events={[]}
+        now={NOW_MS}
         pendingTasks={pending}
         doneTasks={[]}
         topTimer={idleTimer}

--- a/src/features/task-stack/TaskStack.tsx
+++ b/src/features/task-stack/TaskStack.tsx
@@ -36,6 +36,8 @@ type TaskStackProps = {
   pendingTasks: Task[];
   doneTasks: Task[];
   topTimer: TopTimerBinding;
+  /** 現在時刻 (ms)。依存イベントの相対時刻 / 直近判定で使う。0 は SSR 時の placeholder。 */
+  now: number;
   onReorder: (from: number, to: number) => void;
   onToggleDone: (id: string) => void;
   onOpenDetail: (id: string) => void;
@@ -46,6 +48,7 @@ export function TaskStack({
   pendingTasks,
   doneTasks,
   topTimer,
+  now,
   onReorder,
   onToggleDone,
   onOpenDetail,
@@ -75,6 +78,7 @@ export function TaskStack({
               <TopTaskCard
                 task={task}
                 events={events}
+                now={now}
                 isBeingDragged={isBeingDragged}
                 elapsedSeconds={topTimer.elapsedSeconds}
                 pauseReason={topTimer.pauseReason}
@@ -88,6 +92,8 @@ export function TaskStack({
             ) : (
               <TaskRow
                 task={task}
+                events={events}
+                now={now}
                 isBeingDragged={isBeingDragged}
                 onPointerDown={(e) => handlePointerDown(idx, e)}
                 onClick={() => onOpenDetail(task.id)}

--- a/src/features/task-stack/TopTaskCard.tsx
+++ b/src/features/task-stack/TopTaskCard.tsx
@@ -5,7 +5,10 @@ import { getProject } from "../../entities/project/projects";
 import { useProjects } from "../../entities/project/ProjectsContext";
 import type { PauseReason } from "../../entities/task/time-entries";
 import type { Task } from "../../entities/task/types";
-import { formatClock } from "../../shared/lib/time";
+import {
+  IMMINENT_THRESHOLD_MS,
+  formatRelativeTime,
+} from "../../shared/lib/time";
 import { Grip } from "./Grip";
 import { pauseReasonLabel } from "./PauseReasonModal";
 import { formatElapsed } from "./useTaskTimer";
@@ -18,6 +21,8 @@ function bodyPreview(body: string): string {
 type TopTaskCardProps = {
   task: Task;
   events: Event[];
+  /** 現在時刻 (ms)。依存イベントの相対時刻 / 直近判定で使う。0 は SSR placeholder で計算をスキップ。 */
+  now: number;
   isBeingDragged: boolean;
   elapsedSeconds: number;
   pauseReason: PauseReason | null;
@@ -32,6 +37,7 @@ type TopTaskCardProps = {
 export function TopTaskCard({
   task,
   events,
+  now,
   isBeingDragged,
   elapsedSeconds,
   pauseReason,
@@ -47,6 +53,13 @@ export function TopTaskCard({
   const dep = task.dependsOnEventId
     ? events.find((e) => e.id === task.dependsOnEventId)
     : null;
+  // 24h 以内に迫っている依存はハイライト (背景濃度 + 太字) して着手判断のシグナルを強める。
+  // now=0 (SSR placeholder) のときは判定スキップ。
+  const depImminent =
+    dep !== null &&
+    dep !== undefined &&
+    now > 0 &&
+    new Date(dep.startTime).getTime() - now <= IMMINENT_THRESHOLD_MS;
   const preview = bodyPreview(task.body);
   const isActive = task.status === "active";
   const isPaused = task.status === "paused";
@@ -85,8 +98,15 @@ export function TopTaskCard({
               {proj.name}
             </span>
             {dep && (
-              <span className="rounded-[3px] bg-[#E85D0415] px-1.5 py-px font-jp text-[8px] text-accent-amber">
-                ← {formatClock(dep.startTime)}までに
+              <span
+                className={`max-w-[180px] truncate rounded-[3px] px-1.5 py-px font-jp text-[8px] text-accent-amber ${
+                  depImminent
+                    ? "bg-[#E85D0440] font-semibold"
+                    : "bg-[#E85D0415]"
+                }`}
+                title={`${dep.title} (${formatRelativeTime(dep.startTime, new Date(now))})`}
+              >
+                ← {formatRelativeTime(dep.startTime, new Date(now))} {dep.title}
               </span>
             )}
             {isActive && (

--- a/src/shared/lib/time.test.ts
+++ b/src/shared/lib/time.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "vitest";
-import { formatDate, fmtDuration, fmtMin, timeToMin } from "./time";
+import {
+  formatDate,
+  formatRelativeTime,
+  fmtDuration,
+  fmtMin,
+  timeToMin,
+} from "./time";
 
 describe("formatDate", () => {
   test('"YYYY-MM-DD" を "M/D (曜)" 形式に整形する', () => {
@@ -44,5 +50,35 @@ describe("fmtMin", () => {
     expect(fmtMin(570)).toBe("9:30");
     expect(fmtMin(0)).toBe("0:00");
     expect(fmtMin(605)).toBe("10:05");
+  });
+});
+
+describe("formatRelativeTime", () => {
+  // 基準時刻: 2026-04-11 (土) 09:00
+  const now = new Date("2026-04-11T09:00:00");
+
+  test("過去 / 1分以内は「もうすぐ」", () => {
+    expect(formatRelativeTime("2026-04-11T08:30:00", now)).toBe("もうすぐ");
+    expect(formatRelativeTime("2026-04-11T09:00:30", now)).toBe("もうすぐ");
+  });
+
+  test("1時間未満は「N分後」", () => {
+    expect(formatRelativeTime("2026-04-11T09:30:00", now)).toBe("30分後");
+    expect(formatRelativeTime("2026-04-11T09:59:00", now)).toBe("59分後");
+  });
+
+  test("同日 1 時間以上後は「今日 HH:MM」", () => {
+    expect(formatRelativeTime("2026-04-11T14:00:00", now)).toBe("今日 14:00");
+    expect(formatRelativeTime("2026-04-11T23:30:00", now)).toBe("今日 23:30");
+  });
+
+  test("翌日は「明日 HH:MM」", () => {
+    expect(formatRelativeTime("2026-04-12T08:00:00", now)).toBe("明日 08:00");
+    expect(formatRelativeTime("2026-04-12T23:59:00", now)).toBe("明日 23:59");
+  });
+
+  test("2日以上先は「M/D HH:MM」", () => {
+    expect(formatRelativeTime("2026-04-15T10:00:00", now)).toBe("4/15 10:00");
+    expect(formatRelativeTime("2026-05-02T18:30:00", now)).toBe("5/2 18:30");
   });
 });

--- a/src/shared/lib/time.ts
+++ b/src/shared/lib/time.ts
@@ -47,3 +47,41 @@ export function fmtDuration(m: number): string {
 export function fmtMin(m: number): string {
   return `${Math.floor(m / 60)}:${String(m % 60).padStart(2, "0")}`;
 }
+
+const MS_PER_MIN = 60 * 1000;
+const MS_PER_HOUR = 60 * MS_PER_MIN;
+const MS_PER_DAY = 24 * MS_PER_HOUR;
+
+/** 依存イベントが「直近に迫っている」と判定する閾値 (24h)。タスクカードのハイライト判定に使う。 */
+export const IMMINENT_THRESHOLD_MS = MS_PER_DAY;
+
+function startOfLocalDay(d: Date): number {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+}
+
+/**
+ * イベント開始時刻までの相対表現。タスクカード上の依存イベント表示で使う。
+ *
+ * - 過ぎた / 1 分以内: 「もうすぐ」
+ * - 1 時間未満: 「N分後」
+ * - 同日内: 「今日 HH:MM」
+ * - 翌日: 「明日 HH:MM」
+ * - それ以降: 「M/D HH:MM」
+ *
+ * 閾値はパラメータレベルの判断のため ADR には残さず、ここの定数で管理する。
+ */
+export function formatRelativeTime(iso: string, now: Date = new Date()): string {
+  const target = new Date(iso);
+  const diffMs = target.getTime() - now.getTime();
+  if (diffMs < MS_PER_MIN) return "もうすぐ";
+  if (diffMs < MS_PER_HOUR) {
+    const minutes = Math.round(diffMs / MS_PER_MIN);
+    return `${minutes}分後`;
+  }
+  const dayDiff =
+    Math.round((startOfLocalDay(target) - startOfLocalDay(now)) / MS_PER_DAY);
+  const clock = formatClock(iso);
+  if (dayDiff === 0) return `今日 ${clock}`;
+  if (dayDiff === 1) return `明日 ${clock}`;
+  return `${target.getMonth() + 1}/${target.getDate()} ${clock}`;
+}


### PR DESCRIPTION
- TaskDetailPanel に依存イベント編集 UI を追加 (現在の依存先 + 未来イベントから選択 / 解除)
- TaskForm の依存イベント候補を未来のイベント (manual / google_calendar) のみに絞り、時系列順に並べる
- TopTaskCard / TaskRow / TaskDetailPanel の依存表示を「相対時刻 + イベントタイトル」に変更
- 依存イベントが 24h 以内に迫っていればハイライト
- 依存設定の変更を action_log に記録 (task_dependency_set / task_dependency_cleared)

Phase 4 で「依存設定が着手順に効いたか」の分析データに使う。
スコアリング (依存イベント基準の自動着手順ソート) は Phase 4 スコープなので含まない。

https://claude.ai/code/session_016rsXAFXEmNkLdTUhnijVTo