### PR TITLE
test(e2e): 行動データ整合（action_logs / time_entries / tasks.status）を踏む

### DIFF
--- a/e2e/action-log-time-entry.spec.ts
+++ b/e2e/action-log-time-entry.spec.ts
@@ -1,0 +1,175 @@
+import {
+  assertTimeEntriesInvariants,
+  createAdminClient,
+  expectTaskStatus,
+  findTestUserId,
+  getActionLogs,
+  getTaskByTitle,
+  getTimeEntries,
+  requiredEnv,
+  waitForActionLog,
+  waitForTimeEntries,
+} from "./db";
+import { expect, test } from "./fixtures";
+
+/**
+ * Issue #67 🟥 最優先 / ADR 0001 / ADR 0004:
+ *   行動データ (action_logs / task_time_entries / tasks.status) の整合を踏む。
+ *
+ * UI が "それっぽく" 動いていても DB に正しく落ちていなければ Phase 3 の
+ * 学習基盤 (vision.md の差別化の核) が壊れる。ここでは start → pause(voluntary)
+ *  → resume → complete の golden path を回しつつ、各操作の直後に DB を
+ * service_role で query して以下を assert する:
+ *   - action_logs に正しい action_type + metadata.task_id が積まれる
+ *   - task_time_entries が ADR 0004 の状態機械通りに分割される
+ *   - tasks.status が idle → active → paused → active → done を辿る
+ */
+test.describe("行動データ整合 (action_logs / task_time_entries / tasks.status)", () => {
+  test("start → pause → resume → complete で DB が ADR 通りに更新される", async ({
+    signedInPage: page,
+  }) => {
+    const projectName = "行動ログ検証プロジェクト";
+    const taskTitle = "行動ログ検証タスク";
+
+    const admin = createAdminClient();
+    const userId = await findTestUserId(admin, requiredEnv("E2E_TEST_USER_EMAIL"));
+    if (!userId) throw new Error("[e2e] test user must exist (created by global-setup)");
+
+    // --- セットアップ: プロジェクト + タスク 1 件を UI から作る ---------------
+    await page.getByRole("button", { name: "新規追加" }).click();
+    const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+    await addDialog.getByRole("tab", { name: "プロジェクト" }).click();
+    await addDialog.getByLabel("名前").fill(projectName);
+    await addDialog.getByRole("button", { name: "追加" }).click();
+    await expect(addDialog).toHaveCount(0);
+
+    await page.getByRole("button", { name: "新規追加" }).click();
+    const addDialog2 = page.getByRole("dialog", { name: "追加メニュー" });
+    await addDialog2.getByRole("tab", { name: "タスク" }).click();
+    await addDialog2.getByLabel("タイトル").fill(taskTitle);
+    await addDialog2.getByLabel("プロジェクト").selectOption({ label: projectName });
+    await addDialog2.getByRole("button", { name: "追加" }).click();
+    await expect(addDialog2).toHaveCount(0);
+
+    const stack = page.getByRole("list", { name: "タスクスタック" });
+    await expect(stack.getByRole("listitem").filter({ hasText: taskTitle })).toBeVisible();
+
+    // 作成直後は idle, entry なし。
+    const taskInitial = await getTaskByTitle(admin, userId, taskTitle);
+    expect(taskInitial.status).toBe("idle");
+    expect(await getTimeEntries(admin, taskInitial.id)).toHaveLength(0);
+    const taskId = taskInitial.id;
+
+    // --- start ---------------------------------------------------------------
+    await page.getByRole("button", { name: "開始" }).click();
+    await expect(page.getByRole("button", { name: "中断" })).toBeVisible();
+
+    await expectTaskStatus(admin, taskId, "active");
+
+    const startedLog = await waitForActionLog(
+      admin,
+      userId,
+      (l) => l.action_type === "task_started" && l.task_id === taskId,
+      { description: "task_started log" },
+    );
+    expect((startedLog.metadata as { task_id?: string }).task_id).toBe(taskId);
+
+    const afterStart = await waitForTimeEntries(
+      admin,
+      taskId,
+      (es) => es.length === 1 && es[0].paused_at === null,
+      { description: "1 open entry after start" },
+    );
+    assertTimeEntriesInvariants(afterStart);
+    expect(afterStart[0].pause_reason).toBeNull();
+    expect(afterStart[0].duration_seconds).toBeNull();
+
+    // --- pause (voluntary) ---------------------------------------------------
+    await page.getByRole("button", { name: "中断" }).click();
+    const pauseDialog = page.getByRole("dialog", { name: "中断の理由" });
+    await pauseDialog.getByRole("button", { name: /自発的に中断/ }).click();
+
+    await expect(page.getByRole("button", { name: "再開" })).toBeVisible();
+    await expectTaskStatus(admin, taskId, "paused");
+
+    const pausedLog = await waitForActionLog(
+      admin,
+      userId,
+      (l) => l.action_type === "task_paused" && l.task_id === taskId,
+      { description: "task_paused log" },
+    );
+    expect((pausedLog.metadata as { pause_reason?: string }).pause_reason).toBe("voluntary");
+
+    const afterPause = await waitForTimeEntries(
+      admin,
+      taskId,
+      (es) => es.length === 1 && es[0].paused_at !== null,
+      { description: "entry closed after pause" },
+    );
+    assertTimeEntriesInvariants(afterPause);
+    expect(afterPause[0].pause_reason).toBe("voluntary");
+    expect(afterPause[0].duration_seconds).not.toBeNull();
+    expect(afterPause[0].duration_seconds ?? -1).toBeGreaterThanOrEqual(0);
+
+    // --- resume --------------------------------------------------------------
+    await page.getByRole("button", { name: "再開" }).click();
+    await expect(page.getByRole("button", { name: "中断" })).toBeVisible();
+    await expectTaskStatus(admin, taskId, "active");
+
+    await waitForActionLog(
+      admin,
+      userId,
+      (l) => l.action_type === "task_resumed" && l.task_id === taskId,
+      { description: "task_resumed log" },
+    );
+
+    // ADR 0004: 再開のたびに新規 entry を insert する (= 1タスクに複数 entry)
+    const afterResume = await waitForTimeEntries(
+      admin,
+      taskId,
+      (es) => es.length === 2 && es.some((e) => e.paused_at === null),
+      { description: "2 entries after resume (1 closed + 1 open)" },
+    );
+    assertTimeEntriesInvariants(afterResume);
+    const closed = afterResume.filter((e) => e.paused_at !== null);
+    const open = afterResume.filter((e) => e.paused_at === null);
+    expect(closed).toHaveLength(1);
+    expect(open).toHaveLength(1);
+    expect(closed[0].pause_reason).toBe("voluntary");
+
+    // --- complete ------------------------------------------------------------
+    await page.getByRole("button", { name: "完了" }).click();
+    // 完了したタスクは pending stack から消える
+    await expect(stack.getByRole("listitem").filter({ hasText: taskTitle })).toHaveCount(0);
+
+    await expectTaskStatus(admin, taskId, "done");
+
+    const completedLog = await waitForActionLog(
+      admin,
+      userId,
+      (l) => l.action_type === "task_completed" && l.task_id === taskId,
+      { description: "task_completed log" },
+    );
+    expect((completedLog.metadata as { task_id?: string }).task_id).toBe(taskId);
+
+    // 完了時は最後の open entry を close する。pause_reason は null のままでよい
+    // (ADR 0004 Notes / DB 制約 task_time_entries_pause_reason_requires_paused)。
+    const afterComplete = await waitForTimeEntries(
+      admin,
+      taskId,
+      (es) => es.length === 2 && es.every((e) => e.paused_at !== null),
+      { description: "all entries closed after complete" },
+    );
+    assertTimeEntriesInvariants(afterComplete);
+    const completedTask = await getTaskByTitle(admin, userId, taskTitle);
+    expect(completedTask.completed_at).not.toBeNull();
+    const lastEntry = afterComplete[afterComplete.length - 1];
+    expect(lastEntry.paused_at).not.toBeNull();
+    expect(lastEntry.duration_seconds).not.toBeNull();
+
+    // --- 全体: action_logs の順序が UI 操作と一致 ---------------------------
+    const allLogs = await getActionLogs(admin, userId);
+    const ourLogs = allLogs.filter((l) => l.task_id === taskId).map((l) => l.action_type);
+    expect(ourLogs).toEqual(["task_started", "task_paused", "task_resumed", "task_completed"]);
+  });
+});

