### PR TITLE
chore(format): introduce Prettier with eslint-config-prettier (#31)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
               - 'postcss.config.*'
               - 'tailwind.config.*'
               - 'vitest.config.*'
+              - '.prettierrc*'
+              - '.prettierignore'
               - '.github/workflows/ci.yml'
             supabase:
               - 'supabase/**'
@@ -64,6 +66,20 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run lint
+
+  format:
+    name: Format
+    needs: changes
+    if: needs.changes.outputs.node == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run format:check
 
   test:
     name: Test

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+node_modules/
+.next/
+out/
+dist/
+coverage/
+package-lock.json
+tsconfig.tsbuildinfo
+supabase/.branches/
+supabase/.temp/

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,6 @@ package-lock.json
 tsconfig.tsbuildinfo
 supabase/.branches/
 supabase/.temp/
+
+# Markdown は対象外（テーブル padding / 空行整理が手書きのリズムと噛み合わない）
+*.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,10 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "arrowParens": "always",
+  "endOfLine": "lf",
+  "plugins": ["prettier-plugin-tailwindcss"]
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,9 +1,11 @@
 import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
 import nextTypescript from "eslint-config-next/typescript";
+import prettier from "eslint-config-prettier";
 
 export default [
   ...nextCoreWebVitals,
   ...nextTypescript,
+  prettier,
   {
     ignores: [".next/**", "node_modules/**", "out/**"],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,8 +25,11 @@
         "autoprefixer": "^10.5.0",
         "eslint": "^9.39.4",
         "eslint-config-next": "^16.2.4",
+        "eslint-config-prettier": "^10.1.8",
         "happy-dom": "^20.9.0",
         "postcss": "^8.5.10",
+        "prettier": "^3.8.3",
+        "prettier-plugin-tailwindcss": "^0.7.3",
         "tailwindcss": "^3.4.19",
         "typescript": "^6.0.2",
         "vitest": "^4.1.4"
@@ -4796,6 +4799,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.10",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
@@ -7315,6 +7334,101 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.7.3.tgz",
+      "integrity": "sha512-lckXaWWdo2ZVXoMoUO3WIBiz9hVY+YBEh1gYyMFfrWP9WZW/wpFXQKizHx7WrFQFMkcG0bGShdpp531X1n+qpg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-hermes": "*",
+        "@prettier/plugin-oxc": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "@zackad/prettier-plugin-twig": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-multiline-arrays": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-sort-imports": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-hermes": {
+          "optional": true
+        },
+        "@prettier/plugin-oxc": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@zackad/prettier-plugin-twig": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-multiline-arrays": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        }
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint src",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
@@ -31,8 +33,11 @@
     "autoprefixer": "^10.5.0",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.4",
+    "eslint-config-prettier": "^10.1.8",
     "happy-dom": "^20.9.0",
     "postcss": "^8.5.10",
+    "prettier": "^3.8.3",
+    "prettier-plugin-tailwindcss": "^0.7.3",
     "tailwindcss": "^3.4.19",
     "typescript": "^6.0.2",
     "vitest": "^4.1.4"

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -1,11 +1,6 @@
 "use client";
 
-import {
-  useMutation,
-  useQuery,
-  useQueryClient,
-  type QueryClient,
-} from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -39,10 +34,7 @@ import {
   useProjectGateway,
   useTaskGateway,
 } from "@/shared/gateway/GatewayContext";
-import {
-  readSampleDataMode,
-  writeSampleDataMode,
-} from "@/shared/lib/sample-data";
+import { readSampleDataMode, writeSampleDataMode } from "@/shared/lib/sample-data";
 import { isDone } from "@/shared/lib/task";
 import { todayIso } from "@/shared/lib/time";
 
@@ -90,10 +82,7 @@ export function AppShell({ initialView, user }: AppShellProps) {
     queryFn: () => eventGateway.list(),
   });
 
-  const projects = useMemo(
-    () => projectsQuery.data ?? [],
-    [projectsQuery.data],
-  );
+  const projects = useMemo(() => projectsQuery.data ?? [], [projectsQuery.data]);
   const tasks = useMemo(() => tasksQuery.data ?? [], [tasksQuery.data]);
   const events = useMemo(() => eventsQuery.data ?? [], [eventsQuery.data]);
 
