### PR TITLE
feat(p2-6): syncToken 差分同期に移行

### DIFF
--- a/src/entities/calendar-sync/gateway.ts
+++ b/src/entities/calendar-sync/gateway.ts
@@ -1,8 +1,9 @@
 /**
- * Google Calendar 同期状態 (最終同期時刻・syncToken 予約) の永続化 Gateway。
+ * Google Calendar 同期状態 (最終同期時刻 + syncToken) の永続化 Gateway。
  *
- * ADR 0007 の「起動時 15 分閾値で遅延同期するか」を判定するために `lastSyncedAt` を使う。
- * `syncToken` は ADR 0006 の P2-6 差分同期で使う予約枠で、P2-3 時点では読み書きしない。
+ * - `lastSyncedAt`: ADR 0007 の起動時 15 分閾値判定に使う。
+ * - `syncToken`: ADR 0006 の syncToken 差分同期。`null` は「次回 full sync」を意味する
+ *   (初回 / 410 Gone 直後)。
  */
 export type CalendarSyncState = {
   lastSyncedAt: string;
@@ -12,6 +13,13 @@ export type CalendarSyncState = {
 export interface CalendarSyncStateGateway {
   /** 現在ユーザーの同期状態を取得。未同期なら null。 */
   get(): Promise<CalendarSyncState | null>;
-  /** 同期成功時に最終同期時刻を upsert する (`sync_token` は触らない)。 */
-  upsertLastSyncedAt(lastSyncedAt: string): Promise<void>;
+  /**
+   * 同期成功時に最終同期時刻と syncToken を atomic に upsert する。
+   * `syncToken: null` を渡すと DB の `sync_token` も `null` に上書きされ、次回は full sync になる
+   * (410 Gone fallback で nextSyncToken が得られなかったケース等)。
+   */
+  saveSyncState(input: {
+    lastSyncedAt: string;
+    syncToken: string | null;
+  }): Promise<void>;
 }

--- a/src/entities/calendar-sync/supabase-gateway.test.ts
+++ b/src/entities/calendar-sync/supabase-gateway.test.ts
@@ -46,8 +46,35 @@ function makeSupabase(overrides: {
 }
 
 describe("SupabaseCalendarSyncStateGateway.get", () => {
-  test("行があれば CalendarSyncState を返す", async () => {
+  test("行があれば CalendarSyncState を返す (sync_token も含めて)", async () => {
     const { supabase, from, select, eqSelect } = makeSupabase({
+      selectResult: {
+        data: {
+          user_id: "user-1",
+          last_synced_at: "2026-04-24T10:00:00.000Z",
+          sync_token: "tok-abc",
+          updated_at: "2026-04-24T10:00:00.000Z",
+        },
+        error: null,
+      },
+    });
+
+    const gw = new SupabaseCalendarSyncStateGateway(supabase);
+    const state = await gw.get();
+
+    expect(state).toEqual({
+      lastSyncedAt: "2026-04-24T10:00:00.000Z",
+      syncToken: "tok-abc",
+    });
+    expect(from).toHaveBeenCalledWith("user_calendar_sync_state");
+    expect(select).toHaveBeenCalledWith(
+      "user_id, last_synced_at, sync_token, updated_at",
+    );
+    expect(eqSelect).toHaveBeenCalledWith("user_id", "user-1");
+  });
+
+  test("sync_token が null でもそのまま返す (初回 / 410 fallback 直後)", async () => {
+    const { supabase } = makeSupabase({
       selectResult: {
         data: {
           user_id: "user-1",
@@ -66,11 +93,6 @@ describe("SupabaseCalendarSyncStateGateway.get", () => {
       lastSyncedAt: "2026-04-24T10:00:00.000Z",
       syncToken: null,
     });
-    expect(from).toHaveBeenCalledWith("user_calendar_sync_state");
-    expect(select).toHaveBeenCalledWith(
-      "user_id, last_synced_at, sync_token, updated_at",
-    );
-    expect(eqSelect).toHaveBeenCalledWith("user_id", "user-1");
   });
 
   test("行がなければ null を返す", async () => {
@@ -107,23 +129,42 @@ describe("SupabaseCalendarSyncStateGateway.get", () => {
   });
 });
 
-describe("SupabaseCalendarSyncStateGateway.upsertLastSyncedAt", () => {
-  test("user_id + last_synced_at を on conflict user_id で upsert する", async () => {
+describe("SupabaseCalendarSyncStateGateway.saveSyncState", () => {
+  test("user_id + last_synced_at + sync_token を on conflict user_id で upsert する", async () => {
     const { supabase, from, upsert } = makeSupabase({});
     const gw = new SupabaseCalendarSyncStateGateway(supabase);
 
-    await gw.upsertLastSyncedAt("2026-04-24T10:00:00.000Z");
+    await gw.saveSyncState({
+      lastSyncedAt: "2026-04-24T10:00:00.000Z",
+      syncToken: "tok-xyz",
+    });
 
     expect(from).toHaveBeenCalledWith("user_calendar_sync_state");
     expect(upsert).toHaveBeenCalledTimes(1);
     const [payload, options] = upsert.mock.calls[0]!;
-    expect(payload).toMatchObject({
+    expect(payload).toEqual({
       user_id: "user-1",
       last_synced_at: "2026-04-24T10:00:00.000Z",
+      sync_token: "tok-xyz",
     });
-    // sync_token は触らない (P2-6 予約枠、既存値を保持)
-    expect(payload).not.toHaveProperty("sync_token");
     expect(options).toEqual({ onConflict: "user_id" });
+  });
+
+  test("syncToken: null を渡すと sync_token も null で上書きされる (410 fallback で nextSyncToken が無いケース)", async () => {
+    const { supabase, upsert } = makeSupabase({});
+    const gw = new SupabaseCalendarSyncStateGateway(supabase);
+
+    await gw.saveSyncState({
+      lastSyncedAt: "2026-04-24T10:00:00.000Z",
+      syncToken: null,
+    });
+
+    const [payload] = upsert.mock.calls[0]!;
+    expect(payload).toEqual({
+      user_id: "user-1",
+      last_synced_at: "2026-04-24T10:00:00.000Z",
+      sync_token: null,
+    });
   });
 
   test("未ログイン時は throw する (Route Handler 以外からの呼び出しを防ぐ)", async () => {
@@ -131,7 +172,10 @@ describe("SupabaseCalendarSyncStateGateway.upsertLastSyncedAt", () => {
     const gw = new SupabaseCalendarSyncStateGateway(supabase);
 
     await expect(
-      gw.upsertLastSyncedAt("2026-04-24T10:00:00.000Z"),
+      gw.saveSyncState({
+        lastSyncedAt: "2026-04-24T10:00:00.000Z",
+        syncToken: null,
+      }),
     ).rejects.toThrow(/not authenticated/i);
   });
 
@@ -142,7 +186,10 @@ describe("SupabaseCalendarSyncStateGateway.upsertLastSyncedAt", () => {
     const gw = new SupabaseCalendarSyncStateGateway(supabase);
 
     await expect(
-      gw.upsertLastSyncedAt("2026-04-24T10:00:00.000Z"),
+      gw.saveSyncState({
+        lastSyncedAt: "2026-04-24T10:00:00.000Z",
+        syncToken: "t",
+      }),
     ).rejects.toMatchObject({ message: "insert failed" });
   });
 });

--- a/src/entities/calendar-sync/supabase-gateway.ts
+++ b/src/entities/calendar-sync/supabase-gateway.ts
@@ -33,16 +33,19 @@ export class SupabaseCalendarSyncStateGateway
     };
   }
 
-  async upsertLastSyncedAt(lastSyncedAt: string): Promise<void> {
+  async saveSyncState(input: {
+    lastSyncedAt: string;
+    syncToken: string | null;
+  }): Promise<void> {
     const {
       data: { user },
     } = await this.supabase.auth.getUser();
     if (!user) throw new Error("not authenticated");
 
-    // sync_token は payload から外すことで既存値を保持する (P2-6 で使う予約枠)。
     const payload: TablesInsert<"user_calendar_sync_state"> = {
       user_id: user.id,
-      last_synced_at: lastSyncedAt,
+      last_synced_at: input.lastSyncedAt,
+      sync_token: input.syncToken,
     };
     const { error } = await this.supabase
       .from("user_calendar_sync_state")

--- a/src/entities/event/sync.test.ts
+++ b/src/entities/event/sync.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test, vi } from "vitest";
 
 import type { CalendarSyncStateGateway } from "@/entities/calendar-sync/gateway";
 import {
+  GoogleApiError,
   GoogleApiUnauthorizedError,
   type GoogleCalendarEvent,
   type GoogleCalendarEventsListResponse,
@@ -202,15 +203,16 @@ function makeFakeGateway() {
   return { gateway, upsertCalls, deleteCalls };
 }
 
-function makeFakeSyncStateGateway() {
-  const upsertLastSyncedAt = vi.fn<(iso: string) => Promise<void>>(
-    async () => {},
-  );
-  const gateway: CalendarSyncStateGateway = {
-    get: vi.fn(async () => null),
-    upsertLastSyncedAt,
-  };
-  return { gateway, upsertLastSyncedAt };
+function makeFakeSyncStateGateway(initial: {
+  lastSyncedAt: string;
+  syncToken: string | null;
+} | null = null) {
+  const get = vi.fn<() => Promise<typeof initial>>(async () => initial);
+  const saveSyncState = vi.fn<
+    (input: { lastSyncedAt: string; syncToken: string | null }) => Promise<void>
+  >(async () => {});
+  const gateway: CalendarSyncStateGateway = { get, saveSyncState };
+  return { gateway, get, saveSyncState };
 }
 
 function makeActiveEvent(id: string): GoogleCalendarEvent {
@@ -253,11 +255,12 @@ function makeDeps(overrides: {
   };
 }
 
-describe("syncGoogleCalendar", () => {
-  test("primary の timeMin/timeMax を now±window で計算し、1 ページで完了", async () => {
+describe("syncGoogleCalendar (full sync)", () => {
+  test("syncToken 未保存なら primary の timeMin/timeMax を now±window で計算し full sync する", async () => {
     const { gateway, upsertCalls, deleteCalls } = makeFakeGateway();
     const listEvents = vi.fn<ListEventsFn>(async () => ({
       items: [makeActiveEvent("a"), makeActiveEvent("b")],
+      nextSyncToken: "tok-after-full",
     }));
 
     const result = await syncGoogleCalendar(
@@ -285,6 +288,7 @@ describe("syncGoogleCalendar", () => {
       timeMin: "2026-04-16T12:00:00.000Z", // now - 7d
       timeMax: "2026-05-23T12:00:00.000Z", // now + 30d
     });
+    expect(call.syncToken).toBeUndefined();
     expect(upsertCalls).toHaveLength(1);
     expect(upsertCalls[0]!.map((e) => e.externalId)).toEqual(["a", "b"]);
     expect(deleteCalls).toHaveLength(0);
@@ -304,6 +308,7 @@ describe("syncGoogleCalendar", () => {
       })
       .mockResolvedValueOnce({
         items: [makeActiveEvent("p3-a")],
+        nextSyncToken: "final-sync",
       });
 
     const result = await syncGoogleCalendar(
@@ -432,12 +437,13 @@ describe("syncGoogleCalendar", () => {
     ).rejects.toBeInstanceOf(RefreshTokenExpiredError);
   });
 
-  test("成功時は last_synced_at を永続化する", async () => {
+  test("成功時は last_synced_at + nextSyncToken を atomic に永続化する", async () => {
     const { gateway } = makeFakeGateway();
-    const { gateway: syncStateGateway, upsertLastSyncedAt } =
+    const { gateway: syncStateGateway, saveSyncState } =
       makeFakeSyncStateGateway();
     const listEvents = vi.fn<ListEventsFn>(async () => ({
       items: [makeActiveEvent("a")],
+      nextSyncToken: "fresh-tok",
     }));
 
     const result = await syncGoogleCalendar(
@@ -451,14 +457,37 @@ describe("syncGoogleCalendar", () => {
     );
 
     expect(result.lastSyncedAt).toBe("2026-04-24T01:30:00.000Z");
-    expect(upsertLastSyncedAt).toHaveBeenCalledTimes(1);
-    expect(upsertLastSyncedAt).toHaveBeenCalledWith("2026-04-24T01:30:00.000Z");
+    expect(saveSyncState).toHaveBeenCalledTimes(1);
+    expect(saveSyncState).toHaveBeenCalledWith({
+      lastSyncedAt: "2026-04-24T01:30:00.000Z",
+      syncToken: "fresh-tok",
+    });
   });
 
-  test("401 retry 後も失敗する場合は last_synced_at を記録しない", async () => {
+  test("nextSyncToken が無いレスポンスは syncToken: null で保存する", async () => {
     const { gateway } = makeFakeGateway();
-    const { gateway: syncStateGateway, upsertLastSyncedAt } =
+    const { gateway: syncStateGateway, saveSyncState } =
       makeFakeSyncStateGateway();
+    const listEvents = vi.fn<ListEventsFn>(async () => ({ items: [] }));
+
+    await syncGoogleCalendar(
+      FAKE_SUPABASE,
+      makeDeps({ gateway, syncStateGateway, listEvents }),
+    );
+
+    expect(saveSyncState).toHaveBeenCalledWith({
+      lastSyncedAt: expect.any(String),
+      syncToken: null,
+    });
+  });
+
+  test("401 retry 後も失敗する場合は sync state を上書きしない (stale syncToken を保持)", async () => {
+    const { gateway } = makeFakeGateway();
+    const { gateway: syncStateGateway, saveSyncState } =
+      makeFakeSyncStateGateway({
+        lastSyncedAt: "2026-04-23T00:00:00.000Z",
+        syncToken: "previous",
+      });
     const listEvents = vi.fn<ListEventsFn>(async () => {
       throw new GoogleApiUnauthorizedError();
     });
@@ -479,6 +508,185 @@ describe("syncGoogleCalendar", () => {
       ),
     ).rejects.toBeInstanceOf(GoogleApiUnauthorizedError);
 
-    expect(upsertLastSyncedAt).not.toHaveBeenCalled();
+    expect(saveSyncState).not.toHaveBeenCalled();
+  });
+});
+
+describe("syncGoogleCalendar (incremental sync via syncToken)", () => {
+  test("syncToken が DB にあれば incremental として呼び出す (timeMin/timeMax/orderBy を送らない)", async () => {
+    const { gateway, upsertCalls } = makeFakeGateway();
+    const { gateway: syncStateGateway, saveSyncState } =
+      makeFakeSyncStateGateway({
+        lastSyncedAt: "2026-04-23T00:00:00.000Z",
+        syncToken: "tok-prev",
+      });
+    const listEvents = vi.fn<ListEventsFn>(async () => ({
+      items: [makeActiveEvent("incr-1")],
+      nextSyncToken: "tok-next",
+    }));
+
+    const result = await syncGoogleCalendar(
+      FAKE_SUPABASE,
+      makeDeps({
+        gateway,
+        syncStateGateway,
+        listEvents,
+        accessToken: "fresh",
+        now: () => new Date("2026-04-24T00:00:00.000Z"),
+      }),
+    );
+
+    expect(result.synced).toBe(1);
+    expect(listEvents).toHaveBeenCalledTimes(1);
+    const call = listEvents.mock.calls[0]![0];
+    expect(call.syncToken).toBe("tok-prev");
+    expect(call.singleEvents).toBe(true);
+    expect(call.timeMin).toBeUndefined();
+    expect(call.timeMax).toBeUndefined();
+    expect(call.orderBy).toBeUndefined();
+    expect(upsertCalls[0]!.map((e) => e.externalId)).toEqual(["incr-1"]);
+    expect(saveSyncState).toHaveBeenCalledWith({
+      lastSyncedAt: "2026-04-24T00:00:00.000Z",
+      syncToken: "tok-next",
+    });
+  });
+
+  test("incremental sync でも cancelled は削除に回る (差分削除が機能する)", async () => {
+    const { gateway, deleteCalls } = makeFakeGateway();
+    const { gateway: syncStateGateway } = makeFakeSyncStateGateway({
+      lastSyncedAt: "2026-04-23T00:00:00.000Z",
+      syncToken: "tok-prev",
+    });
+    const listEvents = vi.fn<ListEventsFn>(async () => ({
+      items: [
+        { id: "gone-incr", status: "cancelled" },
+        makeActiveEvent("kept"),
+      ],
+      nextSyncToken: "tok-next",
+    }));
+
+    const result = await syncGoogleCalendar(
+      FAKE_SUPABASE,
+      makeDeps({ gateway, syncStateGateway, listEvents }),
+    );
+
+    expect(result.deleted).toBe(1);
+    expect(deleteCalls[0]).toEqual(["gone-incr"]);
+  });
+
+  test("incremental sync のページングは中間ページの nextSyncToken を無視し最終ページのみ採用する", async () => {
+    const { gateway } = makeFakeGateway();
+    const { gateway: syncStateGateway, saveSyncState } =
+      makeFakeSyncStateGateway({
+        lastSyncedAt: "2026-04-23T00:00:00.000Z",
+        syncToken: "tok-prev",
+      });
+    const listEvents = vi.fn<ListEventsFn>();
+    listEvents
+      .mockResolvedValueOnce({
+        items: [makeActiveEvent("p1")],
+        nextPageToken: "page-2",
+        // 中間ページにも nextSyncToken が来るケース (Google の挙動として無効)
+        nextSyncToken: "intermediate-should-be-ignored",
+      })
+      .mockResolvedValueOnce({
+        items: [makeActiveEvent("p2")],
+        nextSyncToken: "final-only",
+      });
+
+    await syncGoogleCalendar(
+      FAKE_SUPABASE,
+      makeDeps({ gateway, syncStateGateway, listEvents }),
+    );
+
+    expect(saveSyncState).toHaveBeenCalledWith({
+      lastSyncedAt: expect.any(String),
+      syncToken: "final-only",
+    });
+  });
+
+  test("410 Gone を受けたら syncToken を捨てて full sync に fallback する", async () => {
+    const { gateway, upsertCalls } = makeFakeGateway();
+    const { gateway: syncStateGateway, saveSyncState } =
+      makeFakeSyncStateGateway({
+        lastSyncedAt: "2026-04-23T00:00:00.000Z",
+        syncToken: "tok-stale",
+      });
+    const listEvents = vi.fn<ListEventsFn>();
+    listEvents
+      .mockRejectedValueOnce(
+        new GoogleApiError("Gone", 410, { error: "fullSyncRequired" }),
+      )
+      .mockResolvedValueOnce({
+        items: [makeActiveEvent("after-fallback")],
+        nextSyncToken: "fresh-after-fallback",
+      });
+
+    const result = await syncGoogleCalendar(
+      FAKE_SUPABASE,
+      makeDeps({
+        gateway,
+        syncStateGateway,
+        listEvents,
+        now: () => new Date("2026-04-24T05:00:00.000Z"),
+      }),
+    );
+
+    expect(result.synced).toBe(1);
+    expect(listEvents).toHaveBeenCalledTimes(2);
+    // 1 回目は incremental
+    expect(listEvents.mock.calls[0]![0].syncToken).toBe("tok-stale");
+    expect(listEvents.mock.calls[0]![0].timeMin).toBeUndefined();
+    // 2 回目は full sync (timeMin/timeMax/orderBy 復活、syncToken 無し)
+    expect(listEvents.mock.calls[1]![0].syncToken).toBeUndefined();
+    expect(listEvents.mock.calls[1]![0].timeMin).toBeDefined();
+    expect(listEvents.mock.calls[1]![0].timeMax).toBeDefined();
+    expect(listEvents.mock.calls[1]![0].orderBy).toBe("startTime");
+    expect(upsertCalls[0]!.map((e) => e.externalId)).toEqual([
+      "after-fallback",
+    ]);
+    // fallback 後の full sync で得た新しい syncToken を保存
+    expect(saveSyncState).toHaveBeenCalledWith({
+      lastSyncedAt: "2026-04-24T05:00:00.000Z",
+      syncToken: "fresh-after-fallback",
+    });
+  });
+
+  test("full sync 中の 410 は fallback せず素通しで throw (syncToken なしの 410 は想定外)", async () => {
+    const { gateway } = makeFakeGateway();
+    const { gateway: syncStateGateway } = makeFakeSyncStateGateway(null);
+    const listEvents = vi.fn<ListEventsFn>(async () => {
+      throw new GoogleApiError("Gone", 410, { error: "x" });
+    });
+
+    await expect(
+      syncGoogleCalendar(
+        FAKE_SUPABASE,
+        makeDeps({ gateway, syncStateGateway, listEvents }),
+      ),
+    ).rejects.toBeInstanceOf(GoogleApiError);
+
+    expect(listEvents).toHaveBeenCalledTimes(1);
+  });
+
+  test("fallback 後にも 410 が出続けたら 2 度目は throw する (無限ループ防止)", async () => {
+    const { gateway } = makeFakeGateway();
+    const { gateway: syncStateGateway } = makeFakeSyncStateGateway({
+      lastSyncedAt: "2026-04-23T00:00:00.000Z",
+      syncToken: "tok-stale",
+    });
+    const listEvents = vi.fn<ListEventsFn>(async () => {
+      throw new GoogleApiError("Gone", 410, { error: "x" });
+    });
+
+    await expect(
+      syncGoogleCalendar(
+        FAKE_SUPABASE,
+        makeDeps({ gateway, syncStateGateway, listEvents }),
+      ),
+    ).rejects.toBeInstanceOf(GoogleApiError);
+
+    // 1 回目 incremental → 410, 2 回目 full → また 410 で throw
+    expect(listEvents).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/entities/event/sync.ts
+++ b/src/entities/event/sync.ts
@@ -3,6 +3,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { CalendarSyncStateGateway } from "@/entities/calendar-sync/gateway";
 import { SupabaseCalendarSyncStateGateway } from "@/entities/calendar-sync/supabase-gateway";
 import {
+  GoogleApiError,
   GoogleApiUnauthorizedError,
   type GoogleCalendarEvent,
   type GoogleCalendarEventsListResponse,
@@ -26,9 +27,12 @@ import { SupabaseEventGateway } from "./supabase-gateway";
  * Google Calendar → events テーブル 同期本体 (ADR 0005 / 0006 / 0008 / 0010)。
  *
  * - 対象は primary カレンダーのみ (ADR 0008)
- * - 過去 7 日 〜 未来 30 日 を full sync
+ * - 同期方式 (ADR 0006):
+ *   - syncToken 未保存 → 過去 7 日 〜 未来 30 日を full sync。最終ページの nextSyncToken を保存
+ *   - syncToken 保存済み → 期間指定なし incremental sync。最終ページの nextSyncToken で更新
+ *   - 410 Gone (syncToken 失効) → syncToken を捨てて full sync に 1 度だけ fallback
  * - 2 回目以降も idempotent: `(source, external_id)` の unique 制約に upsert
- * - Google 側で cancelled になったものはローカルからも削除
+ * - Google 側で cancelled になったものはローカルからも削除 (incremental でも機能する)
  * - 401 を受けたら `refreshAccessToken` → 1 回だけ retry (ADR 0009)
  */
 
@@ -87,38 +91,67 @@ export async function syncGoogleCalendar(
     nowDate.getTime() + SYNC_WINDOW_FUTURE_DAYS * MS_PER_DAY,
   ).toISOString();
 
+  const initialState = await deps.syncStateGateway.get();
+  let activeSyncToken: string | undefined =
+    initialState?.syncToken ?? undefined;
+
   const initial = await deps.getValidAccessToken(supabase);
   let accessToken = initial.accessToken;
   let hasRetriedAuth = false;
+  let hasFallenBackFromGone = false;
 
-  const collected: GoogleCalendarEvent[] = [];
-  let pageToken: string | undefined;
+  let collected: GoogleCalendarEvent[] = [];
+  let nextSyncToken: string | undefined;
 
-  while (true) {
-    let page: GoogleCalendarEventsListResponse;
-    try {
-      page = await deps.listEvents({
-        accessToken,
-        calendarId: PRIMARY_CALENDAR_ID,
-        timeMin,
-        timeMax,
-        singleEvents: true,
-        orderBy: "startTime",
-        pageToken,
-      });
-    } catch (err) {
-      if (err instanceof GoogleApiUnauthorizedError && !hasRetriedAuth) {
-        hasRetriedAuth = true;
-        const refreshed = await deps.refreshAccessToken(supabase);
-        accessToken = refreshed.accessToken;
-        continue;
+  // 外側ループは 410 Gone fallback のリトライ。inner ループで最終ページまで到達したら break。
+  outer: while (true) {
+    collected = [];
+    nextSyncToken = undefined;
+    let pageToken: string | undefined;
+
+    while (true) {
+      let page: GoogleCalendarEventsListResponse;
+      try {
+        page = await deps.listEvents(
+          buildListParams({
+            accessToken,
+            syncToken: activeSyncToken,
+            timeMin,
+            timeMax,
+            pageToken,
+          }),
+        );
+      } catch (err) {
+        if (err instanceof GoogleApiUnauthorizedError && !hasRetriedAuth) {
+          hasRetriedAuth = true;
+          const refreshed = await deps.refreshAccessToken(supabase);
+          accessToken = refreshed.accessToken;
+          continue;
+        }
+        // 410 Gone: syncToken 失効 → token を捨てて full sync に 1 回だけ fallback
+        if (
+          err instanceof GoogleApiError &&
+          err.status === 410 &&
+          activeSyncToken !== undefined &&
+          !hasFallenBackFromGone
+        ) {
+          hasFallenBackFromGone = true;
+          activeSyncToken = undefined;
+          continue outer;
+        }
+        throw err;
       }
-      throw err;
+
+      collected.push(...(page.items ?? []));
+      pageToken = page.nextPageToken;
+      if (!pageToken) {
+        // 最終ページの nextSyncToken のみが次回の incremental に使える (中間ページのものは無効)。
+        nextSyncToken = page.nextSyncToken;
+        break;
+      }
     }
 
-    collected.push(...(page.items ?? []));
-    pageToken = page.nextPageToken;
-    if (!pageToken) break;
+    break;
   }
 
   const { upserts, cancelled } = partitionEvents(collected);
@@ -133,14 +166,50 @@ export async function syncGoogleCalendar(
   }
 
   const lastSyncedAt = nowDate.toISOString();
-  // 成功したときだけ記録する (listEvents/refresh が throw した経路では呼ばれない)。
-  // ADR 0007 の起動時 15 分閾値判定、ADR 0006 の syncToken 保持の両方をこの 1 行で繋ぐ。
-  await deps.syncStateGateway.upsertLastSyncedAt(lastSyncedAt);
+  // 成功したときだけ atomic に lastSyncedAt + syncToken を記録する。
+  // listEvents が最後まで throw した経路ではここに来ないので、stale な syncToken は上書きされない。
+  await deps.syncStateGateway.saveSyncState({
+    lastSyncedAt,
+    syncToken: nextSyncToken ?? null,
+  });
 
   return {
     synced,
     deleted,
     lastSyncedAt,
+  };
+}
+
+/**
+ * full / incremental の差分は Google API の制約 (syncToken 併用不可) を埋め込んだ params 構築に閉じる。
+ * - syncToken あり: timeMin / timeMax / orderBy は付けない
+ * - syncToken なし: 通常の full sync
+ */
+function buildListParams(args: {
+  accessToken: string;
+  syncToken: string | undefined;
+  timeMin: string;
+  timeMax: string;
+  pageToken: string | undefined;
+}): ListEventsParams {
+  if (args.syncToken) {
+    return {
+      accessToken: args.accessToken,
+      calendarId: PRIMARY_CALENDAR_ID,
+      syncToken: args.syncToken,
+      // singleEvents は full sync と同じ値でなければならない (Google API 仕様)
+      singleEvents: true,
+      pageToken: args.pageToken,
+    };
+  }
+  return {
+    accessToken: args.accessToken,
+    calendarId: PRIMARY_CALENDAR_ID,
+    timeMin: args.timeMin,
+    timeMax: args.timeMax,
+    singleEvents: true,
+    orderBy: "startTime",
+    pageToken: args.pageToken,
   };
 }
 


### PR DESCRIPTION
- CalendarSyncStateGateway: upsertLastSyncedAt → saveSyncState({ lastSyncedAt, syncToken }) に振り替え。
  P2-3 で予約していた sync_token 列を atomic に書き込む。
- syncGoogleCalendar: 初回 full / 以降 syncToken incremental の 2 段構造に変更。
  - syncToken 保存済み → timeMin/timeMax/orderBy を送らず差分のみ取得
  - 410 Gone で syncToken 失効 → 1 度だけ full sync に fallback
  - 最終ページの nextSyncToken のみ採用 (中間ページのものは破棄)
  - 401 retry / cancelled 削除 / idempotent upsert の挙動は変えない
- ADR 0006 の Phase 2 後期マイルストーンを満たし、毎回の full fetch による API 消費を削減する。

Closes #54