--- a/e2e/db.ts
+++ b/e2e/db.ts
@@ -1,3 +1,4 @@
+import { expect } from "@playwright/test";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
 /**
@@ -93,4 +94,198 @@ export function requiredEnv(name: string): string {
     throw new Error(`[e2e] Missing env: ${name}`);
   }
   return v;
+}
+
+// =====================================================================
+// Assertion helpers (Issue #67)
+//
+// 行動データ (action_logs / task_time_entries / tasks.status) は
+// kozutsumi の差別化の核 (vision.md)。UI が "それっぽく" 動いていても
+// DB に正しく落ちていなければ Phase 3 の学習基盤が壊れる。
+// service_role で直接 DB を query して、UI と DB の整合を踏みに行く。
+// =====================================================================
+
+export type ActionLogRow = {
+  id: string;
+  user_id: string;
+  action_type: string;
+  task_id: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+};
+
+export type TimeEntryRow = {
+  id: string;
+  task_id: string;
+  started_at: string;
+  paused_at: string | null;
+  pause_reason: "meeting" | "interruption" | "voluntary" | null;
+  duration_seconds: number | null;
+};
+
+export type TaskRow = {
+  id: string;
+  user_id: string;
+  project_id: string | null;
+  title: string;
+  status: "idle" | "active" | "paused" | "done";
+  stack_order: number | null;
+  depends_on_event_id: string | null;
+  completed_at: string | null;
+};
+
+/** ユーザーの action_logs を created_at 昇順で取得する。 */
+export async function getActionLogs(
+  admin: SupabaseClient,
+  userId: string,
+  opts: { actionType?: string } = {},
+): Promise<ActionLogRow[]> {
+  let query = admin
+    .from("action_logs")
+    .select("*")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: true });
+  if (opts.actionType) {
+    query = query.eq("action_type", opts.actionType);
+  }
+  const { data, error } = await query;
+  if (error) {
+    throw new Error(`[e2e] getActionLogs failed: ${error.message}`);
+  }
+  return (data ?? []) as ActionLogRow[];
+}
+
+/**
+ * action_logs は logger が fire-and-forget で書き込むため、UI 操作直後に
+ * SELECT しても未到達のことがある。条件を満たす行が現れるまで poll する。
+ */
+export async function waitForActionLog(
+  admin: SupabaseClient,
+  userId: string,
+  predicate: (row: ActionLogRow) => boolean,
+  opts: { timeoutMs?: number; intervalMs?: number; description?: string } = {},
+): Promise<ActionLogRow> {
+  const timeoutMs = opts.timeoutMs ?? 5_000;
+  const intervalMs = opts.intervalMs ?? 100;
+  const deadline = Date.now() + timeoutMs;
+  let lastSeen: ActionLogRow[] = [];
+  while (Date.now() < deadline) {
+    const logs = await getActionLogs(admin, userId);
+    lastSeen = logs;
+    const hit = logs.find(predicate);
+    if (hit) return hit;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  const desc = opts.description ?? "matching action_log";
+  throw new Error(
+    `[e2e] timed out waiting for ${desc}. seen action_types: ${lastSeen
+      .map((l) => l.action_type)
+      .join(", ")}`,
+  );
+}
+
+/** タスクの time_entries を started_at 昇順で取得する。 */
+export async function getTimeEntries(
+  admin: SupabaseClient,
+  taskId: string,
+): Promise<TimeEntryRow[]> {
+  const { data, error } = await admin
+    .from("task_time_entries")
+    .select("*")
+    .eq("task_id", taskId)
+    .order("started_at", { ascending: true });
+  if (error) {
+    throw new Error(`[e2e] getTimeEntries failed: ${error.message}`);
+  }
+  return (data ?? []) as TimeEntryRow[];
+}
+
+export async function getTaskByTitle(
+  admin: SupabaseClient,
+  userId: string,
+  title: string,
+): Promise<TaskRow> {
+  const { data, error } = await admin
+    .from("tasks")
+    .select("*")
+    .eq("user_id", userId)
+    .eq("title", title)
+    .single();
+  if (error || !data) {
+    throw new Error(`[e2e] getTaskByTitle(${title}) failed: ${error?.message ?? "not found"}`);
+  }
+  return data as TaskRow;
+}
+
+/**
+ * 状態遷移 (idle -> active -> paused -> done など) は楽観的更新で UI が
+ * 先に変わり、DB は数十ms 遅れて反映される。期待 status まで poll する。
+ */
+export async function expectTaskStatus(
+  admin: SupabaseClient,
+  taskId: string,
+  expected: TaskRow["status"],
+  opts: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<TaskRow> {
+  const timeoutMs = opts.timeoutMs ?? 5_000;
+  const intervalMs = opts.intervalMs ?? 100;
+  const deadline = Date.now() + timeoutMs;
+  let lastStatus: string | null = null;
+  while (Date.now() < deadline) {
+    const { data, error } = await admin.from("tasks").select("*").eq("id", taskId).single();
+    if (error || !data) {
+      throw new Error(`[e2e] expectTaskStatus fetch failed: ${error?.message ?? "not found"}`);
+    }
+    lastStatus = (data as TaskRow).status;
+    if (lastStatus === expected) return data as TaskRow;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(
+    `[e2e] timed out waiting for tasks.status=${expected} on ${taskId}. last=${lastStatus}`,
+  );
+}
+
+/**
+ * time_entries が期待数まで増える / 期待 entry の paused_at が埋まる、
+ * のような条件を満たすまで poll する。state machine (ADR 0004) を踏むのに使う。
+ */
+export async function waitForTimeEntries(
+  admin: SupabaseClient,
+  taskId: string,
+  predicate: (entries: TimeEntryRow[]) => boolean,
+  opts: { timeoutMs?: number; intervalMs?: number; description?: string } = {},
+): Promise<TimeEntryRow[]> {
+  const timeoutMs = opts.timeoutMs ?? 5_000;
+  const intervalMs = opts.intervalMs ?? 100;
+  const deadline = Date.now() + timeoutMs;
+  let lastSeen: TimeEntryRow[] = [];
+  while (Date.now() < deadline) {
+    lastSeen = await getTimeEntries(admin, taskId);
+    if (predicate(lastSeen)) return lastSeen;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  const desc = opts.description ?? "matching time_entries";
+  throw new Error(
+    `[e2e] timed out waiting for ${desc}. last entries: ${JSON.stringify(lastSeen, null, 2)}`,
+  );
+}
+
+/**
+ * task_time_entries の不変条件 (ADR 0004):
+ * - open entry (paused_at is null) は高々 1 件
+ * - close 済み entry は paused_at + duration_seconds が必ず埋まる
+ * - duration_seconds は 0 以上 (DB 制約と二重チェック)
+ */
+export function assertTimeEntriesInvariants(entries: readonly TimeEntryRow[]): void {
+  const openCount = entries.filter((e) => e.paused_at === null).length;
+  expect(openCount, "open entry must be at most 1").toBeLessThanOrEqual(1);
+  for (const e of entries) {
+    if (e.paused_at !== null) {
+      expect(e.duration_seconds, `closed entry ${e.id} must have duration_seconds`).not.toBeNull();
+      expect(e.duration_seconds ?? -1).toBeGreaterThanOrEqual(0);
+    } else {
+      expect(e.duration_seconds, `open entry ${e.id} must have null duration_seconds`).toBeNull();
+      expect(e.pause_reason, `open entry ${e.id} must have null pause_reason`).toBeNull();
+    }
+  }
 }


### PR DESCRIPTION
## 概要 (What)

start → pause(voluntary) → resume → complete の golden path を回しつつ、各操作の直後に DB を service_role で query して `action_logs` / `task_time_entries` / `tasks.status` の整合を踏む e2e spec を追加。あわせて poll 型の DB アサーションヘルパーを `e2e/db.ts` に切り出した。

## 関連 Issue

Refs #67

（Issue #67 の 🟥 最優先 3 項目のうち、`task_started` / `task_paused` / `task_resumed` / `task_completed` のフローと state machine 部分をカバー。残りの action_type（reorder / delete / dependency / calendar_synced）と 🟧 以下は段階 PR で続ける。）

## 背景 (Why)

vision.md の差別化の核は行動データ（`action_logs` / `task_time_entries`）の品質。Phase 3 で AI が学習を始める前に、UI が「それっぽく」動いているだけで DB が ADR 通りに更新されていない、という退行を踏める状態にしておく必要がある。Issue #46 の golden path は UI 側だけで、DB の不変条件は未カバーだった。

参照 ADR:

- ADR 0001（action_logs を Phase 1 から運用）
- ADR 0004（タイマー状態機械: pause で close + resume で新規 entry / duration_seconds は close 時点で確定）
- ADR 0011（e2e は本物のローカル Supabase + password sign-in）

## Before → After (概念・フロー・メンタルモデル)

**Before:** golden path は UI のボタン状態と stack の見た目しか見ていなかった。logger が fire-and-forget で書く `action_logs`、ADR 0004 の entry 分割、`tasks.status` の遷移は e2e から検証されていなかった。

**After:** UI 操作のたびに service_role で DB を直接 query し、行動データの不変条件を踏みに行く。logger の fire-and-forget と楽観的更新による DB 反映遅延は `waitForActionLog` / `expectTaskStatus` / `waitForTimeEntries` で polling して吸収する。

## 追加したテスト (How verified)

- [x] `e2e/action-log-time-entry.spec.ts`:
  - start で open entry が 1 件 + `task_started` log + `tasks.status=active`
  - pause で entry が close（`pause_reason=voluntary` / `duration_seconds` 確定） + `task_paused` log（metadata に `pause_reason`） + `tasks.status=paused`
  - resume で新規 entry insert（= 2 件・1 closed + 1 open） + `task_resumed` log + `tasks.status=active`
  - complete で全 entry close + `task_completed` log + `tasks.status=done` + `completed_at` 埋まる
  - 全体: `action_logs` の time order が UI 操作順に並ぶ
- [x] `assertTimeEntriesInvariants` で「open entry は高々 1 件 / closed は duration_seconds 必須 / open は pause_reason null」の不変条件を毎ステップで踏む
- [x] `npm test` (227 passed) / `npm run lint` / `npm run format:check` / `npx tsc --noEmit` 全て green
- [ ] e2e 本体は手元に Docker / Supabase が無いため未実行。CI で踏ませる

## このPRの範囲外 (Out of scope)

Issue #67 のうち以下は別 PR で対応:

- 🟥 残りの action_type: `task_reordered` / `task_deleted` / `task_dependency_set` / `task_dependency_cleared` / `calendar_synced`
- 🟧 中断理由 3 種網羅 (`meeting` / `interruption` / `voluntary`)
- 🟧 CRUD 網羅 / DnD edge case
- 🟨 auth セッション保全 / タイマー累積 + リロード復元 / google_calendar イベント編集制約 / sync 401
- 🟩 PoC レイアウト系
- 構造改善: `signedInPageWithProject` fixture / 巨大 spec の section 化


---
_Generated by [Claude Code](https://claude.ai/code/session_01SiHjZE9wTe1S1fUoW7BfWK)_