@@ -193,8 +182,7 @@ export function AppShell({ initialView, user }: AppShellProps) {
   });
 
   const updateBodyMutation = useMutation({
-    mutationFn: ({ id, body }: { id: string; body: string }) =>
-      taskGateway.update(id, { body }),
+    mutationFn: ({ id, body }: { id: string; body: string }) => taskGateway.update(id, { body }),
     onMutate: async ({ id, body }) => {
       await queryClient.cancelQueries({ queryKey: keys.tasks });
       const previous = queryClient.getQueryData<Task[]>(keys.tasks);
@@ -214,13 +202,8 @@ export function AppShell({ initialView, user }: AppShellProps) {
   // P2-5 (#53): タスクの依存イベント設定。set / cleared を action_log に残し、
   // Phase 4 で「依存設定が着手順に効いたか」の分析データに使う。
   const updateDependencyMutation = useMutation({
-    mutationFn: ({
-      id,
-      dependsOnEventId,
-    }: {
-      id: string;
-      dependsOnEventId: string | null;
-    }) => taskGateway.update(id, { dependsOnEventId }),
+    mutationFn: ({ id, dependsOnEventId }: { id: string; dependsOnEventId: string | null }) =>
+      taskGateway.update(id, { dependsOnEventId }),
     onMutate: async ({ id, dependsOnEventId }) => {
       await queryClient.cancelQueries({ queryKey: keys.tasks });
       const previous = queryClient.getQueryData<Task[]>(keys.tasks);
@@ -238,9 +221,7 @@ export function AppShell({ initialView, user }: AppShellProps) {
         }
       }
       queryClient.setQueryData<Task[]>(keys.tasks, (prev) =>
-        (prev ?? []).map((t) =>
-          t.id === id ? { ...t, dependsOnEventId } : t,
-        ),
+        (prev ?? []).map((t) => (t.id === id ? { ...t, dependsOnEventId } : t)),
       );
       return { previous };
     },
@@ -382,10 +363,7 @@ export function AppShell({ initialView, user }: AppShellProps) {
     }
   }, [seedGateways, queryClient]);
 
-  const pendingTasks = useMemo(
-    () => tasks.filter((t) => !isDone(t)),
-    [tasks],
-  );
+  const pendingTasks = useMemo(() => tasks.filter((t) => !isDone(t)), [tasks]);
   const doneTasks = useMemo(() => tasks.filter((t) => isDone(t)), [tasks]);
   const detailTask = detailId ? tasks.find((t) => t.id === detailId) : null;
 
@@ -457,9 +435,7 @@ export function AppShell({ initialView, user }: AppShellProps) {
                   key={tab.key}
                   href={tab.href}
                   className={`cursor-pointer rounded-[4px] px-3.5 py-1 text-[11px] font-medium no-underline ${
-                    active
-                      ? "bg-bg-divider text-fg-emphasized"
-                      : "bg-transparent text-fg-weak"
+                    active ? "bg-bg-divider text-fg-emphasized" : "bg-transparent text-fg-weak"
                   }`}
                 >
                   {tab.label}
@@ -480,10 +456,7 @@ export function AppShell({ initialView, user }: AppShellProps) {
           />
         </div>
 
-        <ReauthBanner
-          visible={calendarSync.needsReauth}
-          onDismiss={calendarSync.dismissReauth}
-        />
+        <ReauthBanner visible={calendarSync.needsReauth} onDismiss={calendarSync.dismissReauth} />
 
         {view === "stack" ? (
           <StackView
@@ -500,10 +473,7 @@ export function AppShell({ initialView, user }: AppShellProps) {
             onOpenEvent={setEventDetailId}
           />
         ) : (
-          <TreeView
-            historyData={historyData}
-            projectOrder={projectOrderForTree}
-          />
+          <TreeView historyData={historyData} projectOrder={projectOrderForTree} />
         )}
 
         {detailTask && (
@@ -557,12 +527,8 @@ export function AppShell({ initialView, user }: AppShellProps) {
         ) : null}
 
         {pauseModalOpen ? (
-          <PauseReasonModal
-            onSelect={handlePauseSelect}
-            onClose={() => setPauseModalOpen(false)}
-          />
+          <PauseReasonModal onSelect={handlePauseSelect} onClose={() => setPauseModalOpen(false)} />
         ) : null}
-
       </div>
     </ProjectsProvider>
   );
@@ -609,7 +575,10 @@ function mergeTreeProjects(
 // history (mock) に現れる slug 群だけ埋めれば十分。
 const TREE_FALLBACK_BY_SLUG: ReadonlyMap<string, Project> = new Map([
   ["career", { id: "career", name: "転職活動", color: "#E85D04", isPrimary: false, createdAt: "" }],
-  ["loadtest", { id: "loadtest", name: "負荷試験", color: "#0096C7", isPrimary: false, createdAt: "" }],
+  [
+    "loadtest",
+    { id: "loadtest", name: "負荷試験", color: "#0096C7", isPrimary: false, createdAt: "" },
+  ],
   ["slo", { id: "slo", name: "SLO推進", color: "#2D9F45", isPrimary: true, createdAt: "" }],
   ["tasuki", { id: "tasuki", name: "Tasuki", color: "#9B5DE5", isPrimary: false, createdAt: "" }],
 ]);
@@ -643,12 +612,7 @@ function StackView({
 }: StackViewProps) {
   return (
     <div className="pb-[100px]">
-      <DayTimeline
-        events={events}
-        nowMin={nowMin}
-        today={today}
-        onOpenEvent={onOpenEvent}
-      />
+      <DayTimeline events={events} nowMin={nowMin} today={today} onOpenEvent={onOpenEvent} />
       <TaskStack
         events={events}
         pendingTasks={pendingTasks}

--- a/src/app/api/calendar/sync/route.test.ts
+++ b/src/app/api/calendar/sync/route.test.ts
@@ -10,10 +10,7 @@ vi.mock("@/entities/event/sync", () => ({
 }));
 
 import { syncGoogleCalendar } from "@/entities/event/sync";
-import {
-  ProviderTokenMissingError,
-  RefreshTokenExpiredError,
-} from "@/shared/google/token";
+import { ProviderTokenMissingError, RefreshTokenExpiredError } from "@/shared/google/token";
 import { createClient } from "@/shared/supabase/server";
 
 import { POST } from "./route";
@@ -59,9 +56,7 @@ describe("POST /api/calendar/sync", () => {
     vi.mocked(createClient).mockResolvedValue(
       makeSupabase({ provider_token: null, provider_refresh_token: null }),
     );
-    vi.mocked(syncGoogleCalendar).mockRejectedValue(
-      new ProviderTokenMissingError("no token"),
-    );
+    vi.mocked(syncGoogleCalendar).mockRejectedValue(new ProviderTokenMissingError("no token"));
 
     const response = await POST();
 
@@ -77,9 +72,7 @@ describe("POST /api/calendar/sync", () => {
         provider_refresh_token: "expired",
       }),
     );
-    vi.mocked(syncGoogleCalendar).mockRejectedValue(
-      new RefreshTokenExpiredError("refresh failed"),
-    );
+    vi.mocked(syncGoogleCalendar).mockRejectedValue(new RefreshTokenExpiredError("refresh failed"));
 
     const response = await POST();
 
@@ -120,9 +113,7 @@ describe("POST /api/calendar/sync", () => {
         provider_refresh_token: "refresh-1",
       }),
     );
-    vi.mocked(syncGoogleCalendar).mockRejectedValue(
-      new Error("unexpected failure"),
-    );
+    vi.mocked(syncGoogleCalendar).mockRejectedValue(new Error("unexpected failure"));
 
     const response = await POST();
 

--- a/src/app/api/calendar/sync/route.ts
+++ b/src/app/api/calendar/sync/route.ts
@@ -1,10 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { syncGoogleCalendar } from "@/entities/event/sync";
-import {
-  ProviderTokenMissingError,
-  RefreshTokenExpiredError,
-} from "@/shared/google/token";
+import { ProviderTokenMissingError, RefreshTokenExpiredError } from "@/shared/google/token";
 import { createClient } from "@/shared/supabase/server";
 
 /**
@@ -29,10 +26,7 @@ export async function POST() {
     const result = await syncGoogleCalendar(supabase);
     return NextResponse.json(result);
   } catch (error) {
-    if (
-      error instanceof ProviderTokenMissingError ||
-      error instanceof RefreshTokenExpiredError
-    ) {
+    if (error instanceof ProviderTokenMissingError || error instanceof RefreshTokenExpiredError) {
       return NextResponse.json(
         {
           error: "provider_token_missing",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,11 +25,7 @@ export const metadata: Metadata = {
   description: "個人特化AI秘書システム",
 };
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ja" className={`${ibmPlexMono.variable} ${notoSansJp.variable}`}>
       <body className="mx-auto min-h-screen max-w-[480px] bg-bg-primary font-mono text-fg-default">

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -21,9 +21,7 @@ export default async function LoginPage() {
           <span className="text-accent-blue">kozu</span>
           <span className="text-fg-faint">tsumi</span>
         </div>
-        <p className="mt-3 text-[12px] text-fg-weak">
-          個人特化AI秘書システム
-        </p>
+        <p className="mt-3 text-[12px] text-fg-weak">個人特化AI秘書システム</p>
       </div>
       <LoginButton />
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,8 +22,7 @@ export default async function Page() {
         initialView="stack"
         user={{
           email: user.email ?? null,
-          avatarUrl:
-            typeof meta.avatar_url === "string" ? meta.avatar_url : null,
+          avatarUrl: typeof meta.avatar_url === "string" ? meta.avatar_url : null,
         }}
       />
     </GatewayProvider>

--- a/src/app/tree/page.tsx
+++ b/src/app/tree/page.tsx
@@ -22,8 +22,7 @@ export default async function TreePage() {
         initialView="tree"
         user={{
           email: user.email ?? null,
-          avatarUrl:
-            typeof meta.avatar_url === "string" ? meta.avatar_url : null,
+          avatarUrl: typeof meta.avatar_url === "string" ? meta.avatar_url : null,
         }}
       />
     </GatewayProvider>

--- a/src/entities/action-log/logger.test.ts
+++ b/src/entities/action-log/logger.test.ts
@@ -19,13 +19,7 @@ vi.mock("@/shared/supabase/client", () => ({
   }),
 }));
 
-import {
-  ACTION_TYPES,
-  __resetLoggerClientForTest,
-  clearLog,
-  getLog,
-  log,
-} from "./logger";
+import { ACTION_TYPES, __resetLoggerClientForTest, clearLog, getLog, log } from "./logger";
 
 function flushMicrotasks() {
   // persist() は fire-and-forget で複数段の await を含むため、

--- a/src/entities/action-log/logger.ts
+++ b/src/entities/action-log/logger.ts
@@ -1,11 +1,7 @@
 import { createClient } from "@/shared/supabase/client";
 import type { Json } from "@/shared/types/database";
 
-import type {
-  ActionLogEntry,
-  ActionMetadataMap,
-  ActionType,
-} from "./types";
+import type { ActionLogEntry, ActionMetadataMap, ActionType } from "./types";
 
 /**
  * action-log logger
@@ -64,9 +60,7 @@ function extractTaskId(metadata: Record<string, unknown>): string | null {
   return typeof v === "string" ? v : null;
 }
 
-async function persist<T extends ActionType>(
-  entry: ActionLogEntry<T>,
-): Promise<void> {
+async function persist<T extends ActionType>(entry: ActionLogEntry<T>): Promise<void> {
   const supabase = getClient();
   if (!supabase) return;
 
@@ -81,9 +75,7 @@ async function persist<T extends ActionType>(
   const { error } = await supabase.from("action_logs").insert({
     user_id: user.id,
     action_type: entry.action_type,
-    task_id: extractTaskId(
-      entry.metadata as unknown as Record<string, unknown>,
-    ),
+    task_id: extractTaskId(entry.metadata as unknown as Record<string, unknown>),
     metadata: entry.metadata as unknown as Json,
   });
   if (error) {

--- a/src/entities/calendar-sync/gateway.ts
+++ b/src/entities/calendar-sync/gateway.ts
@@ -18,8 +18,5 @@ export interface CalendarSyncStateGateway {
    * `syncToken: null` を渡すと DB の `sync_token` も `null` に上書きされ、次回は full sync になる
    * (410 Gone fallback で nextSyncToken が得られなかったケース等)。
    */
-  saveSyncState(input: {
-    lastSyncedAt: string;
-    syncToken: string | null;
-  }): Promise<void>;
+  saveSyncState(input: { lastSyncedAt: string; syncToken: string | null }): Promise<void>;
 }

--- a/src/entities/calendar-sync/supabase-gateway.test.ts
+++ b/src/entities/calendar-sync/supabase-gateway.test.ts
@@ -21,9 +21,7 @@ function makeSupabase(overrides: {
   upsertError?: { message: string } | null;
 }) {
   const userId = overrides.getUserId === undefined ? "user-1" : overrides.getUserId;
-  const maybeSingle = vi.fn(async () =>
-    overrides.selectResult ?? { data: null, error: null },
-  );
+  const maybeSingle = vi.fn(async () => overrides.selectResult ?? { data: null, error: null });
   const eqSelect = vi.fn(() => ({ maybeSingle }));
   const select = vi.fn(() => ({ eq: eqSelect }));
   const upsert = vi.fn<
@@ -67,9 +65,7 @@ describe("SupabaseCalendarSyncStateGateway.get", () => {
       syncToken: "tok-abc",
     });
     expect(from).toHaveBeenCalledWith("user_calendar_sync_state");
-    expect(select).toHaveBeenCalledWith(
-      "user_id, last_synced_at, sync_token, updated_at",
-    );
+    expect(select).toHaveBeenCalledWith("user_id, last_synced_at, sync_token, updated_at");
     expect(eqSelect).toHaveBeenCalledWith("user_id", "user-1");
   });
 

--- a/src/entities/calendar-sync/supabase-gateway.ts
+++ b/src/entities/calendar-sync/supabase-gateway.ts
@@ -2,16 +2,11 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 
 import type { Database, TablesInsert } from "@/shared/types/database";
 
-import type {
-  CalendarSyncState,
-  CalendarSyncStateGateway,
-} from "./gateway";
+import type { CalendarSyncState, CalendarSyncStateGateway } from "./gateway";
 
 type Sb = SupabaseClient<Database>;
 
-export class SupabaseCalendarSyncStateGateway
-  implements CalendarSyncStateGateway
-{
+export class SupabaseCalendarSyncStateGateway implements CalendarSyncStateGateway {
   constructor(private readonly supabase: Sb) {}
 
   async get(): Promise<CalendarSyncState | null> {
@@ -33,10 +28,7 @@ export class SupabaseCalendarSyncStateGateway
     };
   }
 
-  async saveSyncState(input: {
-    lastSyncedAt: string;
-    syncToken: string | null;
-  }): Promise<void> {
+  async saveSyncState(input: { lastSyncedAt: string; syncToken: string | null }): Promise<void> {
     const {
       data: { user },
     } = await this.supabase.auth.getUser();

--- a/src/entities/event/GoogleCalendarBadge.tsx
+++ b/src/entities/event/GoogleCalendarBadge.tsx
@@ -17,9 +17,7 @@ export function GoogleCalendarBadge({ size = "sm", className }: Props) {
       aria-label="Google Calendar から同期"
       title="Google Calendar から同期"
       className={`inline-flex shrink-0 items-center justify-center rounded-[3px] border border-bg-divider bg-bg-elevated font-jp font-semibold leading-none text-fg-subtle ${
-        size === "md"
-          ? "h-[18px] w-[18px] text-[10px]"
-          : "h-[14px] w-[14px] text-[8px]"
+        size === "md" ? "h-[18px] w-[18px] text-[10px]" : "h-[14px] w-[14px] text-[8px]"
       } ${className ?? ""}`}
       data-testid="google-calendar-badge"
     >

--- a/src/entities/event/gateway.ts
+++ b/src/entities/event/gateway.ts
@@ -46,9 +46,7 @@ export interface EventGateway {
    * `(source='google_calendar', external_id)` 単位で upsert。既存行の `project_id` は保持する。
    * @returns upsert された行数
    */
-  upsertFromGoogleCalendar(
-    inputs: UpsertGoogleCalendarEventInput[],
-  ): Promise<number>;
+  upsertFromGoogleCalendar(inputs: UpsertGoogleCalendarEventInput[]): Promise<number>;
   /**
    * Google 側で `status='cancelled'` になったイベントをローカルから削除する。
    * @returns 削除された行数

--- a/src/entities/event/supabase-gateway.test.ts
+++ b/src/entities/event/supabase-gateway.test.ts
@@ -85,9 +85,7 @@ function makeSupabase(opts: {
       return takeResult();
     };
     // delete().eq(...) はそのまま await されるので thenable にする
-    (builder as { then?: unknown }).then = (
-      onFulfilled: (value: unknown) => unknown,
-    ) => {
+    (builder as { then?: unknown }).then = (onFulfilled: (value: unknown) => unknown) => {
       record(table, "await", []);
       return Promise.resolve(takeResult()).then(onFulfilled);
     };
@@ -131,9 +129,7 @@ describe("SupabaseEventGateway.update", () => {
     expect(eventsCalls[0]).toMatchObject({ method: "select", args: ["source"] });
     expect(
       eventsCalls.some(
-        (c) =>
-          c.method === "update" &&
-          (c.args[0] as Record<string, unknown>).title === "Renamed",
+        (c) => c.method === "update" && (c.args[0] as Record<string, unknown>).title === "Renamed",
       ),
     ).toBe(true);
   });
@@ -187,9 +183,7 @@ describe("SupabaseEventGateway.update", () => {
         results: [{ data: { source: "google_calendar" } }],
       });
       const gw = new SupabaseEventGateway(supabase);
-      await expect(gw.update("g1", patch)).rejects.toThrow(
-        /google_calendar event is read-only/,
-      );
+      await expect(gw.update("g1", patch)).rejects.toThrow(/google_calendar event is read-only/);
     }
   });
 
@@ -199,9 +193,9 @@ describe("SupabaseEventGateway.update", () => {
     });
     const gw = new SupabaseEventGateway(supabase);
 
-    await expect(
-      gw.update("g1", { projectId: "slo", title: "x" }),
-    ).rejects.toThrow(/google_calendar event is read-only/);
+    await expect(gw.update("g1", { projectId: "slo", title: "x" })).rejects.toThrow(
+      /google_calendar event is read-only/,
+    );
   });
 });
 
@@ -229,8 +223,6 @@ describe("SupabaseEventGateway.delete", () => {
     });
     const gw = new SupabaseEventGateway(supabase);
 
-    await expect(gw.delete("g1")).rejects.toThrow(
-      /google_calendar event cannot be deleted/,
-    );
+    await expect(gw.delete("g1")).rejects.toThrow(/google_calendar event cannot be deleted/);
   });
 });

--- a/src/entities/event/supabase-gateway.ts
+++ b/src/entities/event/supabase-gateway.ts
@@ -1,11 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-import type {
-  Database,
-  Tables,
-  TablesInsert,
-  TablesUpdate,
-} from "@/shared/types/database";
+import type { Database, Tables, TablesInsert, TablesUpdate } from "@/shared/types/database";
 
 import type {
   CreateEventInput,
@@ -67,11 +62,7 @@ export class SupabaseEventGateway implements EventGateway {
       source: input.source ?? EVENT_SOURCE.MANUAL,
       external_id: input.externalId ?? null,
     };
-    const { data, error } = await this.supabase
-      .from("events")
-      .insert(payload)
-      .select("*")
-      .single();
+    const { data, error } = await this.supabase.from("events").insert(payload).select("*").single();
     if (error) throw error;
     return fromRow(data);
   }
@@ -89,9 +80,7 @@ export class SupabaseEventGateway implements EventGateway {
     if (touchesGoogleOwned) {
       const source = await this.fetchSource(id);
       if (source === EVENT_SOURCE.GOOGLE_CALENDAR) {
-        throw new Error(
-          "google_calendar event is read-only (only project_id can be updated)",
-        );
+        throw new Error("google_calendar event is read-only (only project_id can be updated)");
       }
     }
     const update: TablesUpdate<"events"> = {};
@@ -100,8 +89,7 @@ export class SupabaseEventGateway implements EventGateway {
     if (patch.endTime !== undefined) update.end_time = patch.endTime;
     if (patch.projectId !== undefined) update.project_id = patch.projectId;
     if (patch.meetUrl !== undefined) update.meet_url = patch.meetUrl;
-    if (patch.hasAttachments !== undefined)
-      update.has_attachments = patch.hasAttachments;
+    if (patch.hasAttachments !== undefined) update.has_attachments = patch.hasAttachments;
     if (patch.description !== undefined) update.description = patch.description;
     const { data, error } = await this.supabase
       .from("events")
@@ -141,16 +129,11 @@ export class SupabaseEventGateway implements EventGateway {
 
   async deleteAllForCurrentUser(): Promise<void> {
     const uid = await getUserId(this.supabase);
-    const { error } = await this.supabase
-      .from("events")
-      .delete()
-      .eq("user_id", uid);
+    const { error } = await this.supabase.from("events").delete().eq("user_id", uid);
     if (error) throw error;
   }
 
-  async upsertFromGoogleCalendar(
-    inputs: UpsertGoogleCalendarEventInput[],
-  ): Promise<number> {
+  async upsertFromGoogleCalendar(inputs: UpsertGoogleCalendarEventInput[]): Promise<number> {
     if (inputs.length === 0) return 0;
     const user_id = await getUserId(this.supabase);
     // project_id を payload に含めないことで、ON CONFLICT DO UPDATE SET ... から除外され、

--- a/src/entities/event/sync.test.ts
+++ b/src/entities/event/sync.test.ts
@@ -12,10 +12,7 @@ import {
 import { RefreshTokenExpiredError } from "@/shared/google/token";
 import type { Database } from "@/shared/types/database";
 
-import type {
-  EventGateway,
-  UpsertGoogleCalendarEventInput,
-} from "./gateway";
+import type { EventGateway, UpsertGoogleCalendarEventInput } from "./gateway";
 import {
   extractMeetUrl,
   mapGoogleEventToUpsertInput,
@@ -68,9 +65,7 @@ describe("extractMeetUrl", () => {
         id: "e1",
         hangoutLink: "https://meet.google.com/abc-defg-hij",
         conferenceData: {
-          entryPoints: [
-            { entryPointType: "video", uri: "https://other.example/video" },
-          ],
+          entryPoints: [{ entryPointType: "video", uri: "https://other.example/video" }],
         },
       }),
     ).toBe("https://meet.google.com/abc-defg-hij");
@@ -137,9 +132,7 @@ describe("mapGoogleEventToUpsertInput", () => {
   });
 
   test("時刻が無い壊れたイベントは null を返す", () => {
-    expect(
-      mapGoogleEventToUpsertInput({ id: "bad", start: {}, end: {} }),
-    ).toBeNull();
+    expect(mapGoogleEventToUpsertInput({ id: "bad", start: {}, end: {} })).toBeNull();
   });
 });
 
@@ -167,10 +160,7 @@ describe("partitionEvents", () => {
     const result = partitionEvents(events);
 
     expect(result.cancelled).toEqual(["deleted-1", "deleted-2"]);
-    expect(result.upserts.map((u) => u.externalId)).toEqual([
-      "active-1",
-      "active-2",
-    ]);
+    expect(result.upserts.map((u) => u.externalId)).toEqual(["active-1", "active-2"]);
   });
 });
 
@@ -178,9 +168,7 @@ describe("partitionEvents", () => {
 // syncGoogleCalendar orchestration
 // =====================================================================
 
-type ListEventsFn = (
-  params: ListEventsParams,
-) => Promise<GoogleCalendarEventsListResponse>;
+type ListEventsFn = (params: ListEventsParams) => Promise<GoogleCalendarEventsListResponse>;
 
 function makeFakeGateway() {
   const upsertCalls: UpsertGoogleCalendarEventInput[][] = [];
@@ -203,10 +191,12 @@ function makeFakeGateway() {
   return { gateway, upsertCalls, deleteCalls };
 }
 
-function makeFakeSyncStateGateway(initial: {
-  lastSyncedAt: string;
-  syncToken: string | null;
-} | null = null) {
+function makeFakeSyncStateGateway(
+  initial: {
+    lastSyncedAt: string;
+    syncToken: string | null;
+  } | null = null,
+) {
   const get = vi.fn<() => Promise<typeof initial>>(async () => initial);
   const saveSyncState = vi.fn<
     (input: { lastSyncedAt: string; syncToken: string | null }) => Promise<void>
@@ -241,8 +231,7 @@ function makeDeps(overrides: {
 }) {
   return {
     gateway: overrides.gateway,
-    syncStateGateway:
-      overrides.syncStateGateway ?? makeFakeSyncStateGateway().gateway,
+    syncStateGateway: overrides.syncStateGateway ?? makeFakeSyncStateGateway().gateway,
     listEvents: overrides.listEvents,
     getValidAccessToken: vi.fn(async () => ({
       accessToken: overrides.accessToken ?? "t",
@@ -311,21 +300,13 @@ describe("syncGoogleCalendar (full sync)", () => {
         nextSyncToken: "final-sync",
       });
 
-    const result = await syncGoogleCalendar(
-      FAKE_SUPABASE,
-      makeDeps({ gateway, listEvents }),
-    );
+    const result = await syncGoogleCalendar(FAKE_SUPABASE, makeDeps({ gateway, listEvents }));
 
     expect(result.synced).toBe(4);
     expect(listEvents).toHaveBeenCalledTimes(3);
     expect(listEvents.mock.calls[1]![0].pageToken).toBe("tok-2");
     expect(listEvents.mock.calls[2]![0].pageToken).toBe("tok-3");
-    expect(upsertCalls[0]!.map((e) => e.externalId)).toEqual([
-      "p1-a",
-      "p1-b",
-      "p2-a",
-      "p3-a",
-    ]);
+    expect(upsertCalls[0]!.map((e) => e.externalId)).toEqual(["p1-a", "p1-b", "p2-a", "p3-a"]);
   });
 
   test("cancelled イベントは delete 側に集約される", async () => {
@@ -338,10 +319,7 @@ describe("syncGoogleCalendar (full sync)", () => {
       ],
     }));
 
-    const result = await syncGoogleCalendar(
-      FAKE_SUPABASE,
-      makeDeps({ gateway, listEvents }),
-    );
+    const result = await syncGoogleCalendar(FAKE_SUPABASE, makeDeps({ gateway, listEvents }));
 
     expect(result.synced).toBe(1);
     expect(result.deleted).toBe(2);
@@ -353,10 +331,7 @@ describe("syncGoogleCalendar (full sync)", () => {
     const { gateway, upsertCalls, deleteCalls } = makeFakeGateway();
     const listEvents = vi.fn<ListEventsFn>(async () => ({ items: [] }));
 
-    const result = await syncGoogleCalendar(
-      FAKE_SUPABASE,
-      makeDeps({ gateway, listEvents }),
-    );
+    const result = await syncGoogleCalendar(FAKE_SUPABASE, makeDeps({ gateway, listEvents }));
 
     expect(result).toMatchObject({ synced: 0, deleted: 0 });
     expect(upsertCalls).toHaveLength(0);
@@ -439,8 +414,7 @@ describe("syncGoogleCalendar (full sync)", () => {
 
   test("成功時は last_synced_at + nextSyncToken を atomic に永続化する", async () => {
     const { gateway } = makeFakeGateway();
-    const { gateway: syncStateGateway, saveSyncState } =
-      makeFakeSyncStateGateway();
+    const { gateway: syncStateGateway, saveSyncState } = makeFakeSyncStateGateway();
     const listEvents = vi.fn<ListEventsFn>(async () => ({
       items: [makeActiveEvent("a")],
       nextSyncToken: "fresh-tok",
@@ -466,14 +440,10 @@ describe("syncGoogleCalendar (full sync)", () => {
 
   test("nextSyncToken が無いレスポンスは syncToken: null で保存する", async () => {
     const { gateway } = makeFakeGateway();
-    const { gateway: syncStateGateway, saveSyncState } =
-      makeFakeSyncStateGateway();
+    const { gateway: syncStateGateway, saveSyncState } = makeFakeSyncStateGateway();
     const listEvents = vi.fn<ListEventsFn>(async () => ({ items: [] }));
 
-    await syncGoogleCalendar(
-      FAKE_SUPABASE,
-      makeDeps({ gateway, syncStateGateway, listEvents }),
-    );
+    await syncGoogleCalendar(FAKE_SUPABASE, makeDeps({ gateway, syncStateGateway, listEvents }));
 
     expect(saveSyncState).toHaveBeenCalledWith({
       lastSyncedAt: expect.any(String),
@@ -483,11 +453,10 @@ describe("syncGoogleCalendar (full sync)", () => {
 
   test("401 retry 後も失敗する場合は sync state を上書きしない (stale syncToken を保持)", async () => {
     const { gateway } = makeFakeGateway();
-    const { gateway: syncStateGateway, saveSyncState } =
-      makeFakeSyncStateGateway({
-        lastSyncedAt: "2026-04-23T00:00:00.000Z",
-        syncToken: "previous",
-      });
+    const { gateway: syncStateGateway, saveSyncState } = makeFakeSyncStateGateway({
+      lastSyncedAt: "2026-04-23T00:00:00.000Z",
+      syncToken: "previous",
+    });
     const listEvents = vi.fn<ListEventsFn>(async () => {
       throw new GoogleApiUnauthorizedError();
     });
@@ -515,11 +484,10 @@ describe("syncGoogleCalendar (full sync)", () => {
 describe("syncGoogleCalendar (incremental sync via syncToken)", () => {
   test("syncToken が DB にあれば incremental として呼び出す (timeMin/timeMax/orderBy を送らない)", async () => {
     const { gateway, upsertCalls } = makeFakeGateway();
-    const { gateway: syncStateGateway, saveSyncState } =
-      makeFakeSyncStateGateway({
-        lastSyncedAt: "2026-04-23T00:00:00.000Z",
-        syncToken: "tok-prev",
-      });
+    const { gateway: syncStateGateway, saveSyncState } = makeFakeSyncStateGateway({
+      lastSyncedAt: "2026-04-23T00:00:00.000Z",
+      syncToken: "tok-prev",
+    });
     const listEvents = vi.fn<ListEventsFn>(async () => ({
       items: [makeActiveEvent("incr-1")],
       nextSyncToken: "tok-next",
@@ -558,10 +526,7 @@ describe("syncGoogleCalendar (incremental sync via syncToken)", () => {
       syncToken: "tok-prev",
     });
     const listEvents = vi.fn<ListEventsFn>(async () => ({
-      items: [
-        { id: "gone-incr", status: "cancelled" },
-        makeActiveEvent("kept"),
-      ],
+      items: [{ id: "gone-incr", status: "cancelled" }, makeActiveEvent("kept")],
       nextSyncToken: "tok-next",
     }));
 
@@ -576,11 +541,10 @@ describe("syncGoogleCalendar (incremental sync via syncToken)", () => {
 
   test("incremental sync のページングは中間ページの nextSyncToken を無視し最終ページのみ採用する", async () => {
     const { gateway } = makeFakeGateway();
-    const { gateway: syncStateGateway, saveSyncState } =
-      makeFakeSyncStateGateway({
-        lastSyncedAt: "2026-04-23T00:00:00.000Z",
-        syncToken: "tok-prev",
-      });
+    const { gateway: syncStateGateway, saveSyncState } = makeFakeSyncStateGateway({
+      lastSyncedAt: "2026-04-23T00:00:00.000Z",
+      syncToken: "tok-prev",
+    });
     const listEvents = vi.fn<ListEventsFn>();
     listEvents
       .mockResolvedValueOnce({
@@ -594,10 +558,7 @@ describe("syncGoogleCalendar (incremental sync via syncToken)", () => {
         nextSyncToken: "final-only",
       });
 
-    await syncGoogleCalendar(
-      FAKE_SUPABASE,
-      makeDeps({ gateway, syncStateGateway, listEvents }),
-    );
+    await syncGoogleCalendar(FAKE_SUPABASE, makeDeps({ gateway, syncStateGateway, listEvents }));
 
     expect(saveSyncState).toHaveBeenCalledWith({
       lastSyncedAt: expect.any(String),
@@ -607,16 +568,13 @@ describe("syncGoogleCalendar (incremental sync via syncToken)", () => {
 
   test("410 Gone を受けたら syncToken を捨てて full sync に fallback する", async () => {
     const { gateway, upsertCalls } = makeFakeGateway();
-    const { gateway: syncStateGateway, saveSyncState } =
-      makeFakeSyncStateGateway({
-        lastSyncedAt: "2026-04-23T00:00:00.000Z",
-        syncToken: "tok-stale",
-      });
+    const { gateway: syncStateGateway, saveSyncState } = makeFakeSyncStateGateway({
+      lastSyncedAt: "2026-04-23T00:00:00.000Z",
+      syncToken: "tok-stale",
+    });
     const listEvents = vi.fn<ListEventsFn>();
     listEvents
-      .mockRejectedValueOnce(
-        new GoogleApiError("Gone", 410, { error: "fullSyncRequired" }),
-      )
+      .mockRejectedValueOnce(new GoogleApiError("Gone", 410, { error: "fullSyncRequired" }))
       .mockResolvedValueOnce({
         items: [makeActiveEvent("after-fallback")],
         nextSyncToken: "fresh-after-fallback",
@@ -642,9 +600,7 @@ describe("syncGoogleCalendar (incremental sync via syncToken)", () => {
     expect(listEvents.mock.calls[1]![0].timeMin).toBeDefined();
     expect(listEvents.mock.calls[1]![0].timeMax).toBeDefined();
     expect(listEvents.mock.calls[1]![0].orderBy).toBe("startTime");
-    expect(upsertCalls[0]!.map((e) => e.externalId)).toEqual([
-      "after-fallback",
-    ]);
+    expect(upsertCalls[0]!.map((e) => e.externalId)).toEqual(["after-fallback"]);
     // fallback 後の full sync で得た新しい syncToken を保存
     expect(saveSyncState).toHaveBeenCalledWith({
       lastSyncedAt: "2026-04-24T05:00:00.000Z",
@@ -660,10 +616,7 @@ describe("syncGoogleCalendar (incremental sync via syncToken)", () => {
     });
 
     await expect(
-      syncGoogleCalendar(
-        FAKE_SUPABASE,
-        makeDeps({ gateway, syncStateGateway, listEvents }),
-      ),
+      syncGoogleCalendar(FAKE_SUPABASE, makeDeps({ gateway, syncStateGateway, listEvents })),
     ).rejects.toBeInstanceOf(GoogleApiError);
 
     expect(listEvents).toHaveBeenCalledTimes(1);
@@ -680,10 +633,7 @@ describe("syncGoogleCalendar (incremental sync via syncToken)", () => {
     });
 
     await expect(
-      syncGoogleCalendar(
-        FAKE_SUPABASE,
-        makeDeps({ gateway, syncStateGateway, listEvents }),
-      ),
+      syncGoogleCalendar(FAKE_SUPABASE, makeDeps({ gateway, syncStateGateway, listEvents })),
     ).rejects.toBeInstanceOf(GoogleApiError);
 
     // 1 回目 incremental → 410, 2 回目 full → また 410 で throw

--- a/src/entities/event/sync.ts
+++ b/src/entities/event/sync.ts
@@ -17,10 +17,7 @@ import {
 } from "@/shared/google/token";
 import type { Database } from "@/shared/types/database";
 
-import type {
-  EventGateway,
-  UpsertGoogleCalendarEventInput,
-} from "./gateway";
+import type { EventGateway, UpsertGoogleCalendarEventInput } from "./gateway";
 import { SupabaseEventGateway } from "./supabase-gateway";
 
 /**
@@ -54,15 +51,9 @@ export type SyncResult = {
 export type SyncGoogleCalendarDeps = {
   gateway: EventGateway;
   syncStateGateway: CalendarSyncStateGateway;
-  listEvents: (
-    params: ListEventsParams,
-  ) => Promise<GoogleCalendarEventsListResponse>;
-  getValidAccessToken: (
-    supabase: SupabaseClient<Database>,
-  ) => Promise<GoogleProviderAccess>;
-  refreshAccessToken: (
-    supabase: SupabaseClient<Database>,
-  ) => Promise<GoogleProviderAccess>;
+  listEvents: (params: ListEventsParams) => Promise<GoogleCalendarEventsListResponse>;
+  getValidAccessToken: (supabase: SupabaseClient<Database>) => Promise<GoogleProviderAccess>;
+  refreshAccessToken: (supabase: SupabaseClient<Database>) => Promise<GoogleProviderAccess>;
   now: () => Date;
 };
 
@@ -72,28 +63,19 @@ export async function syncGoogleCalendar(
 ): Promise<SyncResult> {
   const deps: SyncGoogleCalendarDeps = {
     gateway: overrides.gateway ?? new SupabaseEventGateway(supabase),
-    syncStateGateway:
-      overrides.syncStateGateway ??
-      new SupabaseCalendarSyncStateGateway(supabase),
+    syncStateGateway: overrides.syncStateGateway ?? new SupabaseCalendarSyncStateGateway(supabase),
     listEvents: overrides.listEvents ?? defaultListEvents,
-    getValidAccessToken:
-      overrides.getValidAccessToken ?? defaultGetValidAccessToken,
-    refreshAccessToken:
-      overrides.refreshAccessToken ?? defaultRefreshAccessToken,
+    getValidAccessToken: overrides.getValidAccessToken ?? defaultGetValidAccessToken,
+    refreshAccessToken: overrides.refreshAccessToken ?? defaultRefreshAccessToken,
     now: overrides.now ?? (() => new Date()),
   };
 
   const nowDate = deps.now();
-  const timeMin = new Date(
-    nowDate.getTime() - SYNC_WINDOW_PAST_DAYS * MS_PER_DAY,
-  ).toISOString();
-  const timeMax = new Date(
-    nowDate.getTime() + SYNC_WINDOW_FUTURE_DAYS * MS_PER_DAY,
-  ).toISOString();
+  const timeMin = new Date(nowDate.getTime() - SYNC_WINDOW_PAST_DAYS * MS_PER_DAY).toISOString();
+  const timeMax = new Date(nowDate.getTime() + SYNC_WINDOW_FUTURE_DAYS * MS_PER_DAY).toISOString();
 
   const initialState = await deps.syncStateGateway.get();
-  let activeSyncToken: string | undefined =
-    initialState?.syncToken ?? undefined;
+  let activeSyncToken: string | undefined = initialState?.syncToken ?? undefined;
 
   const initial = await deps.getValidAccessToken(supabase);
   let accessToken = initial.accessToken;
@@ -242,8 +224,7 @@ export function mapGoogleEventToUpsertInput(
     startTime: times.start,
     endTime: times.end,
     meetUrl: extractMeetUrl(event),
-    hasAttachments:
-      Array.isArray(event.attachments) && event.attachments.length > 0,
+    hasAttachments: Array.isArray(event.attachments) && event.attachments.length > 0,
     description: event.description ?? "",
   };
 }

--- a/src/entities/project/ProjectsContext.tsx
+++ b/src/entities/project/ProjectsContext.tsx
@@ -23,11 +23,7 @@ export function ProjectsProvider({
     () => ({ projects, projectsById: indexProjectsById(projects) }),
     [projects],
   );
-  return (
-    <ProjectsContext.Provider value={value}>
-      {children}
-    </ProjectsContext.Provider>
-  );
+  return <ProjectsContext.Provider value={value}>{children}</ProjectsContext.Provider>;
 }
 
 /**

--- a/src/entities/project/projects.ts
+++ b/src/entities/project/projects.ts
@@ -22,9 +22,7 @@ export const PROJECT_SEEDS: readonly ProjectSeed[] = [
 /**
  * Project 配列から id → Project のマップを作る。
  */
-export function indexProjectsById(
-  projects: readonly Project[],
-): Record<string, Project> {
+export function indexProjectsById(projects: readonly Project[]): Record<string, Project> {
   const out: Record<string, Project> = {};
   for (const p of projects) out[p.id] = p;
   return out;

--- a/src/entities/project/supabase-gateway.ts
+++ b/src/entities/project/supabase-gateway.ts
@@ -1,17 +1,8 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-import type {
-  Database,
-  Tables,
-  TablesInsert,
-  TablesUpdate,
-} from "@/shared/types/database";
+import type { Database, Tables, TablesInsert, TablesUpdate } from "@/shared/types/database";
 
-import type {
-  CreateProjectInput,
-  ProjectGateway,
-  UpdateProjectInput,
-} from "./gateway";
+import type { CreateProjectInput, ProjectGateway, UpdateProjectInput } from "./gateway";
 import type { Project } from "./types";
 
 type Sb = SupabaseClient<Database>;
@@ -79,19 +70,13 @@ export class SupabaseProjectGateway implements ProjectGateway {
   }
 
   async delete(id: string): Promise<void> {
-    const { error } = await this.supabase
-      .from("projects")
-      .delete()
-      .eq("id", id);
+    const { error } = await this.supabase.from("projects").delete().eq("id", id);
     if (error) throw error;
   }
 
   async deleteAllForCurrentUser(): Promise<void> {
     const uid = await getUserId(this.supabase);
-    const { error } = await this.supabase
-      .from("projects")
-      .delete()
-      .eq("user_id", uid);
+    const { error } = await this.supabase.from("projects").delete().eq("user_id", uid);
     if (error) throw error;
   }
 }

--- a/src/entities/task/gateway.ts
+++ b/src/entities/task/gateway.ts
@@ -31,9 +31,7 @@ export interface TaskGateway {
   list(): Promise<Task[]>;
   create(input: CreateTaskInput): Promise<Task>;
   update(id: string, patch: UpdateTaskInput): Promise<Task>;
-  reorder(
-    entries: readonly { id: string; stackOrder: number | null }[],
-  ): Promise<void>;
+  reorder(entries: readonly { id: string; stackOrder: number | null }[]): Promise<void>;
   delete(id: string): Promise<void>;
   deleteAllForCurrentUser(): Promise<void>;
 }

--- a/src/entities/task/supabase-gateway.ts
+++ b/src/entities/task/supabase-gateway.ts
@@ -1,12 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 import { ACTION_TYPES, log } from "@/entities/action-log/logger";
-import type {
-  Database,
-  Tables,
-  TablesInsert,
-  TablesUpdate,
-} from "@/shared/types/database";
+import type { Database, Tables, TablesInsert, TablesUpdate } from "@/shared/types/database";
 
 import type { CreateTaskInput, TaskGateway, UpdateTaskInput } from "./gateway";
 import type { Task } from "./types";
@@ -64,11 +59,7 @@ export class SupabaseTaskGateway implements TaskGateway {
       is_interruption: input.isInterruption ?? false,
       parent_task_id: input.parentTaskId ?? null,
     };
-    const { data, error } = await this.supabase
-      .from("tasks")
-      .insert(payload)
-      .select("*")
-      .single();
+    const { data, error } = await this.supabase.from("tasks").insert(payload).select("*").single();
     if (error) throw error;
     return fromRow(data);
   }
@@ -78,16 +69,12 @@ export class SupabaseTaskGateway implements TaskGateway {
     if (patch.projectId !== undefined) update.project_id = patch.projectId;
     if (patch.title !== undefined) update.title = patch.title;
     if (patch.body !== undefined) update.body = patch.body;
-    if (patch.estimatedMinutes !== undefined)
-      update.estimated_minutes = patch.estimatedMinutes;
+    if (patch.estimatedMinutes !== undefined) update.estimated_minutes = patch.estimatedMinutes;
     if (patch.status !== undefined) update.status = patch.status;
     if (patch.stackOrder !== undefined) update.stack_order = patch.stackOrder;
-    if (patch.dependsOnEventId !== undefined)
-      update.depends_on_event_id = patch.dependsOnEventId;
-    if (patch.isInterruption !== undefined)
-      update.is_interruption = patch.isInterruption;
-    if (patch.completedAt !== undefined)
-      update.completed_at = patch.completedAt;
+    if (patch.dependsOnEventId !== undefined) update.depends_on_event_id = patch.dependsOnEventId;
+    if (patch.isInterruption !== undefined) update.is_interruption = patch.isInterruption;
+    if (patch.completedAt !== undefined) update.completed_at = patch.completedAt;
     const { data, error } = await this.supabase
       .from("tasks")
       .update(update)
@@ -98,9 +85,7 @@ export class SupabaseTaskGateway implements TaskGateway {
     return fromRow(data);
   }
 
-  async reorder(
-    entries: readonly { id: string; stackOrder: number | null }[],
-  ): Promise<void> {
+  async reorder(entries: readonly { id: string; stackOrder: number | null }[]): Promise<void> {
     if (entries.length === 0) return;
     // 並列 update: 個別 patch を Promise.all で流す。件数は高々 20〜30 件想定。
     // 1 call で済ませるには upsert + on_conflict だが、全カラムを送る必要が出るので採用しない。
@@ -123,10 +108,7 @@ export class SupabaseTaskGateway implements TaskGateway {
 
   async deleteAllForCurrentUser(): Promise<void> {
     const uid = await getUserId(this.supabase);
-    const { error } = await this.supabase
-      .from("tasks")
-      .delete()
-      .eq("user_id", uid);
+    const { error } = await this.supabase.from("tasks").delete().eq("user_id", uid);
     if (error) throw error;
   }
 }

--- a/src/entities/task/supabase-time-entry-gateway.ts
+++ b/src/entities/task/supabase-time-entry-gateway.ts
@@ -1,11 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-import type {
-  Database,
-  Tables,
-  TablesInsert,
-  TablesUpdate,
-} from "@/shared/types/database";
+import type { Database, Tables, TablesInsert, TablesUpdate } from "@/shared/types/database";
 
 import type { PauseReason, TimeEntry } from "./time-entries";
 import type { TaskTimeEntryGateway } from "./time-entry-gateway";
@@ -24,9 +19,7 @@ function fromRow(row: Tables<"task_time_entries">): TimeEntry {
 }
 
 function computeDurationSeconds(startedAt: string, pausedAt: string): number {
-  const delta = Math.floor(
-    (new Date(pausedAt).getTime() - new Date(startedAt).getTime()) / 1000,
-  );
+  const delta = Math.floor((new Date(pausedAt).getTime() - new Date(startedAt).getTime()) / 1000);
   return delta < 0 ? 0 : delta;
 }
 
@@ -56,10 +49,7 @@ export class SupabaseTaskTimeEntryGateway implements TaskTimeEntryGateway {
     return row ? fromRow(row) : null;
   }
 
-  async start(
-    taskId: string,
-    startedAt: string = new Date().toISOString(),
-  ): Promise<TimeEntry> {
+  async start(taskId: string, startedAt: string = new Date().toISOString()): Promise<TimeEntry> {
     const payload: TablesInsert<"task_time_entries"> = {
       task_id: taskId,
       started_at: startedAt,

--- a/src/entities/task/time-entries.ts
+++ b/src/entities/task/time-entries.ts
@@ -27,9 +27,7 @@ export function sumDurationSeconds(
       continue;
     }
     if (e.pausedAt == null) {
-      const delta = Math.floor(
-        (referenceTime - new Date(e.startedAt).getTime()) / 1000,
-      );
+      const delta = Math.floor((referenceTime - new Date(e.startedAt).getTime()) / 1000);
       total += delta < 0 ? 0 : delta;
     }
   }

--- a/src/entities/task/time-entry-gateway.ts
+++ b/src/entities/task/time-entry-gateway.ts
@@ -12,9 +12,5 @@ export interface TaskTimeEntryGateway {
   list(taskId: string): Promise<TimeEntry[]>;
   getOpen(taskId: string): Promise<TimeEntry | null>;
   start(taskId: string, startedAt?: string): Promise<TimeEntry>;
-  close(
-    entry: TimeEntry,
-    pauseReason: PauseReason | null,
-    pausedAt?: string,
-  ): Promise<TimeEntry>;
+  close(entry: TimeEntry, pauseReason: PauseReason | null, pausedAt?: string): Promise<TimeEntry>;
 }

--- a/src/features/add-forms/AddPanel.tsx
+++ b/src/features/add-forms/AddPanel.tsx
@@ -46,10 +46,7 @@ export function AddPanel({
 
   return (
     <div className="fixed inset-0 z-[210] flex flex-col">
-      <div
-        onClick={onClose}
-        className="absolute inset-0 bg-black/60 backdrop-blur-[4px]"
-      />
+      <div onClick={onClose} className="absolute inset-0 bg-black/60 backdrop-blur-[4px]" />
       <div className="relative mt-auto flex max-h-[85vh] animate-panel-slide-up flex-col rounded-t-2xl bg-bg-surface">
         <div className="flex justify-center pb-1 pt-2.5">
           <div className="h-[3px] w-8 rounded-[2px] bg-bg-divider" />
@@ -64,9 +61,7 @@ export function AddPanel({
                 key={t.key}
                 onClick={() => setTab(t.key)}
                 className={`rounded-t-md px-3 py-1.5 font-jp text-[11px] font-medium ${
-                  active
-                    ? "bg-bg-elevated text-fg-emphasized"
-                    : "bg-transparent text-fg-weak"
+                  active ? "bg-bg-elevated text-fg-emphasized" : "bg-transparent text-fg-weak"
                 }`}
               >
                 {t.label}
@@ -91,15 +86,9 @@ export function AddPanel({
             )
           ) : null}
           {tab === "event" ? (
-            <EventForm
-              projects={projects}
-              onSubmit={onCreateEvent}
-              onClose={onClose}
-            />
+            <EventForm projects={projects} onSubmit={onCreateEvent} onClose={onClose} />
           ) : null}
-          {tab === "project" ? (
-            <ProjectForm onSubmit={onCreateProject} onClose={onClose} />
-          ) : null}
+          {tab === "project" ? <ProjectForm onSubmit={onCreateProject} onClose={onClose} /> : null}
         </div>
       </div>
     </div>
@@ -109,9 +98,7 @@ export function AddPanel({
 function EmptyProjectsNotice({ onSwitch }: { onSwitch: () => void }) {
   return (
     <div className="flex flex-col items-center gap-3 py-6 text-center">
-      <p className="font-jp text-[12px] text-fg-muted">
-        タスクにはプロジェクトが必要です。
-      </p>
+      <p className="font-jp text-[12px] text-fg-muted">タスクにはプロジェクトが必要です。</p>
       <button
         type="button"
         onClick={onSwitch}

--- a/src/features/add-forms/ProjectForm.tsx
+++ b/src/features/add-forms/ProjectForm.tsx
@@ -9,14 +9,7 @@ type ProjectFormProps = {
   onClose: () => void;
 };
 
-const DEFAULT_COLORS = [
-  "#E85D04",
-  "#0096C7",
-  "#2D9F45",
-  "#9B5DE5",
-  "#58A6FF",
-  "#EF4444",
-];
+const DEFAULT_COLORS = ["#E85D04", "#0096C7", "#2D9F45", "#9B5DE5", "#58A6FF", "#EF4444"];
 
 /**
  * Phase 1 仕様 Step 3「プロジェクト管理（名前、色、本業フラグ）」。

--- a/src/features/add-forms/TaskForm.tsx
+++ b/src/features/add-forms/TaskForm.tsx
@@ -35,10 +35,7 @@ export function TaskForm({ projects, events, onSubmit, onClose }: TaskFormProps)
   const futureEvents = useMemo(() => {
     return [...events]
       .filter((ev) => new Date(ev.startTime).getTime() >= openedAt)
-      .sort(
-        (a, b) =>
-          new Date(a.startTime).getTime() - new Date(b.startTime).getTime(),
-      );
+      .sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime());
   }, [events, openedAt]);
 
   const submit = async (e: React.FormEvent) => {
@@ -95,9 +92,7 @@ export function TaskForm({ projects, events, onSubmit, onClose }: TaskFormProps)
           onChange={(e) => setProjectId(e.target.value)}
           className="rounded border border-bg-divider bg-bg-elevated px-3 py-2 text-[13px] text-fg-default outline-none focus:border-accent-blue"
         >
-          {projects.length === 0 ? (
-            <option value="">プロジェクトがありません</option>
-          ) : null}
+          {projects.length === 0 ? <option value="">プロジェクトがありません</option> : null}
           {projects.map((p) => (
             <option key={p.id} value={p.id}>
               {p.name}
@@ -128,7 +123,7 @@ export function TaskForm({ projects, events, onSubmit, onClose }: TaskFormProps)
           <option value="">なし</option>
           {futureEvents.map((ev) => (
             <option key={ev.id} value={ev.id}>
-              {formatRelativeTime(ev.startTime, new Date(openedAt))}  {ev.title}
+              {formatRelativeTime(ev.startTime, new Date(openedAt))} {ev.title}
             </option>
           ))}
         </select>

--- a/src/features/day-timeline/DayTimeline.test.tsx
+++ b/src/features/day-timeline/DayTimeline.test.tsx
@@ -23,12 +23,7 @@ const events: Event[] = [
 describe("DayTimeline", () => {
   test("today を formatDate して表示する", () => {
     const { getByText } = render(
-      <DayTimeline
-        events={[]}
-        nowMin={10 * 60}
-        today="2026-04-11"
-        onOpenEvent={() => {}}
-      />,
+      <DayTimeline events={[]} nowMin={10 * 60} today="2026-04-11" onOpenEvent={() => {}} />,
     );
     expect(getByText("4/11 (土)")).toBeTruthy();
   });

--- a/src/features/day-timeline/DayTimeline.tsx
+++ b/src/features/day-timeline/DayTimeline.tsx
@@ -1,11 +1,6 @@
 import { useMemo } from "react";
 import type { Event } from "../../entities/event/types";
-import {
-  fmtDuration,
-  fmtMin,
-  formatDate,
-  minutesOfDay,
-} from "../../shared/lib/time";
+import { fmtDuration, fmtMin, formatDate, minutesOfDay } from "../../shared/lib/time";
 import { buildSlots, computeDayBounds } from "./buildSlots";
 import { EventCard } from "./EventCard";
 import { TimelineBar } from "./TimelineBar";
@@ -19,57 +14,34 @@ type DayTimelineProps = {
 
 export function DayTimeline({ events, nowMin, today, onOpenEvent }: DayTimelineProps) {
   const { dayStart, dayEnd } = computeDayBounds(events, nowMin);
-  const slots = useMemo(
-    () => buildSlots(events, dayStart, dayEnd),
-    [events, dayStart, dayEnd],
-  );
+  const slots = useMemo(() => buildSlots(events, dayStart, dayEnd), [events, dayStart, dayEnd]);
   const sortedEvents = useMemo(
-    () =>
-      [...events].sort(
-        (a, b) => minutesOfDay(a.startTime) - minutesOfDay(b.startTime),
-      ),
+    () => [...events].sort((a, b) => minutesOfDay(a.startTime) - minutesOfDay(b.startTime)),
     [events],
   );
 
   const currentSlot = slots.find((s) => s.start <= nowMin && s.end > nowMin);
-  const nextEvent = sortedEvents.find(
-    (e) => minutesOfDay(e.startTime) > nowMin,
-  );
-  const minutesUntilNext = nextEvent
-    ? minutesOfDay(nextEvent.startTime) - nowMin
-    : dayEnd - nowMin;
-  const firstFutureIdx = sortedEvents.findIndex(
-    (e) => minutesOfDay(e.startTime) > nowMin,
-  );
+  const nextEvent = sortedEvents.find((e) => minutesOfDay(e.startTime) > nowMin);
+  const minutesUntilNext = nextEvent ? minutesOfDay(nextEvent.startTime) - nowMin : dayEnd - nowMin;
+  const firstFutureIdx = sortedEvents.findIndex((e) => minutesOfDay(e.startTime) > nowMin);
 
   return (
     <div className="px-4 pb-1 pt-3.5">
       <div className="mb-2.5 flex items-baseline gap-2">
         <div className="h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-accent-green" />
-        <span className="font-jp text-[11px] text-fg-subtle">
-          {formatDate(today)}
-        </span>
-        <span className="text-[11px] tabular-nums text-fg-emphasized">
-          {fmtMin(nowMin)}
-        </span>
+        <span className="font-jp text-[11px] text-fg-subtle">{formatDate(today)}</span>
+        <span className="text-[11px] tabular-nums text-fg-emphasized">{fmtMin(nowMin)}</span>
         {currentSlot?.type === "free" && (
           <span className="text-[10px] text-accent-green">
             空き {fmtDuration(minutesUntilNext)}
           </span>
         )}
         {currentSlot?.type === "event" && (
-          <span className="text-[10px] text-accent-amber">
-            {currentSlot.event.title}中
-          </span>
+          <span className="text-[10px] text-accent-amber">{currentSlot.event.title}中</span>
         )}
       </div>
 
-      <TimelineBar
-        slots={slots}
-        nowMin={nowMin}
-        dayStart={dayStart}
-        dayEnd={dayEnd}
-      />
+      <TimelineBar slots={slots} nowMin={nowMin} dayStart={dayStart} dayEnd={dayEnd} />
 
       <div className="mt-2 flex flex-col gap-1">
         {sortedEvents.map((ev, i) => (

--- a/src/features/day-timeline/EventCard.test.tsx
+++ b/src/features/day-timeline/EventCard.test.tsx
@@ -21,36 +21,21 @@ const baseEvent: Event = {
 describe("EventCard", () => {
   test("タイトルを表示する", () => {
     const { getByText } = render(
-      <EventCard
-        event={baseEvent}
-        nowMin={0}
-        isNextCandidate={false}
-        onClick={() => {}}
-      />,
+      <EventCard event={baseEvent} nowMin={0} isNextCandidate={false} onClick={() => {}} />,
     );
     expect(getByText("Test Event")).toBeTruthy();
   });
 
   test("時刻レンジを表示する", () => {
     const { getByText } = render(
-      <EventCard
-        event={baseEvent}
-        nowMin={0}
-        isNextCandidate={false}
-        onClick={() => {}}
-      />,
+      <EventCard event={baseEvent} nowMin={0} isNextCandidate={false} onClick={() => {}} />,
     );
     expect(getByText("10:00–11:00")).toBeTruthy();
   });
 
   test("isNextCandidate=true かつイベント前なら NEXT バッジを表示", () => {
     const { getByText } = render(
-      <EventCard
-        event={baseEvent}
-        nowMin={9 * 60}
-        isNextCandidate={true}
-        onClick={() => {}}
-      />,
+      <EventCard event={baseEvent} nowMin={9 * 60} isNextCandidate={true} onClick={() => {}} />,
     );
     expect(getByText("NEXT")).toBeTruthy();
   });
@@ -69,12 +54,7 @@ describe("EventCard", () => {
 
   test("source=manual なら Google バッジは表示しない", () => {
     const { queryByTestId } = render(
-      <EventCard
-        event={baseEvent}
-        nowMin={0}
-        isNextCandidate={false}
-        onClick={() => {}}
-      />,
+      <EventCard event={baseEvent} nowMin={0} isNextCandidate={false} onClick={() => {}} />,
     );
     expect(queryByTestId("google-calendar-badge")).toBeNull();
   });

--- a/src/features/day-timeline/EventCard.tsx
+++ b/src/features/day-timeline/EventCard.tsx
@@ -1,11 +1,7 @@
 import { EVENT_SOURCE, type Event } from "../../entities/event/types";
 import { getProject } from "../../entities/project/projects";
 import { useProjects } from "../../entities/project/ProjectsContext";
-import {
-  fmtDuration,
-  formatClock,
-  minutesOfDay,
-} from "../../shared/lib/time";
+import { fmtDuration, formatClock, minutesOfDay } from "../../shared/lib/time";
 import { GoogleCalendarBadge } from "../../entities/event/GoogleCalendarBadge";
 
 type EventCardProps = {
@@ -22,9 +18,7 @@ export function EventCard({ event, nowMin, isNextCandidate, onClick }: EventCard
   const isPast = evEnd <= nowMin;
   const isNow = evStart <= nowMin && evEnd > nowMin;
   const isNext = isNextCandidate && !isNow;
-  const evColor = event.projectId
-    ? getProject(projectsById, event.projectId).color
-    : "#52525b";
+  const evColor = event.projectId ? getProject(projectsById, event.projectId).color : "#52525b";
   const hasAttachments = event.hasAttachments;
   const hasMeet = !!event.meetUrl;
   const meetLabel = event.meetUrl?.includes("zoom") ? "Zoom" : "Meet";
@@ -45,14 +39,10 @@ export function EventCard({ event, nowMin, isNextCandidate, onClick }: EventCard
         <span className="shrink-0 text-[10px] tabular-nums text-fg-weak">
           {formatClock(event.startTime)}–{formatClock(event.endTime)}
         </span>
-        <span className="shrink-0 text-[9px] text-fg-faint">
-          ({fmtDuration(evEnd - evStart)})
-        </span>
+        <span className="shrink-0 text-[9px] text-fg-faint">({fmtDuration(evEnd - evStart)})</span>
         <span
           className={`flex-1 truncate font-jp text-[11px] ${
-            isNow
-              ? "font-medium text-fg-emphasized"
-              : "font-normal text-fg-muted"
+            isNow ? "font-medium text-fg-emphasized" : "font-normal text-fg-muted"
           }`}
         >
           {event.title}
@@ -72,12 +62,7 @@ export function EventCard({ event, nowMin, isNextCandidate, onClick }: EventCard
               strokeWidth="1.2"
               strokeLinejoin="round"
             />
-            <path
-              d="M9 2V5H12"
-              stroke="#71717a"
-              strokeWidth="1.2"
-              strokeLinejoin="round"
-            />
+            <path d="M9 2V5H12" stroke="#71717a" strokeWidth="1.2" strokeLinejoin="round" />
           </svg>
         )}
         {hasMeet && !isNext && (
@@ -88,15 +73,7 @@ export function EventCard({ event, nowMin, isNextCandidate, onClick }: EventCard
             fill="none"
             className="shrink-0 opacity-50"
           >
-            <rect
-              x="1"
-              y="4"
-              width="10"
-              height="8"
-              rx="1"
-              stroke="#71717a"
-              strokeWidth="1.2"
-            />
+            <rect x="1" y="4" width="10" height="8" rx="1" stroke="#71717a" strokeWidth="1.2" />
             <path
               d="M11 7L15 5V11L11 9"
               stroke="#71717a"
@@ -149,9 +126,7 @@ export function EventCard({ event, nowMin, isNextCandidate, onClick }: EventCard
             </svg>
             {meetLabel}に参加
           </a>
-          {hasAttachments && (
-            <span className="font-jp text-[9px] text-fg-weak">資料あり</span>
-          )}
+          {hasAttachments && <span className="font-jp text-[9px] text-fg-weak">資料あり</span>}
         </div>
       )}
     </div>

--- a/src/features/day-timeline/TimelineBar.tsx
+++ b/src/features/day-timeline/TimelineBar.tsx
@@ -22,7 +22,14 @@ type SlotDisplayProps = {
   label: string;
 };
 
-function EventSlot({ slot, widthPct, isPast, isCurrent, nowPct, label }: SlotDisplayProps & { slot: EventSlotType }) {
+function EventSlot({
+  slot,
+  widthPct,
+  isPast,
+  isCurrent,
+  nowPct,
+  label,
+}: SlotDisplayProps & { slot: EventSlotType }) {
   const { projectsById } = useProjects();
   const evColor = slot.event.projectId
     ? getProject(projectsById, slot.event.projectId).color
@@ -37,7 +44,7 @@ function EventSlot({ slot, widthPct, isPast, isCurrent, nowPct, label }: SlotDis
     >
       {isCurrent && (
         <div
-          className="absolute top-0 bottom-0 z-[2] w-0.5 bg-accent-green"
+          className="absolute bottom-0 top-0 z-[2] w-0.5 bg-accent-green"
           style={{ left: `${nowPct}%` }}
         />
       )}
@@ -68,18 +75,14 @@ function FreeSlot({ widthPct, isPast, isCurrent, nowPct, label }: SlotDisplayPro
     >
       {isCurrent && (
         <div
-          className="absolute top-0 bottom-0 z-[2] w-0.5 bg-accent-green"
+          className="absolute bottom-0 top-0 z-[2] w-0.5 bg-accent-green"
           style={{ left: `${nowPct}%` }}
         />
       )}
       {widthPct > 4 && (
         <span
           className={`whitespace-nowrap text-[7px] tabular-nums ${
-            isPast
-              ? "text-bg-divider"
-              : isCurrent
-                ? "text-accent-green"
-                : "text-fg-faint"
+            isPast ? "text-bg-divider" : isCurrent ? "text-accent-green" : "text-fg-faint"
           }`}
         >
           {label}
@@ -104,9 +107,7 @@ export function TimelineBar({ slots, nowMin, dayStart, dayEnd }: TimelineBarProp
           const widthPct = (slot.duration / (dayEnd - dayStart)) * 100;
           const isPast = slot.end <= nowMin;
           const isCurrent = slot.start <= nowMin && slot.end > nowMin;
-          const nowPct = isCurrent
-            ? ((nowMin - slot.start) / slot.duration) * 100
-            : 0;
+          const nowPct = isCurrent ? ((nowMin - slot.start) / slot.duration) * 100 : 0;
           const label = fmtDuration(slot.duration);
           const props = { widthPct, isPast, isCurrent, nowPct, label };
           return slot.type === "event" ? (

--- a/src/features/day-timeline/buildSlots.test.ts
+++ b/src/features/day-timeline/buildSlots.test.ts
@@ -52,9 +52,7 @@ describe("computeDayBounds", () => {
 describe("buildSlots", () => {
   test("イベント無しなら 1つの free スロット", () => {
     const slots = buildSlots([], 9 * 60, 18 * 60);
-    expect(slots).toEqual([
-      { type: "free", start: 9 * 60, end: 18 * 60, duration: 9 * 60 },
-    ]);
+    expect(slots).toEqual([{ type: "free", start: 9 * 60, end: 18 * 60, duration: 9 * 60 }]);
   });
 
   test("1つのイベントは free / event / free の3スロットに分割される", () => {
@@ -85,7 +83,9 @@ describe("buildSlots", () => {
   test("時刻順でない入力も開始時刻順にソートされる", () => {
     const events = [ev("e2", "14:00", "15:00"), ev("e1", "10:00", "11:00")];
     const slots = buildSlots(events, 9 * 60, 18 * 60);
-    const eventIds = slots.filter((s): s is import("./buildSlots").EventSlot => s.type === "event").map((s) => s.event.id);
+    const eventIds = slots
+      .filter((s): s is import("./buildSlots").EventSlot => s.type === "event")
+      .map((s) => s.event.id);
     expect(eventIds).toEqual(["e1", "e2"]);
   });
 

--- a/src/features/day-timeline/buildSlots.ts
+++ b/src/features/day-timeline/buildSlots.ts
@@ -22,29 +22,16 @@ export function computeDayBounds(
   events: readonly Event[],
   nowMin: number,
 ): { dayStart: number; dayEnd: number } {
-  const latestEnd = Math.max(
-    18 * 60,
-    nowMin,
-    ...events.map((e) => minutesOfDay(e.endTime)),
-  );
-  const earliestStart = Math.min(
-    9 * 60,
-    ...events.map((e) => minutesOfDay(e.startTime)),
-  );
+  const latestEnd = Math.max(18 * 60, nowMin, ...events.map((e) => minutesOfDay(e.endTime)));
+  const earliestStart = Math.min(9 * 60, ...events.map((e) => minutesOfDay(e.startTime)));
   return {
     dayStart: Math.floor(earliestStart / 60) * 60,
     dayEnd: Math.ceil(latestEnd / 60) * 60,
   };
 }
 
-export function buildSlots(
-  events: readonly Event[],
-  dayStart: number,
-  dayEnd: number,
-): Slot[] {
-  const sorted = [...events].sort(
-    (a, b) => minutesOfDay(a.startTime) - minutesOfDay(b.startTime),
-  );
+export function buildSlots(events: readonly Event[], dayStart: number, dayEnd: number): Slot[] {
+  const sorted = [...events].sort((a, b) => minutesOfDay(a.startTime) - minutesOfDay(b.startTime));
   const slots: Slot[] = [];
   let cursor = dayStart;
   sorted.forEach((ev) => {

--- a/src/features/event-detail/EventDetailPanel.test.tsx
+++ b/src/features/event-detail/EventDetailPanel.test.tsx
@@ -120,18 +120,14 @@ describe("EventDetailPanel", () => {
         onChangeProject: vi.fn(),
       });
       expect(queryByTestId("google-calendar-badge")).toBeNull();
-      expect(
-        queryByText(/Google Calendar で編集した内容は次回同期で反映されます/),
-      ).toBeNull();
+      expect(queryByText(/Google Calendar で編集した内容は次回同期で反映されます/)).toBeNull();
       expect(queryByText(/を変更$/)).toBeNull();
     });
 
     test("google_calendar: Google バッジと同期補足テキストを出す", () => {
       const { getByTestId, getByText } = renderPanel({ event: googleEvent });
       expect(getByTestId("google-calendar-badge")).toBeTruthy();
-      expect(
-        getByText(/Google Calendar で編集した内容は次回同期で反映されます/),
-      ).toBeTruthy();
+      expect(getByText(/Google Calendar で編集した内容は次回同期で反映されます/)).toBeTruthy();
     });
 
     test("google_calendar: onChangeProject 未指定なら project 編集 UI を出さない", () => {

--- a/src/features/event-detail/EventDetailPanel.tsx
+++ b/src/features/event-detail/EventDetailPanel.tsx
@@ -4,11 +4,7 @@ import { EVENT_SOURCE, type Event } from "../../entities/event/types";
 import { GoogleCalendarBadge } from "../../entities/event/GoogleCalendarBadge";
 import { getProject } from "../../entities/project/projects";
 import { useProjects } from "../../entities/project/ProjectsContext";
-import {
-  fmtDuration,
-  formatClock,
-  minutesOfDay,
-} from "../../shared/lib/time";
+import { fmtDuration, formatClock, minutesOfDay } from "../../shared/lib/time";
 import { renderMarkdown } from "../../shared/lib/markdown";
 
 type EventDetailPanelProps = {
@@ -21,11 +17,7 @@ type EventDetailPanelProps = {
   onChangeProject?: (id: string, projectId: string | null) => void;
 };
 
-export function EventDetailPanel({
-  event,
-  onClose,
-  onChangeProject,
-}: EventDetailPanelProps) {
+export function EventDetailPanel({ event, onClose, onChangeProject }: EventDetailPanelProps) {
   const { projects, projectsById } = useProjects();
   const proj = event.projectId ? getProject(projectsById, event.projectId) : null;
   const evColor = proj ? proj.color : "#52525b";
@@ -46,10 +38,7 @@ export function EventDetailPanel({
 
   return (
     <div className="fixed inset-0 z-[200] flex flex-col">
-      <div
-        onClick={onClose}
-        className="absolute inset-0 bg-black/60 backdrop-blur-[4px]"
-      />
+      <div onClick={onClose} className="absolute inset-0 bg-black/60 backdrop-blur-[4px]" />
       <div
         className="relative mt-auto flex max-h-[85vh] animate-panel-slide-up flex-col rounded-t-2xl bg-bg-surface"
         style={{
@@ -62,17 +51,8 @@ export function EventDetailPanel({
 
         <div className="px-5 pb-3 pt-2">
           <div className="mb-2 flex items-center gap-2">
-            {proj && (
-              <div
-                className="h-2 w-2 rounded-full"
-                style={{ background: evColor }}
-              />
-            )}
-            {proj && (
-              <span className="font-jp text-[10px] text-fg-subtle">
-                {proj.name}
-              </span>
-            )}
+            {proj && <div className="h-2 w-2 rounded-full" style={{ background: evColor }} />}
+            {proj && <span className="font-jp text-[10px] text-fg-subtle">{proj.name}</span>}
             <span className="text-[10px] tabular-nums text-fg-weak">
               {formatClock(event.startTime)}–{formatClock(event.endTime)} ({fmtDuration(duration)})
             </span>
@@ -103,12 +83,7 @@ export function EventDetailPanel({
                   strokeLinecap="round"
                   strokeLinejoin="round"
                 />
-                <path
-                  d="M14 2L8 8"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                />
+                <path d="M14 2L8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
                 <path
                   d="M6 3H3V13H13V10"
                   stroke="currentColor"
@@ -132,12 +107,7 @@ export function EventDetailPanel({
                   strokeWidth="1.2"
                   strokeLinejoin="round"
                 />
-                <path
-                  d="M9 2V5H12"
-                  stroke="#52525b"
-                  strokeWidth="1.2"
-                  strokeLinejoin="round"
-                />
+                <path d="M9 2V5H12" stroke="#52525b" strokeWidth="1.2" strokeLinejoin="round" />
               </svg>
               添付資料あり
             </div>
@@ -147,9 +117,7 @@ export function EventDetailPanel({
         {canEditProject && (
           <div className="px-5 pb-2">
             <div className="flex items-center gap-2">
-              <span className="font-jp text-[10px] text-fg-weak">
-                プロジェクト
-              </span>
+              <span className="font-jp text-[10px] text-fg-weak">プロジェクト</span>
               {editingProject ? (
                 <select
                   autoFocus

--- a/src/features/sync/CalendarSyncButton.test.tsx
+++ b/src/features/sync/CalendarSyncButton.test.tsx
@@ -6,13 +6,7 @@ import { CalendarSyncButton } from "./CalendarSyncButton";
 describe("CalendarSyncButton", () => {
   test("デフォルトではクリック可能でラベルは「同期」", () => {
     const onClick = vi.fn();
-    render(
-      <CalendarSyncButton
-        isPending={false}
-        lastSyncedAt={null}
-        onClick={onClick}
-      />,
-    );
+    render(<CalendarSyncButton isPending={false} lastSyncedAt={null} onClick={onClick} />);
 
     const button = screen.getByRole("button", {
       name: "カレンダーを同期",
@@ -26,13 +20,7 @@ describe("CalendarSyncButton", () => {
 
   test("isPending=true のときは disabled / スピナー表示で「同期中...」", () => {
     const onClick = vi.fn();
-    render(
-      <CalendarSyncButton
-        isPending={true}
-        lastSyncedAt={null}
-        onClick={onClick}
-      />,
-    );
+    render(<CalendarSyncButton isPending={true} lastSyncedAt={null} onClick={onClick} />);
 
     const button = screen.getByRole("button", {
       name: "カレンダーを同期",

--- a/src/features/sync/CalendarSyncButton.tsx
+++ b/src/features/sync/CalendarSyncButton.tsx
@@ -10,14 +10,8 @@ type CalendarSyncButtonProps = {
  * ヘッダーに置くカレンダー同期ボタン。押下で `useCalendarSync.triggerSync('manual')` を呼ぶ前提。
  * 実行中はスピナー + disabled、成功時は最終同期時刻を tooltip として表示する。
  */
-export function CalendarSyncButton({
-  isPending,
-  lastSyncedAt,
-  onClick,
-}: CalendarSyncButtonProps) {
-  const tooltip = lastSyncedAt
-    ? `最終同期: ${formatRelative(lastSyncedAt)}`
-    : "カレンダーを同期";
+export function CalendarSyncButton({ isPending, lastSyncedAt, onClick }: CalendarSyncButtonProps) {
+  const tooltip = lastSyncedAt ? `最終同期: ${formatRelative(lastSyncedAt)}` : "カレンダーを同期";
   return (
     <button
       type="button"

--- a/src/features/sync/ReauthBanner.test.tsx
+++ b/src/features/sync/ReauthBanner.test.tsx
@@ -9,9 +9,9 @@ type SignInWithOAuthArgs = {
     queryParams: Record<string, string>;
   };
 };
-const signInWithOAuthMock = vi.fn<
-  (args: SignInWithOAuthArgs) => Promise<{ error: null }>
->(async () => ({ error: null }));
+const signInWithOAuthMock = vi.fn<(args: SignInWithOAuthArgs) => Promise<{ error: null }>>(
+  async () => ({ error: null }),
+);
 vi.mock("@/shared/supabase/client", () => ({
   createClient: () => ({
     auth: {
@@ -31,18 +31,14 @@ describe("ReauthBanner", () => {
   });
 
   test("visible=false のときは何も描画しない", () => {
-    const { container } = render(
-      <ReauthBanner visible={false} onDismiss={() => {}} />,
-    );
+    const { container } = render(<ReauthBanner visible={false} onDismiss={() => {}} />);
     expect(container.firstChild).toBeNull();
   });
 
   test("visible=true のとき alert と再連携ボタンを出す", () => {
     render(<ReauthBanner visible={true} onDismiss={() => {}} />);
     expect(screen.getByRole("alert")).not.toBeNull();
-    expect(
-      screen.getByRole("button", { name: /Google と連携し直す/ }),
-    ).not.toBeNull();
+    expect(screen.getByRole("button", { name: /Google と連携し直す/ })).not.toBeNull();
   });
 
   test("再連携ボタンで signInWithOAuth を Google + calendar.readonly scope で起動する", () => {
@@ -52,9 +48,7 @@ describe("ReauthBanner", () => {
     expect(signInWithOAuthMock).toHaveBeenCalledTimes(1);
     const args = signInWithOAuthMock.mock.calls[0]![0];
     expect(args.provider).toBe("google");
-    expect(args.options.scopes).toContain(
-      "https://www.googleapis.com/auth/calendar.readonly",
-    );
+    expect(args.options.scopes).toContain("https://www.googleapis.com/auth/calendar.readonly");
     expect(args.options.queryParams).toEqual({
       access_type: "offline",
       prompt: "consent",

--- a/src/features/sync/useCalendarSync.test.tsx
+++ b/src/features/sync/useCalendarSync.test.tsx
@@ -33,17 +33,12 @@ function makeWrapper() {
   });
   const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
   function Wrapper({ children }: { children: ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    );
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
   }
   return { Wrapper, queryClient, invalidateSpy };
 }
 
-function mockFetchOnce(init: {
-  status: number;
-  body?: unknown;
-}): ReturnType<typeof vi.fn> {
+function mockFetchOnce(init: { status: number; body?: unknown }): ReturnType<typeof vi.fn> {
   const fetchMock = vi.fn<typeof fetch>(
     async () =>
       new Response(init.body ? JSON.stringify(init.body) : null, {

--- a/src/features/sync/useCalendarSync.ts
+++ b/src/features/sync/useCalendarSync.ts
@@ -3,10 +3,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
 
-import {
-  ACTION_TYPES,
-  log,
-} from "@/entities/action-log/logger";
+import { ACTION_TYPES, log } from "@/entities/action-log/logger";
 import type { CalendarSyncTrigger } from "@/entities/action-log/types";
 
 const SYNC_ENDPOINT = "/api/calendar/sync";

--- a/src/features/sync/useLazyCalendarSync.test.tsx
+++ b/src/features/sync/useLazyCalendarSync.test.tsx
@@ -41,12 +41,7 @@ describe("shouldTriggerLazy", () => {
   });
 
   test("lastSyncedAt が ISO として壊れている場合は stale 扱いで true (fail-open)", () => {
-    expect(
-      shouldTriggerLazy(
-        { lastSyncedAt: "garbage", syncToken: null },
-        FIXED_NOW,
-      ),
-    ).toBe(true);
+    expect(shouldTriggerLazy({ lastSyncedAt: "garbage", syncToken: null }, FIXED_NOW)).toBe(true);
   });
 });
 
@@ -55,9 +50,7 @@ describe("useLazyCalendarSync", () => {
     const triggerSync = vi.fn();
     const getState = vi.fn(async () => null);
 
-    renderHook(() =>
-      useLazyCalendarSync({ triggerSync, deps: { getState, now } }),
-    );
+    renderHook(() => useLazyCalendarSync({ triggerSync, deps: { getState, now } }));
 
     await waitFor(() => expect(triggerSync).toHaveBeenCalledTimes(1));
     expect(triggerSync).toHaveBeenCalledWith("lazy");
@@ -72,9 +65,7 @@ describe("useLazyCalendarSync", () => {
       }),
     );
 
-    renderHook(() =>
-      useLazyCalendarSync({ triggerSync, deps: { getState, now } }),
-    );
+    renderHook(() => useLazyCalendarSync({ triggerSync, deps: { getState, now } }));
 
     // 1 tick 待って triggerSync が呼ばれないことを確認
     await new Promise((r) => setTimeout(r, 0));
@@ -106,9 +97,7 @@ describe("useLazyCalendarSync", () => {
     });
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    renderHook(() =>
-      useLazyCalendarSync({ triggerSync, deps: { getState, now } }),
-    );
+    renderHook(() => useLazyCalendarSync({ triggerSync, deps: { getState, now } }));
 
     await waitFor(() => expect(errorSpy).toHaveBeenCalled());
     expect(triggerSync).not.toHaveBeenCalled();

--- a/src/features/sync/useLazyCalendarSync.ts
+++ b/src/features/sync/useLazyCalendarSync.ts
@@ -2,10 +2,7 @@
 
 import { useEffect, useRef } from "react";
 
-import type {
-  CalendarSyncState,
-  CalendarSyncStateGateway,
-} from "@/entities/calendar-sync/gateway";
+import type { CalendarSyncState, CalendarSyncStateGateway } from "@/entities/calendar-sync/gateway";
 import { SupabaseCalendarSyncStateGateway } from "@/entities/calendar-sync/supabase-gateway";
 import type { CalendarSyncTrigger } from "@/entities/action-log/types";
 import { createClient } from "@/shared/supabase/client";
@@ -29,10 +26,7 @@ export type UseLazyCalendarSyncOptions = {
  * 以上経過していれば `triggerSync('lazy')` をバックグラウンドで呼ぶ。
  * ref ガードで React.StrictMode の 2 重 fire と、親の再レンダリングによる再実行を防ぐ。
  */
-export function useLazyCalendarSync({
-  triggerSync,
-  deps,
-}: UseLazyCalendarSyncOptions): void {
+export function useLazyCalendarSync({ triggerSync, deps }: UseLazyCalendarSyncOptions): void {
   const hasRunRef = useRef(false);
 
   useEffect(() => {
@@ -56,10 +50,7 @@ export function useLazyCalendarSync({
   }, [triggerSync, deps]);
 }
 
-export function shouldTriggerLazy(
-  state: CalendarSyncState | null,
-  now: Date,
-): boolean {
+export function shouldTriggerLazy(state: CalendarSyncState | null, now: Date): boolean {
   if (!state) return true;
   const then = new Date(state.lastSyncedAt).getTime();
   if (Number.isNaN(then)) return true;
@@ -69,8 +60,6 @@ export function shouldTriggerLazy(
 
 async function defaultGetState(): Promise<CalendarSyncState | null> {
   const supabase = createClient();
-  const gateway: CalendarSyncStateGateway = new SupabaseCalendarSyncStateGateway(
-    supabase,
-  );
+  const gateway: CalendarSyncStateGateway = new SupabaseCalendarSyncStateGateway(supabase);
   return gateway.get();
 }

--- a/src/features/task-detail/TaskDetailPanel.tsx
+++ b/src/features/task-detail/TaskDetailPanel.tsx
@@ -43,22 +43,17 @@ export function TaskDetailPanel({
   const nowMs = now && now > 0 ? now : openedAt;
   const nowDate = useMemo(() => new Date(nowMs), [nowMs]);
   const proj = getProject(projectsById, task.projectId);
-  const dep = task.dependsOnEventId
-    ? events.find((e) => e.id === task.dependsOnEventId)
-    : null;
+  const dep = task.dependsOnEventId ? events.find((e) => e.id === task.dependsOnEventId) : null;
   const done = isDone(task);
 
   // 依存先候補は「未来のイベント + 現在選択中のイベント (過去でも保持表示)」。
   // 過去のイベントを新規依存先にしても意味がないが、既存の依存先を勝手に外すと混乱するため残す。
   const depCandidates = useMemo(() => {
-    const future = events.filter(
-      (ev) => new Date(ev.startTime).getTime() >= nowMs,
-    );
+    const future = events.filter((ev) => new Date(ev.startTime).getTime() >= nowMs);
     const includesCurrent = dep ? future.some((ev) => ev.id === dep.id) : true;
     const merged = includesCurrent && dep ? future : dep ? [dep, ...future] : future;
     return [...merged].sort(
-      (a, b) =>
-        new Date(a.startTime).getTime() - new Date(b.startTime).getTime(),
+      (a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime(),
     );
   }, [events, dep, nowMs]);
 
@@ -69,10 +64,7 @@ export function TaskDetailPanel({
 
   return (
     <div className="fixed inset-0 z-[200] flex flex-col">
-      <div
-        onClick={onClose}
-        className="absolute inset-0 bg-black/60 backdrop-blur-[4px]"
-      />
+      <div onClick={onClose} className="absolute inset-0 bg-black/60 backdrop-blur-[4px]" />
 
       <div
         className="relative mt-auto flex max-h-[85vh] animate-panel-slide-up flex-col rounded-t-2xl bg-bg-surface"
@@ -86,13 +78,8 @@ export function TaskDetailPanel({
 
         <div className="px-5 pb-3 pt-2">
           <div className="mb-2 flex items-center gap-2">
-            <div
-              className="h-2 w-2 rounded-full"
-              style={{ background: proj.color }}
-            />
-            <span className="font-jp text-[10px] text-fg-subtle">
-              {proj.name}
-            </span>
+            <div className="h-2 w-2 rounded-full" style={{ background: proj.color }} />
+            <span className="font-jp text-[10px] text-fg-subtle">{proj.name}</span>
             {task.estimatedMinutes !== null && (
               <span className="text-[9px] tabular-nums text-fg-faint">
                 {fmtDuration(task.estimatedMinutes)}
@@ -126,9 +113,7 @@ export function TaskDetailPanel({
         {onChangeDependency && (
           <div className="px-5 pb-2">
             <div className="flex items-center gap-2">
-              <span className="font-jp text-[10px] text-fg-weak">
-                依存イベント
-              </span>
+              <span className="font-jp text-[10px] text-fg-weak">依存イベント</span>
               {editingDep ? (
                 <select
                   autoFocus
@@ -144,7 +129,7 @@ export function TaskDetailPanel({
                   <option value="">なし</option>
                   {depCandidates.map((ev) => (
                     <option key={ev.id} value={ev.id}>
-                      {formatRelativeTime(ev.startTime, nowDate)}  {ev.title}
+                      {formatRelativeTime(ev.startTime, nowDate)} {ev.title}
                     </option>
                   ))}
                 </select>
@@ -154,9 +139,7 @@ export function TaskDetailPanel({
                   onClick={() => setEditingDep(true)}
                   className="cursor-pointer rounded-[4px] border border-bg-divider bg-transparent px-2 py-[3px] font-jp text-[10px] text-fg-subtle"
                 >
-                  {dep
-                    ? `${formatRelativeTime(dep.startTime, nowDate)} ${dep.title}`
-                    : "なし"}{" "}
+                  {dep ? `${formatRelativeTime(dep.startTime, nowDate)} ${dep.title}` : "なし"}{" "}
                   を変更
                 </button>
               )}

--- a/src/features/task-stack/DoneList.tsx
+++ b/src/features/task-stack/DoneList.tsx
@@ -32,9 +32,7 @@ export function DoneList({ doneTasks, onOpenDetail, onToggleDone }: DoneListProp
               strokeLinejoin="round"
             />
           </svg>
-          <span className="font-jp text-[11px] text-fg-weak line-through">
-            {task.title}
-          </span>
+          <span className="font-jp text-[11px] text-fg-weak line-through">{task.title}</span>
           <div className="flex-1" />
           <button
             onClick={(e) => {

--- a/src/features/task-stack/Grip.tsx
+++ b/src/features/task-stack/Grip.tsx
@@ -1,12 +1,6 @@
 export function Grip() {
   return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 14 14"
-      fill="none"
-      className="block"
-    >
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" className="block">
       <circle cx="5" cy="3" r="1.2" fill="#3f3f46" />
       <circle cx="9" cy="3" r="1.2" fill="#3f3f46" />
       <circle cx="5" cy="7" r="1.2" fill="#3f3f46" />

--- a/src/features/task-stack/PauseReasonModal.tsx
+++ b/src/features/task-stack/PauseReasonModal.tsx
@@ -22,10 +22,7 @@ const OPTIONS: { value: PauseReason; label: string; hint: string }[] = [
 export function PauseReasonModal({ onSelect, onClose }: PauseReasonModalProps) {
   return (
     <div className="fixed inset-0 z-[220] flex flex-col">
-      <div
-        onClick={onClose}
-        className="absolute inset-0 bg-black/60 backdrop-blur-[4px]"
-      />
+      <div onClick={onClose} className="absolute inset-0 bg-black/60 backdrop-blur-[4px]" />
       <div className="relative mt-auto flex animate-panel-slide-up flex-col rounded-t-2xl bg-bg-surface">
         <div className="flex justify-center pb-1 pt-2.5">
           <div className="h-[3px] w-8 rounded-[2px] bg-bg-divider" />
@@ -42,12 +39,8 @@ export function PauseReasonModal({ onSelect, onClose }: PauseReasonModalProps) {
                 onClick={() => onSelect(opt.value)}
                 className="flex items-center justify-between rounded-lg bg-bg-elevated px-4 py-3 text-left"
               >
-                <span className="font-jp text-[13px] text-fg-strong">
-                  {opt.label}
-                </span>
-                <span className="font-jp text-[10px] text-fg-weak">
-                  {opt.hint}
-                </span>
+                <span className="font-jp text-[13px] text-fg-strong">{opt.label}</span>
+                <span className="font-jp text-[10px] text-fg-weak">{opt.hint}</span>
               </button>
             ))}
           </div>

--- a/src/features/task-stack/TaskRow.tsx
+++ b/src/features/task-stack/TaskRow.tsx
@@ -3,11 +3,7 @@ import type { Event } from "../../entities/event/types";
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { getProject } from "../../entities/project/projects";
 import { useProjects } from "../../entities/project/ProjectsContext";
-import {
-  IMMINENT_THRESHOLD_MS,
-  fmtDuration,
-  formatRelativeTime,
-} from "../../shared/lib/time";
+import { IMMINENT_THRESHOLD_MS, fmtDuration, formatRelativeTime } from "../../shared/lib/time";
 import { Grip } from "./Grip";
 
 type TaskRowProps = {
@@ -32,9 +28,7 @@ export function TaskRow({
 }: TaskRowProps) {
   const { projectsById } = useProjects();
   const proj = getProject(projectsById, task.projectId);
-  const dep = task.dependsOnEventId
-    ? events.find((e) => e.id === task.dependsOnEventId)
-    : null;
+  const dep = task.dependsOnEventId ? events.find((e) => e.id === task.dependsOnEventId) : null;
   const depImminent =
     dep !== null &&
     dep !== undefined &&
@@ -61,15 +55,11 @@ export function TaskRow({
         className="h-1.5 w-1.5 shrink-0 rounded-full opacity-70"
         style={{ background: proj.color }}
       />
-      <span className="flex-1 truncate font-jp text-[12px] text-fg-muted">
-        {task.title}
-      </span>
+      <span className="flex-1 truncate font-jp text-[12px] text-fg-muted">{task.title}</span>
       {dep && (
         <span
           className={`max-w-[140px] shrink-0 truncate rounded-[3px] px-1 py-px font-jp text-[8px] text-accent-amber ${
-            depImminent
-              ? "bg-[#E85D0440] font-semibold"
-              : "bg-[#E85D0415]"
+            depImminent ? "bg-[#E85D0440] font-semibold" : "bg-[#E85D0415]"
           }`}
           title={`${dep.title} (${formatRelativeTime(dep.startTime, new Date(now))})`}
         >

--- a/src/features/task-stack/TaskStack.test.tsx
+++ b/src/features/task-stack/TaskStack.test.tsx
@@ -109,12 +109,7 @@ describe("TopTaskCard", () => {
     const onStart = vi.fn();
     const onClick = vi.fn();
     const { getByLabelText } = render(
-      <TopTaskCard
-        {...topProps}
-        task={baseTask}
-        onStart={onStart}
-        onClick={onClick}
-      />,
+      <TopTaskCard {...topProps} task={baseTask} onStart={onStart} onClick={onClick} />,
     );
     fireEvent.click(getByLabelText("開始"));
     expect(onStart).toHaveBeenCalledTimes(1);
@@ -217,11 +212,7 @@ describe("DoneList", () => {
   test("done タスクのタイトルと「戻す」ボタンを表示", () => {
     const doneTasks: Task[] = [{ ...baseTask, status: "done" }];
     const { getByText } = render(
-      <DoneList
-        doneTasks={doneTasks}
-        onOpenDetail={noop}
-        onToggleDone={noop}
-      />,
+      <DoneList doneTasks={doneTasks} onOpenDetail={noop} onToggleDone={noop} />,
     );
     expect(getByText("SLI 定義更新")).toBeTruthy();
     expect(getByText("戻す")).toBeTruthy();
@@ -269,9 +260,7 @@ describe("TaskStack", () => {
   });
 
   test("done が混在すると DoneList も表示される", () => {
-    const doneTasks: Task[] = [
-      { ...baseTask, id: "t9", title: "Completed", status: "done" },
-    ];
+    const doneTasks: Task[] = [{ ...baseTask, id: "t9", title: "Completed", status: "done" }];
     const { getByText } = render(
       <TaskStack
         events={[]}

--- a/src/features/task-stack/TaskStack.tsx
+++ b/src/features/task-stack/TaskStack.tsx
@@ -53,8 +53,7 @@ export function TaskStack({
   onToggleDone,
   onOpenDetail,
 }: TaskStackProps) {
-  const { dragIdx, overIdx, rowRefs, handlePointerDown } =
-    useStackDnD(onReorder);
+  const { dragIdx, overIdx, rowRefs, handlePointerDown } = useStackDnD(onReorder);
 
   return (
     <>
@@ -63,8 +62,7 @@ export function TaskStack({
       {pendingTasks.map((task, idx) => {
         const isFirst = idx === 0;
         const isBeingDragged = dragIdx === idx;
-        const isDropTarget =
-          overIdx === idx && dragIdx !== null && dragIdx !== idx;
+        const isDropTarget = overIdx === idx && dragIdx !== null && dragIdx !== idx;
 
         return (
           <div
@@ -104,11 +102,7 @@ export function TaskStack({
         );
       })}
 
-      <DoneList
-        doneTasks={doneTasks}
-        onOpenDetail={onOpenDetail}
-        onToggleDone={onToggleDone}
-      />
+      <DoneList doneTasks={doneTasks} onOpenDetail={onOpenDetail} onToggleDone={onToggleDone} />
     </>
   );
 }

--- a/src/features/task-stack/TopTaskCard.tsx
+++ b/src/features/task-stack/TopTaskCard.tsx
@@ -5,10 +5,7 @@ import { getProject } from "../../entities/project/projects";
 import { useProjects } from "../../entities/project/ProjectsContext";
 import type { PauseReason } from "../../entities/task/time-entries";
 import type { Task } from "../../entities/task/types";
-import {
-  IMMINENT_THRESHOLD_MS,
-  formatRelativeTime,
-} from "../../shared/lib/time";
+import { IMMINENT_THRESHOLD_MS, formatRelativeTime } from "../../shared/lib/time";
 import { Grip } from "./Grip";
 import { pauseReasonLabel } from "./PauseReasonModal";
 import { formatElapsed } from "./useTaskTimer";
@@ -50,9 +47,7 @@ export function TopTaskCard({
 }: TopTaskCardProps) {
   const { projectsById } = useProjects();
   const proj = getProject(projectsById, task.projectId);
-  const dep = task.dependsOnEventId
-    ? events.find((e) => e.id === task.dependsOnEventId)
-    : null;
+  const dep = task.dependsOnEventId ? events.find((e) => e.id === task.dependsOnEventId) : null;
   // 24h 以内に迫っている依存はハイライト (背景濃度 + 太字) して着手判断のシグナルを強める。
   // now=0 (SSR placeholder) のときは判定スキップ。
   const depImminent =
@@ -74,10 +69,7 @@ export function TopTaskCard({
         border: `1px solid ${proj.color}40`,
       }}
     >
-      <div
-        className="absolute left-0 top-0 bottom-0 w-[3px]"
-        style={{ background: proj.color }}
-      />
+      <div className="absolute bottom-0 left-0 top-0 w-[3px]" style={{ background: proj.color }} />
       <div className="flex items-start gap-2.5">
         <div
           onPointerDown={(e) => {
@@ -90,19 +82,12 @@ export function TopTaskCard({
         </div>
         <div className="flex-1">
           <div className="mb-1 flex items-center gap-2">
-            <div
-              className="h-2 w-2 rounded-full"
-              style={{ background: proj.color }}
-            />
-            <span className="font-jp text-[9px] text-fg-subtle">
-              {proj.name}
-            </span>
+            <div className="h-2 w-2 rounded-full" style={{ background: proj.color }} />
+            <span className="font-jp text-[9px] text-fg-subtle">{proj.name}</span>
             {dep && (
               <span
                 className={`max-w-[180px] truncate rounded-[3px] px-1.5 py-px font-jp text-[8px] text-accent-amber ${
-                  depImminent
-                    ? "bg-[#E85D0440] font-semibold"
-                    : "bg-[#E85D0415]"
+                  depImminent ? "bg-[#E85D0440] font-semibold" : "bg-[#E85D0415]"
                 }`}
                 title={`${dep.title} (${formatRelativeTime(dep.startTime, new Date(now))})`}
               >
@@ -127,9 +112,7 @@ export function TopTaskCard({
             {task.title}
           </div>
           {preview && (
-            <div className="mt-1 truncate font-jp text-[10px] text-fg-weak">
-              {preview}
-            </div>
+            <div className="mt-1 truncate font-jp text-[10px] text-fg-weak">{preview}</div>
           )}
         </div>
         <TimerControls

--- a/src/features/task-stack/findDropTarget.ts
+++ b/src/features/task-stack/findDropTarget.ts
@@ -1,9 +1,6 @@
 export type DropTargetRect = { top: number; height: number };
 
-export function findDropTarget(
-  clientY: number,
-  rects: readonly (DropTargetRect | null)[],
-): number {
+export function findDropTarget(clientY: number, rects: readonly (DropTargetRect | null)[]): number {
   for (let i = 0; i < rects.length; i++) {
     const rect = rects[i];
     if (!rect) continue;

--- a/src/features/task-stack/useStackDnD.ts
+++ b/src/features/task-stack/useStackDnD.ts
@@ -11,15 +11,10 @@ export type UseStackDnDResult = {
   dragIdx: number | null;
   overIdx: number | null;
   rowRefs: MutableRefObject<(HTMLDivElement | null)[]>;
-  handlePointerDown: (
-    idx: number,
-    e: ReactPointerEvent<HTMLElement>,
-  ) => void;
+  handlePointerDown: (idx: number, e: ReactPointerEvent<HTMLElement>) => void;
 };
 
-export function useStackDnD(
-  onReorder: (from: number, to: number) => void,
-): UseStackDnDResult {
+export function useStackDnD(onReorder: (from: number, to: number) => void): UseStackDnDResult {
   const [dragIdx, setDragIdx] = useState<number | null>(null);
   const [overIdx, setOverIdx] = useState<number | null>(null);
   const rowRefs = useRef<(HTMLDivElement | null)[]>([]);
@@ -29,9 +24,7 @@ export function useStackDnD(
   const isDragging = useRef(false);
 
   const computeTarget = useCallback((clientY: number): number => {
-    const rects = rowRefs.current.map((el) =>
-      el ? el.getBoundingClientRect() : null,
-    );
+    const rects = rowRefs.current.map((el) => (el ? el.getBoundingClientRect() : null));
     return findDropTarget(clientY, rects);
   }, []);
 
@@ -48,8 +41,7 @@ export function useStackDnD(
       const onMove = (ev: PointerEvent) => {
         ev.preventDefault();
         const cy = ev.clientY ?? 0;
-        if (!isDragging.current && Math.abs(cy - startY.current) > 5)
-          isDragging.current = true;
+        if (!isDragging.current && Math.abs(cy - startY.current) > 5) isDragging.current = true;
         if (isDragging.current) {
           const t = computeTarget(cy);
           overIdxRef.current = t;
@@ -59,8 +51,7 @@ export function useStackDnD(
       const onUp = () => {
         const from = dragIdxRef.current;
         const to = overIdxRef.current;
-        if (isDragging.current && from !== null && to !== null && from !== to)
-          onReorder(from, to);
+        if (isDragging.current && from !== null && to !== null && from !== to) onReorder(from, to);
         dragIdxRef.current = null;
         overIdxRef.current = null;
         isDragging.current = false;

--- a/src/features/task-stack/useTaskTimer.ts
+++ b/src/features/task-stack/useTaskTimer.ts
@@ -4,16 +4,9 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { ACTION_TYPES, log } from "@/entities/action-log/logger";
-import {
-  type PauseReason,
-  sumDurationSeconds,
-  type TimeEntry,
-} from "@/entities/task/time-entries";
+import { type PauseReason, sumDurationSeconds, type TimeEntry } from "@/entities/task/time-entries";
 import type { Task } from "@/entities/task/types";
-import {
-  useTaskGateway,
-  useTaskTimeEntryGateway,
-} from "@/shared/gateway/GatewayContext";
+import { useTaskGateway, useTaskTimeEntryGateway } from "@/shared/gateway/GatewayContext";
 
 export const TASKS_QUERY_KEY = ["tasks"] as const;
 
@@ -53,16 +46,12 @@ export function useTaskTimer(task: Task | null): TaskTimerApi {
 
   const entriesQuery = useQuery({
     queryKey: taskId ? timeEntriesKey(taskId) : ["time-entries", "none"],
-    queryFn: () =>
-      taskId ? taskTimeEntryGateway.list(taskId) : Promise.resolve([]),
+    queryFn: () => (taskId ? taskTimeEntryGateway.list(taskId) : Promise.resolve([])),
     enabled: taskId !== null,
   });
 
   const entries = useMemo(() => entriesQuery.data ?? [], [entriesQuery.data]);
-  const openEntry = useMemo(
-    () => entries.find((e) => e.pausedAt === null) ?? null,
-    [entries],
-  );
+  const openEntry = useMemo(() => entries.find((e) => e.pausedAt === null) ?? null, [entries]);
 
   const isActive = task?.status === "active";
   const isPaused = task?.status === "paused";
@@ -76,10 +65,7 @@ export function useTaskTimer(task: Task | null): TaskTimerApi {
     return () => window.clearInterval(id);
   }, [isRunning]);
 
-  const elapsedSeconds = useMemo(
-    () => sumDurationSeconds(entries, tickMs),
-    [entries, tickMs],
-  );
+  const elapsedSeconds = useMemo(() => sumDurationSeconds(entries, tickMs), [entries, tickMs]);
 
   const pauseReason = useMemo<PauseReason | null>(() => {
     if (!isPaused) return null;
@@ -114,8 +100,7 @@ export function useTaskTimer(task: Task | null): TaskTimerApi {
   const pause = useCallback(
     async (reason: PauseReason) => {
       if (!task) return;
-      const open =
-        openEntry ?? (await taskTimeEntryGateway.getOpen(task.id));
+      const open = openEntry ?? (await taskTimeEntryGateway.getOpen(task.id));
       if (open) {
         await taskTimeEntryGateway.close(open, reason);
       }
@@ -139,8 +124,7 @@ export function useTaskTimer(task: Task | null): TaskTimerApi {
 
   const complete = useCallback(async () => {
     if (!task) return;
-    const open =
-      openEntry ?? (await taskTimeEntryGateway.getOpen(task.id));
+    const open = openEntry ?? (await taskTimeEntryGateway.getOpen(task.id));
     if (open) {
       // 完了時の close は pause ではないので pause_reason = null
       await taskTimeEntryGateway.close(open, null);

--- a/src/features/tree-view/DateGroup.tsx
+++ b/src/features/tree-view/DateGroup.tsx
@@ -28,10 +28,7 @@ export function DateGroup({ date, items, projectOrder }: DateGroupProps) {
         const pi = projectOrder.indexOf(task.projectId);
         const nodeLeft = nodeCenterPx(pi);
         return (
-          <div
-            key={task.id}
-            className="relative flex min-h-[30px] items-center px-4 py-0.5"
-          >
+          <div key={task.id} className="relative flex min-h-[30px] items-center px-4 py-0.5">
             <div
               className="absolute top-1/2 z-[3] h-2 w-2 -translate-y-1/2 rounded-full bg-bg-primary"
               style={{
@@ -40,9 +37,7 @@ export function DateGroup({ date, items, projectOrder }: DateGroupProps) {
               }}
             />
             <div className="shrink-0" style={{ width: lanesWidth }} />
-            <span className="font-jp text-[11px] text-fg-subtle">
-              {task.title}
-            </span>
+            <span className="font-jp text-[11px] text-fg-subtle">{task.title}</span>
           </div>
         );
       })}

--- a/src/features/tree-view/ProjectLanes.tsx
+++ b/src/features/tree-view/ProjectLanes.tsx
@@ -16,7 +16,7 @@ export function ProjectLanes({ projectOrder }: ProjectLanesProps) {
       {projectOrder.map((pk, pi) => (
         <div
           key={pk}
-          className="pointer-events-none absolute top-0 bottom-0 z-[1] w-0.5 opacity-30"
+          className="pointer-events-none absolute bottom-0 top-0 z-[1] w-0.5 opacity-30"
           style={{
             left: laneLeftPx(pi),
             background: getProject(projectsById, pk).color,
@@ -28,10 +28,7 @@ export function ProjectLanes({ projectOrder }: ProjectLanesProps) {
           const p = getProject(projectsById, k);
           return (
             <div key={k} className="flex items-center gap-1">
-              <div
-                className="h-1.5 w-1.5 rounded-full"
-                style={{ background: p.color }}
-              />
+              <div className="h-1.5 w-1.5 rounded-full" style={{ background: p.color }} />
               <span className="font-jp text-[9px] text-fg-weak">{p.name}</span>
             </div>
           );

--- a/src/features/tree-view/TreeView.tsx
+++ b/src/features/tree-view/TreeView.tsx
@@ -20,12 +20,7 @@ export function TreeView({ historyData, projectOrder }: TreeViewProps) {
       <ProjectLanes projectOrder={projectOrder} />
       <div className="relative z-[2]">
         {dateGroups.map(([date, items]) => (
-          <DateGroup
-            key={date}
-            date={date}
-            items={items}
-            projectOrder={projectOrder}
-          />
+          <DateGroup key={date} date={date} items={items} projectOrder={projectOrder} />
         ))}
       </div>
     </div>

--- a/src/features/tree-view/layout.test.ts
+++ b/src/features/tree-view/layout.test.ts
@@ -1,12 +1,5 @@
 import { describe, expect, test } from "vitest";
-import {
-  COL,
-  GRAPH_LEFT,
-  groupByDateDesc,
-  laneLeftPx,
-  lanesWidthPx,
-  nodeCenterPx,
-} from "./layout";
+import { COL, GRAPH_LEFT, groupByDateDesc, laneLeftPx, lanesWidthPx, nodeCenterPx } from "./layout";
 
 describe("laneLeftPx / nodeCenterPx / lanesWidthPx", () => {
   test("プロジェクトインデックス 0 のレーン位置", () => {
@@ -33,11 +26,7 @@ describe("groupByDateDesc", () => {
       { id: "h4", date: "2026-04-06", title: "t4", projectId: "tasuki" },
     ];
     const result = groupByDateDesc(history);
-    expect(result.map(([date]) => date)).toEqual([
-      "2026-04-07",
-      "2026-04-06",
-      "2026-04-05",
-    ]);
+    expect(result.map(([date]) => date)).toEqual(["2026-04-07", "2026-04-06", "2026-04-05"]);
     expect(result[2][1]).toHaveLength(2);
   });
 });

--- a/src/features/tree-view/layout.ts
+++ b/src/features/tree-view/layout.ts
@@ -15,9 +15,7 @@ export function lanesWidthPx(projectCount: number): number {
   return GRAPH_LEFT + COL * projectCount + 6;
 }
 
-export function groupByDateDesc(
-  historyData: readonly HistoryEntry[],
-): [string, HistoryEntry[]][] {
+export function groupByDateDesc(historyData: readonly HistoryEntry[]): [string, HistoryEntry[]][] {
   const groups: Record<string, HistoryEntry[]> = {};
   for (const item of historyData) {
     if (!groups[item.date]) groups[item.date] = [];

--- a/src/features/user-menu/UserMenu.tsx
+++ b/src/features/user-menu/UserMenu.tsx
@@ -65,9 +65,7 @@ export function UserMenu({ email, avatarUrl, onResetSample, onClearAll }: UserMe
       {open ? (
         <div className="absolute right-0 top-9 z-50 w-52 rounded-md border border-bg-divider bg-bg-elevated p-2 shadow-lg">
           {email ? (
-            <div className="truncate px-2 py-1 text-[11px] text-fg-muted">
-              {email}
-            </div>
+            <div className="truncate px-2 py-1 text-[11px] text-fg-muted">{email}</div>
           ) : null}
           {onResetSample ? (
             <button

--- a/src/mocks/events.ts
+++ b/src/mocks/events.ts
@@ -63,8 +63,7 @@ export function buildInitialEvents(): Event[] {
       projectId: null,
       meetUrl: "https://meet.google.com/xyz-uvwx-rst",
       hasAttachments: false,
-      description:
-        "- 今週の振り返り\n- 来週の優先順位確認\n- キャリアの相談（転職活動の進捗共有）",
+      description: "- 今週の振り返り\n- 来週の優先順位確認\n- キャリアの相談（転職活動の進捗共有）",
     },
     {
       ...base,

--- a/src/mocks/seed.ts
+++ b/src/mocks/seed.ts
@@ -88,8 +88,7 @@ export async function seedSampleData({
       projectSlug: null,
       meetUrl: "https://meet.google.com/xyz-uvwx-rst",
       hasAttachments: false,
-      description:
-        "- 今週の振り返り\n- 来週の優先順位確認\n- キャリアの相談（転職活動の進捗共有）",
+      description: "- 今週の振り返り\n- 来週の優先順位確認\n- キャリアの相談（転職活動の進捗共有）",
     },
     {
       slug: "e5",
@@ -105,9 +104,7 @@ export async function seedSampleData({
 
   const eventSlugToId = new Map<string, string>();
   for (const seed of eventSeeds) {
-    const projectId = seed.projectSlug
-      ? (projectSlugToId.get(seed.projectSlug) ?? null)
-      : null;
+    const projectId = seed.projectSlug ? (projectSlugToId.get(seed.projectSlug) ?? null) : null;
     const e = await eventGateway.create({
       title: seed.title,
       startTime: seed.startTime,
@@ -135,8 +132,7 @@ export async function seedSampleData({
       estimatedMinutes: 45,
       stackOrder: 0,
       dependsOnEventSlug: "e3",
-      body:
-        "## やること\n\n- **志望動機**を3パターン用意\n- 技術的な強みの整理\n  - DDD / Clean Architecture\n  - SLI/SLO導入経験\n- 逆質問リストの準備\n\n## 参考\n\n`転職ドラフト`のフィードバックを確認\n\n> 上流工程への関与意欲が伝わる内容にすること",
+      body: "## やること\n\n- **志望動機**を3パターン用意\n- 技術的な強みの整理\n  - DDD / Clean Architecture\n  - SLI/SLO導入経験\n- 逆質問リストの準備\n\n## 参考\n\n`転職ドラフト`のフィードバックを確認\n\n> 上流工程への関与意欲が伝わる内容にすること",
     },
     {
       projectSlug: "slo",
@@ -144,8 +140,7 @@ export async function seedSampleData({
       estimatedMinutes: 40,
       stackOrder: 1,
       dependsOnEventSlug: "e2",
-      body:
-        "## 対象\n\nWeb Cart フロントエンドの SLI\n\n## 更新内容\n\n- Availability SLI: `成功リクエスト / 全リクエスト`\n- Latency SLI: `p99 < 500ms`\n- 計測ポイントをNew Relicの`Transaction`に合わせる",
+      body: "## 対象\n\nWeb Cart フロントエンドの SLI\n\n## 更新内容\n\n- Availability SLI: `成功リクエスト / 全リクエスト`\n- Latency SLI: `p99 < 500ms`\n- 計測ポイントをNew Relicの`Transaction`に合わせる",
     },
     {
       projectSlug: "loadtest",
@@ -153,8 +148,7 @@ export async function seedSampleData({
       estimatedMinutes: 35,
       stackOrder: 2,
       dependsOnEventSlug: null,
-      body:
-        "chaos test用のstub定義ファイルを作成する\n\n### エンドポイント\n\n1. `/api/v1/orders` — 正常レスポンス\n2. `/api/v1/orders` — 429 レスポンス (rate limit)\n3. `/api/v1/payments` — 500ms遅延",
+      body: "chaos test用のstub定義ファイルを作成する\n\n### エンドポイント\n\n1. `/api/v1/orders` — 正常レスポンス\n2. `/api/v1/orders` — 429 レスポンス (rate limit)\n3. `/api/v1/payments` — 500ms遅延",
     },
     {
       projectSlug: "career",
@@ -162,8 +156,7 @@ export async function seedSampleData({
       estimatedMinutes: 15,
       stackOrder: 3,
       dependsOnEventSlug: null,
-      body:
-        "最終版PDFを浅野さんにメール送付\n\n確認ポイント:\n- 誤字脱字チェック済み\n- BASE在籍期間の記載が正確か",
+      body: "最終版PDFを浅野さんにメール送付\n\n確認ポイント:\n- 誤字脱字チェック済み\n- BASE在籍期間の記載が正確か",
     },
     {
       projectSlug: "tasuki",
@@ -171,8 +164,7 @@ export async function seedSampleData({
       estimatedMinutes: 90,
       stackOrder: 4,
       dependsOnEventSlug: null,
-      body:
-        "## 目的\n\ncode-inspector用の抽象化層を設計する\n\n## 設計メモ\n\n```rust\ntrait AnalyzerContract {\n    fn analyze(&self, input: &SourceFile) -> AnalysisResult;\n    fn supports(&self, file_type: &FileType) -> bool;\n}\n```\n\n- php-parser と tree-sitter の両方に対応\n- call chain 解析は別traitに分離",
+      body: "## 目的\n\ncode-inspector用の抽象化層を設計する\n\n## 設計メモ\n\n```rust\ntrait AnalyzerContract {\n    fn analyze(&self, input: &SourceFile) -> AnalysisResult;\n    fn supports(&self, file_type: &FileType) -> bool;\n}\n```\n\n- php-parser と tree-sitter の両方に対応\n- call chain 解析は別traitに分離",
     },
     {
       projectSlug: "loadtest",
@@ -180,8 +172,7 @@ export async function seedSampleData({
       estimatedMinutes: 120,
       stackOrder: 5,
       dependsOnEventSlug: null,
-      body:
-        "ピーク負荷パターンのシナリオを実装\n\n## 要件\n\n- 通常: 100 RPS\n- ピーク: 500 RPS (10分間)\n- ramp-up: 5分\n\n## メモ\n\n分散モードで ECS 上に展開予定",
+      body: "ピーク負荷パターンのシナリオを実装\n\n## 要件\n\n- 通常: 100 RPS\n- ピーク: 500 RPS (10分間)\n- ramp-up: 5分\n\n## メモ\n\n分散モードで ECS 上に展開予定",
     },
   ];
 

--- a/src/mocks/tasks.ts
+++ b/src/mocks/tasks.ts
@@ -24,8 +24,7 @@ export function buildInitialTasks(): Task[] {
       estimatedMinutes: 45,
       stackOrder: 0,
       dependsOnEventId: "e3",
-      body:
-        "## やること\n\n- **志望動機**を3パターン用意\n- 技術的な強みの整理\n  - DDD / Clean Architecture\n  - SLI/SLO導入経験\n- 逆質問リストの準備\n\n## 参考\n\n`転職ドラフト`のフィードバックを確認\n\n> 上流工程への関与意欲が伝わる内容にすること",
+      body: "## やること\n\n- **志望動機**を3パターン用意\n- 技術的な強みの整理\n  - DDD / Clean Architecture\n  - SLI/SLO導入経験\n- 逆質問リストの準備\n\n## 参考\n\n`転職ドラフト`のフィードバックを確認\n\n> 上流工程への関与意欲が伝わる内容にすること",
     },
     {
       ...base,
@@ -35,8 +34,7 @@ export function buildInitialTasks(): Task[] {
       estimatedMinutes: 40,
       stackOrder: 1,
       dependsOnEventId: "e2",
-      body:
-        "## 対象\n\nWeb Cart フロントエンドの SLI\n\n## 更新内容\n\n- Availability SLI: `成功リクエスト / 全リクエスト`\n- Latency SLI: `p99 < 500ms`\n- 計測ポイントをNew Relicの`Transaction`に合わせる",
+      body: "## 対象\n\nWeb Cart フロントエンドの SLI\n\n## 更新内容\n\n- Availability SLI: `成功リクエスト / 全リクエスト`\n- Latency SLI: `p99 < 500ms`\n- 計測ポイントをNew Relicの`Transaction`に合わせる",
     },
     {
       ...base,
@@ -46,8 +44,7 @@ export function buildInitialTasks(): Task[] {
       estimatedMinutes: 35,
       stackOrder: 2,
       dependsOnEventId: null,
-      body:
-        "chaos test用のstub定義ファイルを作成する\n\n### エンドポイント\n\n1. `/api/v1/orders` — 正常レスポンス\n2. `/api/v1/orders` — 429 レスポンス (rate limit)\n3. `/api/v1/payments` — 500ms遅延",
+      body: "chaos test用のstub定義ファイルを作成する\n\n### エンドポイント\n\n1. `/api/v1/orders` — 正常レスポンス\n2. `/api/v1/orders` — 429 レスポンス (rate limit)\n3. `/api/v1/payments` — 500ms遅延",
     },
     {
       ...base,
@@ -57,8 +54,7 @@ export function buildInitialTasks(): Task[] {
       estimatedMinutes: 15,
       stackOrder: 3,
       dependsOnEventId: null,
-      body:
-        "最終版PDFを浅野さんにメール送付\n\n確認ポイント:\n- 誤字脱字チェック済み\n- BASE在籍期間の記載が正確か",
+      body: "最終版PDFを浅野さんにメール送付\n\n確認ポイント:\n- 誤字脱字チェック済み\n- BASE在籍期間の記載が正確か",
     },
     {
       ...base,
@@ -68,8 +64,7 @@ export function buildInitialTasks(): Task[] {
       estimatedMinutes: 90,
       stackOrder: 4,
       dependsOnEventId: null,
-      body:
-        "## 目的\n\ncode-inspector用の抽象化層を設計する\n\n## 設計メモ\n\n```rust\ntrait AnalyzerContract {\n    fn analyze(&self, input: &SourceFile) -> AnalysisResult;\n    fn supports(&self, file_type: &FileType) -> bool;\n}\n```\n\n- php-parser と tree-sitter の両方に対応\n- call chain 解析は別traitに分離",
+      body: "## 目的\n\ncode-inspector用の抽象化層を設計する\n\n## 設計メモ\n\n```rust\ntrait AnalyzerContract {\n    fn analyze(&self, input: &SourceFile) -> AnalysisResult;\n    fn supports(&self, file_type: &FileType) -> bool;\n}\n```\n\n- php-parser と tree-sitter の両方に対応\n- call chain 解析は別traitに分離",
     },
     {
       ...base,
@@ -79,8 +74,7 @@ export function buildInitialTasks(): Task[] {
       estimatedMinutes: 120,
       stackOrder: 5,
       dependsOnEventId: null,
-      body:
-        "ピーク負荷パターンのシナリオを実装\n\n## 要件\n\n- 通常: 100 RPS\n- ピーク: 500 RPS (10分間)\n- ramp-up: 5分\n\n## メモ\n\n分散モードで ECS 上に展開予定",
+      body: "ピーク負荷パターンのシナリオを実装\n\n## 要件\n\n- 通常: 100 RPS\n- ピーク: 500 RPS (10分間)\n- ramp-up: 5分\n\n## メモ\n\n分散モードで ECS 上に展開予定",
     },
   ];
 }

--- a/src/shared/gateway/GatewayContext.test.tsx
+++ b/src/shared/gateway/GatewayContext.test.tsx
@@ -12,9 +12,7 @@ describe("GatewayContext hooks — Provider 未提供時", () => {
   test("useTaskGateway は Provider 無しで throw する", () => {
     const suppress = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
-      expect(() => renderHook(() => useTaskGateway())).toThrowError(
-        /GatewayProvider/,
-      );
+      expect(() => renderHook(() => useTaskGateway())).toThrowError(/GatewayProvider/);
     } finally {
       suppress.mockRestore();
     }
@@ -23,9 +21,7 @@ describe("GatewayContext hooks — Provider 未提供時", () => {
   test("useProjectGateway は Provider 無しで throw する", () => {
     const suppress = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
-      expect(() => renderHook(() => useProjectGateway())).toThrowError(
-        /GatewayProvider/,
-      );
+      expect(() => renderHook(() => useProjectGateway())).toThrowError(/GatewayProvider/);
     } finally {
       suppress.mockRestore();
     }
@@ -34,9 +30,7 @@ describe("GatewayContext hooks — Provider 未提供時", () => {
   test("useEventGateway は Provider 無しで throw する", () => {
     const suppress = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
-      expect(() => renderHook(() => useEventGateway())).toThrowError(
-        /GatewayProvider/,
-      );
+      expect(() => renderHook(() => useEventGateway())).toThrowError(/GatewayProvider/);
     } finally {
       suppress.mockRestore();
     }
@@ -45,9 +39,7 @@ describe("GatewayContext hooks — Provider 未提供時", () => {
   test("useTaskTimeEntryGateway は Provider 無しで throw する", () => {
     const suppress = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
-      expect(() => renderHook(() => useTaskTimeEntryGateway())).toThrowError(
-        /GatewayProvider/,
-      );
+      expect(() => renderHook(() => useTaskTimeEntryGateway())).toThrowError(/GatewayProvider/);
     } finally {
       suppress.mockRestore();
     }

--- a/src/shared/gateway/GatewayContext.tsx
+++ b/src/shared/gateway/GatewayContext.tsx
@@ -36,15 +36,8 @@ export function GatewayProvider({
   value?: GatewayBundle;
   children: ReactNode;
 }) {
-  const resolved = useMemo(
-    () => value ?? createSupabaseGateways(),
-    [value],
-  );
-  return (
-    <GatewayContext.Provider value={resolved}>
-      {children}
-    </GatewayContext.Provider>
-  );
+  const resolved = useMemo(() => value ?? createSupabaseGateways(), [value]);
+  return <GatewayContext.Provider value={resolved}>{children}</GatewayContext.Provider>;
 }
 
 function useGatewayBundle(): GatewayBundle {

--- a/src/shared/gateway/test-helpers.tsx
+++ b/src/shared/gateway/test-helpers.tsx
@@ -13,10 +13,7 @@ import { GatewayProvider, type GatewayBundle } from "./GatewayContext";
  * 「呼ばれるはずのないメソッドが呼ばれた」「テストが足りないモックを要求している」状況を
  * テスト失敗として検出する（undefined 関数呼び出しによる TypeError より診断しやすい）。
  */
-function strictMockGateway<T extends object>(
-  name: string,
-  override: Partial<T> = {},
-): T {
+function strictMockGateway<T extends object>(name: string, override: Partial<T> = {}): T {
   return new Proxy({} as T, {
     get(_target, prop) {
       const val = (override as Record<string | symbol, unknown>)[prop as string];
@@ -46,26 +43,15 @@ export type WithGatewaysResult = {
  * まとめて挿入する。`overrides` で渡した Gateway メソッドのみが呼び出し可能で、
  * 未指定メソッドへのアクセスは即 throw する。
  */
-export function withGateways(
-  overrides: GatewayOverrides = {},
-): WithGatewaysResult {
+export function withGateways(overrides: GatewayOverrides = {}): WithGatewaysResult {
   const bundle: GatewayBundle = {
-    taskGateway: strictMockGateway<TaskGateway>(
-      "TaskGateway",
-      overrides.taskGateway,
-    ),
+    taskGateway: strictMockGateway<TaskGateway>("TaskGateway", overrides.taskGateway),
     taskTimeEntryGateway: strictMockGateway<TaskTimeEntryGateway>(
       "TaskTimeEntryGateway",
       overrides.taskTimeEntryGateway,
     ),
-    projectGateway: strictMockGateway<ProjectGateway>(
-      "ProjectGateway",
-      overrides.projectGateway,
-    ),
-    eventGateway: strictMockGateway<EventGateway>(
-      "EventGateway",
-      overrides.eventGateway,
-    ),
+    projectGateway: strictMockGateway<ProjectGateway>("ProjectGateway", overrides.projectGateway),
+    eventGateway: strictMockGateway<EventGateway>("EventGateway", overrides.eventGateway),
   };
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 } },

--- a/src/shared/google/calendar.test.ts
+++ b/src/shared/google/calendar.test.ts
@@ -1,11 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  test,
-  vi,
-} from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { GoogleApiUnauthorizedError, listEvents } from "./calendar";
 
@@ -21,10 +14,7 @@ describe("listEvents", () => {
     vi.restoreAllMocks();
   });
 
-  function mockResponse(
-    body: unknown,
-    init: { status?: number; statusText?: string } = {},
-  ) {
+  function mockResponse(body: unknown, init: { status?: number; statusText?: string } = {}) {
     return new Response(JSON.stringify(body), {
       status: init.status ?? 200,
       statusText: init.statusText ?? "OK",
@@ -52,22 +42,16 @@ describe("listEvents", () => {
   });
 
   test("Bearer token を Authorization ヘッダに載せる", async () => {
-    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
-      mockResponse({ items: [] }),
-    );
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse({ items: [] }));
 
     await listEvents({ accessToken: "the-token", calendarId: "primary" });
 
     const [, init] = vi.mocked(globalThis.fetch).mock.calls[0]!;
-    expect(init?.headers).toEqual(
-      expect.objectContaining({ Authorization: "Bearer the-token" }),
-    );
+    expect(init?.headers).toEqual(expect.objectContaining({ Authorization: "Bearer the-token" }));
   });
 
   test("calendarId を URL に含み、クエリパラメータを組み立てる", async () => {
-    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
-      mockResponse({ items: [] }),
-    );
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse({ items: [] }));
 
     await listEvents({
       accessToken: "token",
@@ -92,9 +76,7 @@ describe("listEvents", () => {
   });
 
   test("calendarId は URL エンコードされる", async () => {
-    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
-      mockResponse({ items: [] }),
-    );
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse({ items: [] }));
 
     await listEvents({
       accessToken: "token",
@@ -102,15 +84,11 @@ describe("listEvents", () => {
     });
 
     const [url] = vi.mocked(globalThis.fetch).mock.calls[0]!;
-    expect(String(url)).toContain(
-      "/calendar/v3/calendars/user%40example.com/events",
-    );
+    expect(String(url)).toContain("/calendar/v3/calendars/user%40example.com/events");
   });
 
   test("syncToken 指定時は timeMin/timeMax を送らない (Google API 仕様)", async () => {
-    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
-      mockResponse({ items: [] }),
-    );
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse({ items: [] }));
 
     await listEvents({
       accessToken: "token",
@@ -159,11 +137,11 @@ describe("listEvents", () => {
       mockResponse({ error: "server" }, { status: 500 }),
     );
 
-    await expect(
-      listEvents({ accessToken: "token", calendarId: "primary" }),
-    ).rejects.toMatchObject({
-      name: "GoogleApiError",
-      status: 500,
-    });
+    await expect(listEvents({ accessToken: "token", calendarId: "primary" })).rejects.toMatchObject(
+      {
+        name: "GoogleApiError",
+        status: 500,
+      },
+    );
   });
 });

--- a/src/shared/google/env.ts
+++ b/src/shared/google/env.ts
@@ -7,22 +7,14 @@
  */
 function required(name: string, value: string | undefined): string {
   if (!value) {
-    throw new Error(
-      `[kozutsumi] Missing env: ${name}. See .env.local.example`,
-    );
+    throw new Error(`[kozutsumi] Missing env: ${name}. See .env.local.example`);
   }
   return value;
 }
 
 export function getGoogleOAuthEnv() {
   return {
-    clientId: required(
-      "GOOGLE_OAUTH_CLIENT_ID",
-      process.env.GOOGLE_OAUTH_CLIENT_ID,
-    ),
-    clientSecret: required(
-      "GOOGLE_OAUTH_CLIENT_SECRET",
-      process.env.GOOGLE_OAUTH_CLIENT_SECRET,
-    ),
+    clientId: required("GOOGLE_OAUTH_CLIENT_ID", process.env.GOOGLE_OAUTH_CLIENT_ID),
+    clientSecret: required("GOOGLE_OAUTH_CLIENT_SECRET", process.env.GOOGLE_OAUTH_CLIENT_SECRET),
   };
 }

--- a/src/shared/google/token.test.ts
+++ b/src/shared/google/token.test.ts
@@ -1,12 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  test,
-  vi,
-} from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import {
   getValidAccessToken,
@@ -73,9 +66,7 @@ describe("getValidAccessToken", () => {
 
   test("session が無ければ ProviderTokenMissingError", async () => {
     const supabase = makeSupabase(null);
-    await expect(getValidAccessToken(supabase)).rejects.toBeInstanceOf(
-      ProviderTokenMissingError,
-    );
+    await expect(getValidAccessToken(supabase)).rejects.toBeInstanceOf(ProviderTokenMissingError);
   });
 
   test("provider_token が無ければ ProviderTokenMissingError", async () => {
@@ -83,9 +74,7 @@ describe("getValidAccessToken", () => {
       provider_token: null,
       provider_refresh_token: "refresh-1",
     });
-    await expect(getValidAccessToken(supabase)).rejects.toBeInstanceOf(
-      ProviderTokenMissingError,
-    );
+    await expect(getValidAccessToken(supabase)).rejects.toBeInstanceOf(ProviderTokenMissingError);
   });
 
   test("provider_refresh_token が無ければ ProviderTokenMissingError", async () => {
@@ -93,9 +82,7 @@ describe("getValidAccessToken", () => {
       provider_token: "access-1",
       provider_refresh_token: null,
     });
-    await expect(getValidAccessToken(supabase)).rejects.toBeInstanceOf(
-      ProviderTokenMissingError,
-    );
+    await expect(getValidAccessToken(supabase)).rejects.toBeInstanceOf(ProviderTokenMissingError);
   });
 });
 
@@ -161,23 +148,16 @@ describe("refreshAccessToken", () => {
       provider_refresh_token: "refresh-1",
     });
     vi.mocked(globalThis.fetch).mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({ error: "invalid_grant" }),
-        { status: 400 },
-      ),
+      new Response(JSON.stringify({ error: "invalid_grant" }), { status: 400 }),
     );
 
-    await expect(refreshAccessToken(supabase)).rejects.toBeInstanceOf(
-      RefreshTokenExpiredError,
-    );
+    await expect(refreshAccessToken(supabase)).rejects.toBeInstanceOf(RefreshTokenExpiredError);
   });
 
   test("session が無ければ ProviderTokenMissingError で Google を叩かない", async () => {
     const supabase = makeSupabase(null);
 
-    await expect(refreshAccessToken(supabase)).rejects.toBeInstanceOf(
-      ProviderTokenMissingError,
-    );
+    await expect(refreshAccessToken(supabase)).rejects.toBeInstanceOf(ProviderTokenMissingError);
     expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled();
   });
 
@@ -187,9 +167,7 @@ describe("refreshAccessToken", () => {
       provider_refresh_token: null,
     });
 
-    await expect(refreshAccessToken(supabase)).rejects.toBeInstanceOf(
-      ProviderTokenMissingError,
-    );
+    await expect(refreshAccessToken(supabase)).rejects.toBeInstanceOf(ProviderTokenMissingError);
     expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled();
   });
 });

--- a/src/shared/google/token.ts
+++ b/src/shared/google/token.ts
@@ -27,21 +27,15 @@ export class RefreshTokenExpiredError extends Error {
   readonly name = "RefreshTokenExpiredError";
 }
 
-export async function getValidAccessToken(
-  supabase: SupabaseClient,
-): Promise<GoogleProviderAccess> {
+export async function getValidAccessToken(supabase: SupabaseClient): Promise<GoogleProviderAccess> {
   const { accessToken, refreshToken } = await readProviderTokens(supabase);
   if (!accessToken) {
-    throw new ProviderTokenMissingError(
-      "No Google provider_token in Supabase session",
-    );
+    throw new ProviderTokenMissingError("No Google provider_token in Supabase session");
   }
   return { accessToken, refreshToken };
 }
 
-export async function refreshAccessToken(
-  supabase: SupabaseClient,
-): Promise<GoogleProviderAccess> {
+export async function refreshAccessToken(supabase: SupabaseClient): Promise<GoogleProviderAccess> {
   const { refreshToken } = await readProviderTokens(supabase);
   const { clientId, clientSecret } = getGoogleOAuthEnv();
 
@@ -84,9 +78,7 @@ async function readProviderTokens(
   }
   const refreshToken = data.session.provider_refresh_token;
   if (!refreshToken) {
-    throw new ProviderTokenMissingError(
-      "No Google provider_refresh_token in Supabase session",
-    );
+    throw new ProviderTokenMissingError("No Google provider_refresh_token in Supabase session");
   }
   return {
     accessToken: data.session.provider_token ?? null,

--- a/src/shared/lib/markdown.tsx
+++ b/src/shared/lib/markdown.tsx
@@ -21,9 +21,7 @@ const headingSizeClass: Record<HeadingLevel, string> = {
   3: "text-[12px]",
 };
 
-export function renderMarkdown(
-  md: string | null | undefined,
-): ReactNode[] | null {
+export function renderMarkdown(md: string | null | undefined): ReactNode[] | null {
   if (!md) return null;
   const lines = md.split("\n");
   const elements: ReactNode[] = [];
@@ -79,9 +77,7 @@ export function renderMarkdown(
           key={key++}
           className="my-1.5 overflow-auto whitespace-pre rounded-md border border-bg-divider bg-bg-elevated px-3 py-2.5 text-[11px] leading-[1.5] text-fg-muted"
         >
-          {lang && (
-            <div className="mb-1 text-[9px] text-fg-weak">{lang}</div>
-          )}
+          {lang && <div className="mb-1 text-[9px] text-fg-weak">{lang}</div>}
           {codeLines.join("\n")}
         </pre>,
       );
@@ -107,9 +103,7 @@ export function renderMarkdown(
               }`}
             >
               <span className="shrink-0 text-fg-weak">•</span>
-              <span
-                dangerouslySetInnerHTML={{ __html: inlineStyle(it.text) }}
-              />
+              <span dangerouslySetInnerHTML={{ __html: inlineStyle(it.text) }} />
             </div>
           ))}
         </div>,
@@ -126,13 +120,8 @@ export function renderMarkdown(
       elements.push(
         <div key={key++} className="my-1">
           {items.map((it, j) => (
-            <div
-              key={j}
-              className="flex gap-1.5 py-0.5 font-jp text-[12px] text-fg-muted"
-            >
-              <span className="min-w-[16px] shrink-0 text-right text-fg-weak">
-                {j + 1}.
-              </span>
+            <div key={j} className="flex gap-1.5 py-0.5 font-jp text-[12px] text-fg-muted">
+              <span className="min-w-[16px] shrink-0 text-right text-fg-weak">{j + 1}.</span>
               <span dangerouslySetInnerHTML={{ __html: inlineStyle(it) }} />
             </div>
           ))}

--- a/src/shared/lib/time.test.ts
+++ b/src/shared/lib/time.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, test } from "vitest";
-import {
-  formatDate,
-  formatRelativeTime,
-  fmtDuration,
-  fmtMin,
-  timeToMin,
-} from "./time";
+import { formatDate, formatRelativeTime, fmtDuration, fmtMin, timeToMin } from "./time";
 
 describe("formatDate", () => {
   test('"YYYY-MM-DD" を "M/D (曜)" 形式に整形する', () => {

--- a/src/shared/lib/time.ts
+++ b/src/shared/lib/time.ts
@@ -78,8 +78,7 @@ export function formatRelativeTime(iso: string, now: Date = new Date()): string 
     const minutes = Math.round(diffMs / MS_PER_MIN);
     return `${minutes}分後`;
   }
-  const dayDiff =
-    Math.round((startOfLocalDay(target) - startOfLocalDay(now)) / MS_PER_DAY);
+  const dayDiff = Math.round((startOfLocalDay(target) - startOfLocalDay(now)) / MS_PER_DAY);
   const clock = formatClock(iso);
   if (dayDiff === 0) return `今日 ${clock}`;
   if (dayDiff === 1) return `明日 ${clock}`;

--- a/src/shared/supabase/env.ts
+++ b/src/shared/supabase/env.ts
@@ -6,22 +6,14 @@
  */
 function required(name: string, value: string | undefined): string {
   if (!value) {
-    throw new Error(
-      `[kozutsumi] Missing env: ${name}. See .env.local.example`,
-    );
+    throw new Error(`[kozutsumi] Missing env: ${name}. See .env.local.example`);
   }
   return value;
 }
 
 export function getSupabaseEnv() {
   return {
-    url: required(
-      "NEXT_PUBLIC_SUPABASE_URL",
-      process.env.NEXT_PUBLIC_SUPABASE_URL,
-    ),
-    anonKey: required(
-      "NEXT_PUBLIC_SUPABASE_ANON_KEY",
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-    ),
+    url: required("NEXT_PUBLIC_SUPABASE_URL", process.env.NEXT_PUBLIC_SUPABASE_URL),
+    anonKey: required("NEXT_PUBLIC_SUPABASE_ANON_KEY", process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY),
   };
 }

--- a/src/shared/supabase/middleware.ts
+++ b/src/shared/supabase/middleware.ts
@@ -39,9 +39,7 @@ export async function updateSession(request: NextRequest) {
   } = await supabase.auth.getUser();
 
   const pathname = request.nextUrl.pathname;
-  const isPublic = PUBLIC_PATHS.some(
-    (p) => pathname === p || pathname.startsWith(`${p}/`),
-  );
+  const isPublic = PUBLIC_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`));
 
   if (!user && !isPublic) {
     const loginUrl = request.nextUrl.clone();

--- a/src/shared/types/database.ts
+++ b/src/shared/types/database.ts
@@ -9,13 +9,7 @@
  *
  * スキーマ参照: supabase/migrations/20260419000000_initial_schema.sql
  */
-export type Json =
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string]: Json | undefined }
-  | Json[];
+export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
 
 export type Database = {
   public: {
@@ -232,5 +226,4 @@ export type TablesInsert<T extends keyof Database["public"]["Tables"]> =
   Database["public"]["Tables"][T]["Insert"];
 export type TablesUpdate<T extends keyof Database["public"]["Tables"]> =
   Database["public"]["Tables"][T]["Update"];
-export type Enums<T extends keyof Database["public"]["Enums"]> =
-  Database["public"]["Enums"][T];
+export type Enums<T extends keyof Database["public"]["Enums"]> = Database["public"]["Enums"][T];

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,11 +1,6 @@
 import type { Config } from "tailwindcss";
 
-import {
-  ACCENT_COLORS,
-  BG_COLORS,
-  FG_COLORS,
-  PROJECT_COLORS,
-} from "./src/shared/theme/tokens";
+import { ACCENT_COLORS, BG_COLORS, FG_COLORS, PROJECT_COLORS } from "./src/shared/theme/tokens";
 
 const config: Config = {
   content: ["./src/**/*.{ts,tsx}"],
@@ -37,12 +32,7 @@ const config: Config = {
         "panel-slide-up": "panel-slide-up 0.25s ease",
       },
       fontFamily: {
-        mono: [
-          "var(--font-mono)",
-          "ui-monospace",
-          "SFMono-Regular",
-          "monospace",
-        ],
+        mono: ["var(--font-mono)", "ui-monospace", "SFMono-Regular", "monospace"],
         jp: ["var(--font-jp)", "sans-serif"],
       },
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": [
-      "ES2022",
-      "DOM",
-      "DOM.Iterable"
-    ],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
@@ -25,21 +21,11 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     },
     "allowJs": true,
     "incremental": true
   },
-  "include": [
-    "src",
-    "next-env.d.ts",
-    ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    ".next"
-  ]
+  "include": ["src", "next-env.d.ts", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
+  "exclude": ["node_modules", ".next"]
 }


### PR DESCRIPTION
差分ノイズを抑えるため Prettier を導入。eslint-config-prettier で
ESLint 側の整形ルールとの衝突を無効化する。Tailwind 使用中なので
prettier-plugin-tailwindcss も同梱して className の並びを安定化。

実コードへの一括フォーマット適用は次コミットで行う（巨大 diff になる
ためレビューしやすさを優先して分離）。

https://claude.ai/code/session_01TDbn4JJZiZeACsPeCQCLDE