### PR TITLE
chore(e2e): e2e auth バイパスの二重ガード (#66)

### DIFF
--- a/docs/adr/0011-e2e-real-supabase-with-password-bypass.md
+++ b/docs/adr/0011-e2e-real-supabase-with-password-bypass.md
@@ -83,9 +83,27 @@ e2e テストを入れたいが、以下の制約がある:
 ## Notes
 
 - 実装ファイル: `playwright.config.ts` / `e2e/golden-path.spec.ts` / `e2e/global-setup.ts` /
-  `src/app/login/TestLoginForm.tsx`。
+  `e2e/db.ts` / `e2e/fixtures.ts` / `src/app/login/TestLoginForm.tsx` / `src/app/login/page.tsx`。
 - env: `E2E_TEST_USER_EMAIL` / `E2E_TEST_USER_PASSWORD` / `SUPABASE_SERVICE_ROLE_KEY` /
   `NEXT_PUBLIC_E2E_TEST_AUTH`。値（パスワード等）は code の constant ではなく env で渡す。
-- 見直し条件:
-  - Phase 3 で AI モック設計が固まったら、e2e の AI 周りカバー方針を別 ADR にする。
-  - Google OAuth フローを e2e に乗せたくなったら（プロダクト化検討時）、別 ADR で再設計。
+
+### 二重ガード (Issue #66)
+
+password sign-in 経路は本番に絶対漏らさない方針。3 層で防御する:
+
+1. **本質防衛: 本番 Supabase Dashboard で email/password provider を Disabled にする**。
+   form を消しても `signInWithPassword` endpoint は JS から直接叩けるため、本番側で
+   provider を無効化するのが唯一の真の防衛線。
+2. **build-time gate**: `TestLoginForm` の描画は
+   `NODE_ENV !== "production" && NEXT_PUBLIC_E2E_TEST_AUTH === "true"` の AND。
+   `page.tsx` (server) と `TestLoginForm` 自体 (client) の両方でチェックする。
+   どちらかの env が誤って prod に継承されても prod build なら描画されない。
+3. **e2e 側の URL guard**: `e2e/db.ts createAdminClient` が
+   `NEXT_PUBLIC_SUPABASE_URL` の hostname を localhost / 127.0.0.1 に限定して
+   abort する。`global-setup.ts` で誤って prod Supabase URL を指しても
+   test ユーザー作成 / purge が走る前に止まる。
+
+### 見直し条件
+
+- Phase 3 で AI モック設計が固まったら、e2e の AI 周りカバー方針を別 ADR にする。
+- Google OAuth フローを e2e に乗せたくなったら（プロダクト化検討時）、別 ADR で再設計。

--- a/e2e/db.ts
+++ b/e2e/db.ts
@@ -5,15 +5,32 @@ import { createClient, type SupabaseClient } from "@supabase/supabase-js";
  *
  * 役割:
  * - global-setup と各テスト fixture の双方から共有して使う
- * - ローカル Supabase 以外に向くのを防ぐため URL の host チェックは呼び出し側で行う想定
- *   (ADR 0011 二重ガードの follow-up #66 で集約予定)
+ * - prod Supabase に向いた状態で test ユーザー作成 / purge が走るのを防ぐため、
+ *   URL の hostname を localhost / 127.0.0.1 に限定する (ADR 0011 二重ガード)。
  */
+const ALLOWED_E2E_HOSTNAMES = new Set(["127.0.0.1", "localhost"]);
+
+function assertLocalSupabaseUrl(url: string): void {
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname;
+  } catch {
+    throw new Error(`[e2e] Invalid NEXT_PUBLIC_SUPABASE_URL: ${url}`);
+  }
+  if (!ALLOWED_E2E_HOSTNAMES.has(hostname)) {
+    throw new Error(
+      `[e2e] Refusing to use non-local Supabase (${hostname}). e2e must run against local Supabase only.`,
+    );
+  }
+}
+
 export function createAdminClient(): SupabaseClient {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !serviceRoleKey) {
     throw new Error("[e2e] Missing env: NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY");
   }
+  assertLocalSupabaseUrl(url);
   return createClient(url, serviceRoleKey, {
     auth: { persistSession: false, autoRefreshToken: false },
   });

--- a/src/app/login/TestLoginForm.tsx
+++ b/src/app/login/TestLoginForm.tsx
@@ -7,8 +7,8 @@ import { createClient } from "@/shared/supabase/client";
 /**
  * E2E テスト専用の password sign-in フォーム。
  *
- * `NEXT_PUBLIC_E2E_TEST_AUTH=true` のときだけ login page から render される
- * (ADR 0011)。本番ビルドでは env 未設定 → 表示されない。
+ * `NODE_ENV !== "production"` かつ `NEXT_PUBLIC_E2E_TEST_AUTH=true` のときだけ
+ * 描画される (ADR 0011 二重ガード)。本番ビルドでは early return で消える。
  *
  * 役割:
  * - Playwright が Google OAuth を踏まずに本物の Supabase へログインするための導線
@@ -16,6 +16,16 @@ import { createClient } from "@/shared/supabase/client";
  *   browser client の signInWithPassword をそのまま呼ぶ
  */
 export function TestLoginForm() {
+  // 二重ガード: page.tsx 側 (server) のガードが env 漏れで素通りしても、
+  // client 側のここで止める。NODE_ENV / NEXT_PUBLIC_E2E_TEST_AUTH は build 時に
+  // inline されるため、prod build からはこの分岐ごと落ちる。
+  if (process.env.NODE_ENV === "production" || process.env.NEXT_PUBLIC_E2E_TEST_AUTH !== "true") {
+    return null;
+  }
+  return <TestLoginFormInner />;
+}
+
+function TestLoginFormInner() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [pending, setPending] = useState(false);

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -16,8 +16,10 @@ export default async function LoginPage() {
   }
 
   // ADR 0011: e2e モードでだけ password sign-in フォームを表示する。
-  // NEXT_PUBLIC_E2E_TEST_AUTH=true のときに限り render され、本番では存在しない。
-  const e2eAuthEnabled = process.env.NEXT_PUBLIC_E2E_TEST_AUTH === "true";
+  // NODE_ENV と NEXT_PUBLIC_E2E_TEST_AUTH の二重ガード。
+  // 片方の env が誤って prod に継承されても prod build なら描画されない。
+  const e2eAuthEnabled =
+    process.env.NODE_ENV !== "production" && process.env.NEXT_PUBLIC_E2E_TEST_AUTH === "true";
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-8 px-6">


### PR DESCRIPTION
password sign-in 経路が誤って本番に漏れる事故を 3 層で防ぐ。

- TestLoginForm の描画ガードに NODE_ENV !== "production" を AND する。
  page.tsx (server) と TestLoginForm (client) の両方でチェックして、
  片方の env 漏れがあっても prod build では描画されない。
  TestLoginForm は早期 return + inner component で hooks rules を維持。
- e2e/db.ts の createAdminClient に Supabase URL hostname guard を追加。
  127.0.0.1 / localhost 以外を検出したら abort し、誤って prod Supabase に
  test ユーザー作成 / purge が走るのを物理的に止める。
- ADR 0011 の Notes に運用 note を追記。本質防衛は本番 Supabase Dashboard
  での password provider 無効化であることを明記し、3 層防御の関係を整理。