### PR TITLE
test(e2e): タスク削除 / DnD 並び替え / 中断理由 3 種の DB 整合を踏む

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -12,9 +12,16 @@ import { createAdminClient, findTestUserId, purgeUserData, requiredEnv } from ".
  *      (AppShell の自動 seed を止める)
  *   3. /login に遷移し、テスト用 password sign-in フォームで認証
  *   4. / へリダイレクトされるのを待って返す
+ *
+ * `signedInPageWithProject` は `signedInPage` の上にプロジェクト 1 件を作った
+ * 状態を返す。プロジェクト名は `projectName` で受け取る (各テストで上書き可)。
+ * Issue #67 構造改善: タスク CRUD / DnD / 中断テスト群でプロジェクト作成の
+ * 重複セットアップを減らすための fixture。
  */
 type Fixtures = {
   signedInPage: Page;
+  projectName: string;
+  signedInPageWithProject: Page;
 };
 
 export const test = base.extend<Fixtures>({
@@ -49,6 +56,28 @@ export const test = base.extend<Fixtures>({
 
     // hard nav (window.location.assign) で / に遷移するので load イベントが取れる。
     await page.waitForURL((url) => url.pathname === "/", { timeout: 15_000 });
+
+    await use(page);
+  },
+
+  // テスト側で `({ projectName: "..." }) => {}` の形で上書きできる。
+  // eslint-disable-next-line no-empty-pattern
+  projectName: async ({}, use) => {
+    await use("E2E プロジェクト");
+  },
+
+  signedInPageWithProject: async ({ signedInPage, projectName }, use) => {
+    const page = signedInPage;
+
+    // AddPanel を開いて「プロジェクト」タブから 1 件作る。
+    // golden-path / action-log spec と同じ a11y locator を使う
+    // (skill: kozutsumi-frontend-a11y)。
+    await page.getByRole("button", { name: "新規追加" }).click();
+    const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+    await addDialog.getByRole("tab", { name: "プロジェクト" }).click();
+    await addDialog.getByLabel("名前").fill(projectName);
+    await addDialog.getByRole("button", { name: "追加" }).click();
+    await expect(addDialog).toHaveCount(0);
 
     await use(page);
   },

--- a/e2e/pause-reason.spec.ts
+++ b/e2e/pause-reason.spec.ts
@@ -1,0 +1,97 @@
+import type { Page } from "@playwright/test";
+
+import {
+  assertTimeEntriesInvariants,
+  createAdminClient,
+  expectTaskStatus,
+  findTestUserId,
+  getTaskByTitle,
+  requiredEnv,
+  waitForActionLog,
+  waitForTimeEntries,
+} from "./db";
+import { expect, test } from "./fixtures";
+
+/**
+ * Issue #67 🟧 / ADR 0001 / ADR 0004:
+ *   中断理由 3 種 (meeting / interruption / voluntary) のすべてが
+ *   action_log と task_time_entries.pause_reason に正しく落ちることを踏む。
+ *
+ * voluntary は action-log-time-entry.spec で既にカバー済み。
+ * 残り 2 つ (meeting / interruption) を data-driven で踏む。
+ * Phase 4 で「割り込みの多い時間帯 / MTG 後のリカバリ」を分析するために、
+ * pause_reason の分布が DB に正確に書かれていることが前提条件になる。
+ */
+type PauseCase = {
+  reason: "meeting" | "interruption";
+  buttonName: RegExp;
+};
+
+const CASES: readonly PauseCase[] = [
+  { reason: "meeting", buttonName: /MTG/ },
+  { reason: "interruption", buttonName: /割り込み/ },
+] as const;
+
+test.describe("中断理由の網羅 (action_log.pause_reason / time_entries.pause_reason)", () => {
+  for (const c of CASES) {
+    test(`pause_reason=${c.reason} で中断すると DB に同じ値が入る`, async ({
+      signedInPageWithProject: page,
+      projectName,
+    }) => {
+      const taskTitle = `中断理由テスト (${c.reason})`;
+      const admin = createAdminClient();
+      const userId = await findTestUserId(admin, requiredEnv("E2E_TEST_USER_EMAIL"));
+      if (!userId) throw new Error("[e2e] test user must exist (created by global-setup)");
+
+      await createTask(page, taskTitle, projectName);
+      const task = await getTaskByTitle(admin, userId, taskTitle);
+      const taskId = task.id;
+
+      // start
+      await page.getByRole("button", { name: "開始" }).click();
+      await expect(page.getByRole("button", { name: "中断" })).toBeVisible();
+      await expectTaskStatus(admin, taskId, "active");
+
+      // pause: 該当の理由ボタンを押す
+      await page.getByRole("button", { name: "中断" }).click();
+      const pauseDialog = page.getByRole("dialog", { name: "中断の理由" });
+      await pauseDialog.getByRole("button", { name: c.buttonName }).click();
+
+      await expect(page.getByRole("button", { name: "再開" })).toBeVisible();
+      await expectTaskStatus(admin, taskId, "paused");
+
+      // action_log: pause_reason が metadata に正しく入る
+      const pausedLog = await waitForActionLog(
+        admin,
+        userId,
+        (l) =>
+          l.action_type === "task_paused" &&
+          l.task_id === taskId &&
+          (l.metadata as { pause_reason?: string }).pause_reason === c.reason,
+        { description: `task_paused log with pause_reason=${c.reason}` },
+      );
+      expect((pausedLog.metadata as { pause_reason?: string }).pause_reason).toBe(c.reason);
+
+      // task_time_entries: 直近 entry が close され pause_reason が一致
+      const entries = await waitForTimeEntries(
+        admin,
+        taskId,
+        (es) => es.length === 1 && es[0].paused_at !== null,
+        { description: "entry closed after pause" },
+      );
+      assertTimeEntriesInvariants(entries);
+      expect(entries[0].pause_reason).toBe(c.reason);
+      expect(entries[0].duration_seconds).not.toBeNull();
+    });
+  }
+});
+
+async function createTask(page: Page, title: string, projectName: string): Promise<void> {
+  await page.getByRole("button", { name: "新規追加" }).click();
+  const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+  await addDialog.getByRole("tab", { name: "タスク" }).click();
+  await addDialog.getByLabel("タイトル").fill(title);
+  await addDialog.getByLabel("プロジェクト").selectOption({ label: projectName });
+  await addDialog.getByRole("button", { name: "追加" }).click();
+  await expect(addDialog).toHaveCount(0);
+}

--- a/e2e/task-crud.spec.ts
+++ b/e2e/task-crud.spec.ts
@@ -1,0 +1,123 @@
+import {
+  createAdminClient,
+  findTestUserId,
+  getActionLogs,
+  getTaskByTitle,
+  getTimeEntries,
+  requiredEnv,
+  waitForActionLog,
+} from "./db";
+import { expect, test } from "./fixtures";
+
+/**
+ * Issue #67 🟥 / 🟧 / ADR 0001:
+ *   タスク削除フローの DB 整合 (task_deleted action_log + cascade)。
+ *
+ * 削除はリグレで一番気付きにくい (UI からは消える / DB を見ないとわからない) が、
+ * Phase 3 の学習で「ユーザーが何を捨てたか」を学ぶには task_deleted ログの
+ * 存続が必須 (vision.md / ADR 0001)。タスク本体の消失と time_entries の
+ * cascade、ログの永続化を 1 セットで踏む。
+ */
+test.describe("タスク削除 (task_deleted + cascade)", () => {
+  test("削除すると task_time_entries が cascade で消え、task_deleted ログが残る", async ({
+    signedInPageWithProject: page,
+    projectName,
+  }) => {
+    const taskTitle = "削除されるタスク";
+
+    const admin = createAdminClient();
+    const userId = await findTestUserId(admin, requiredEnv("E2E_TEST_USER_EMAIL"));
+    if (!userId) throw new Error("[e2e] test user must exist (created by global-setup)");
+
+    // --- タスク追加 ----------------------------------------------------------
+    await page.getByRole("button", { name: "新規追加" }).click();
+    const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+    await addDialog.getByRole("tab", { name: "タスク" }).click();
+    await addDialog.getByLabel("タイトル").fill(taskTitle);
+    await addDialog.getByLabel("プロジェクト").selectOption({ label: projectName });
+    await addDialog.getByRole("button", { name: "追加" }).click();
+    await expect(addDialog).toHaveCount(0);
+
+    const stack = page.getByRole("list", { name: "タスクスタック" });
+    const row = stack.getByRole("listitem").filter({ hasText: taskTitle });
+    await expect(row).toBeVisible();
+
+    const task = await getTaskByTitle(admin, userId, taskTitle);
+    const taskId = task.id;
+
+    // --- 開始 → 中断: task_time_entries を 1 件 close 状態で残す --------------
+    // cascade を確認するため、先に time_entries が DB に存在する状態を作る。
+    await page.getByRole("button", { name: "開始" }).click();
+    await expect(page.getByRole("button", { name: "中断" })).toBeVisible();
+
+    await page.getByRole("button", { name: "中断" }).click();
+    const pauseDialog = page.getByRole("dialog", { name: "中断の理由" });
+    await pauseDialog.getByRole("button", { name: /自発的に中断/ }).click();
+    await expect(page.getByRole("button", { name: "再開" })).toBeVisible();
+
+    // pause 後、entry が DB に書かれるまで待つ。
+    await expect
+      .poll(async () => (await getTimeEntries(admin, taskId)).length, {
+        message: "task_time_entries should have at least 1 row after pause",
+        timeout: 5_000,
+      })
+      .toBeGreaterThanOrEqual(1);
+
+    // --- TaskDetailPanel から削除 -------------------------------------------
+    // ブラウザ標準 confirm を accept する。
+    page.once("dialog", (d) => d.accept());
+
+    // タイトル文字をクリックして詳細パネルを開く (TopTaskCard 全体が onClick)。
+    // アクションボタン領域を避けるため title 文字を狙う。
+    await row.getByText(taskTitle).first().click();
+
+    // TaskDetailPanel には role=dialog が無いので button 名で取る。
+    // この時点で他に「削除」ボタンが出る画面要素は無い。
+    await page.getByRole("button", { name: "削除" }).click();
+
+    // 削除すると pending stack から消える。
+    await expect(row).toHaveCount(0);
+
+    // --- DB 整合 -------------------------------------------------------------
+    // tasks 行が消える (poll: 楽観的更新と DB 反映の間に小さなラグがある)。
+    await expect
+      .poll(
+        async () => {
+          const { data } = await admin.from("tasks").select("id").eq("id", taskId).maybeSingle();
+          return data;
+        },
+        { message: "tasks row should be deleted", timeout: 5_000 },
+      )
+      .toBeNull();
+
+    // task_time_entries は ON DELETE CASCADE で同時に消える (initial_schema.sql)。
+    expect(await getTimeEntries(admin, taskId)).toHaveLength(0);
+
+    // task_deleted の action_log が残る。
+    // ADR 0001: 削除イベント自体を Phase 3 学習の入力として保持したい。
+    // FK 制約 (ON DELETE SET NULL) は INSERT 時に効かないので、column.task_id
+    // に削除済み id を書こうとすると FK 違反で insert 自体が落ちる。logger は
+    // task_deleted のときだけ column を null にして metadata.task_id を一次の
+    // 真実として残す (logger.ts: extractTaskId)。
+    const deletedLog = await waitForActionLog(
+      admin,
+      userId,
+      (l) =>
+        l.action_type === "task_deleted" && (l.metadata as { task_id?: string }).task_id === taskId,
+      { description: "task_deleted log with metadata.task_id" },
+    );
+    expect((deletedLog.metadata as { task_id?: string }).task_id).toBe(taskId);
+    expect(deletedLog.task_id).toBeNull();
+
+    // 過去の task_started ログは SET NULL で task_id 列が NULL になっている
+    // はずだが、metadata.task_id は jsonb なので残る (Phase 3 で metadata
+    // 経由の相関を取れるかの基盤)。
+    const allLogs = await getActionLogs(admin, userId);
+    const startedForThisTask = allLogs.filter(
+      (l) =>
+        l.action_type === "task_started" && (l.metadata as { task_id?: string }).task_id === taskId,
+    );
+    expect(startedForThisTask).toHaveLength(1);
+    expect(startedForThisTask[0].task_id).toBeNull();
+  });
+});

--- a/e2e/task-reorder.spec.ts
+++ b/e2e/task-reorder.spec.ts
@@ -1,0 +1,205 @@
+import type { Page } from "@playwright/test";
+
+import {
+  createAdminClient,
+  findTestUserId,
+  getTaskByTitle,
+  requiredEnv,
+  waitForActionLog,
+} from "./db";
+import { expect, test } from "./fixtures";
+
+/**
+ * Issue #67 🟥 / 🟧 / ADR 0001:
+ *   DnD 並び替えの DB 整合 (task_reordered + tasks.stack_order)。
+ *
+ * Phase 4 でユーザーがどのタスクを上に持ち上げて着手したか を学ぶには、
+ * 並び替えの from/to_position と stack_order の両方が必要。UI 操作
+ * (custom pointer events) と DB の最終状態を 1 セットで踏む。
+ */
+test.describe("DnD 並び替え (task_reordered + tasks.stack_order)", () => {
+  test("末尾を先頭に持ち上げると stack_order が 0,1,2 で再採番され、from/to ログが残る", async ({
+    signedInPageWithProject: page,
+    projectName,
+  }) => {
+    const titles = ["並べ替え A", "並べ替え B", "並べ替え C"] as const;
+    const admin = createAdminClient();
+    const userId = await findTestUserId(admin, requiredEnv("E2E_TEST_USER_EMAIL"));
+    if (!userId) throw new Error("[e2e] test user must exist (created by global-setup)");
+
+    for (const t of titles) {
+      await createTask(page, t, projectName);
+    }
+
+    const stack = page.getByRole("list", { name: "タスクスタック" });
+    for (const t of titles) {
+      await expect(stack.getByRole("listitem").filter({ hasText: t })).toBeVisible();
+    }
+
+    // 末尾 (idx=2 / C) を先頭 (idx=0 / A の上) にドロップ。
+    // ADR 0001: from_position / to_position が UI と一致するか踏む。
+    await dragRowAboveRow(page, titles[2], titles[0]);
+
+    // task_reordered ログが、つかんだ task の id + 該当 from/to で 1 件以上残る。
+    // findDropTarget は「半分より上」で from を返す挙動なので to_position=0。
+    // (task A の box top + 4 を狙うので、midpoint より上 → 0 が選ばれる)
+    const movedC = await getTaskByTitle(admin, userId, titles[2]);
+    const reorderLog = await waitForActionLog(
+      admin,
+      userId,
+      (l) =>
+        l.action_type === "task_reordered" &&
+        (l.metadata as { task_id?: string }).task_id === movedC.id &&
+        (l.metadata as { from_position?: number }).from_position === 2 &&
+        (l.metadata as { to_position?: number }).to_position === 0,
+      { description: "task_reordered log: 末尾→先頭" },
+    );
+    expect((reorderLog.metadata as { from_position?: number }).from_position).toBe(2);
+    expect((reorderLog.metadata as { to_position?: number }).to_position).toBe(0);
+
+    // tasks.stack_order: C(0) / A(1) / B(2) の順に再採番されている。
+    // 楽観的更新と Promise.all 個別 update の間に DB 反映ラグがあるので poll。
+    await expect
+      .poll(async () => await readStackOrderByTitle(admin, userId), {
+        message: "stack_order が C(0) / A(1) / B(2) になる",
+        timeout: 5_000,
+      })
+      .toEqual([
+        { title: titles[2], stack_order: 0 },
+        { title: titles[0], stack_order: 1 },
+        { title: titles[1], stack_order: 2 },
+      ]);
+  });
+
+  test("先頭を末尾に下ろすと stack_order が更新される", async ({
+    signedInPageWithProject: page,
+    projectName,
+  }) => {
+    const titles = ["逆方向 X", "逆方向 Y", "逆方向 Z"] as const;
+    const admin = createAdminClient();
+    const userId = await findTestUserId(admin, requiredEnv("E2E_TEST_USER_EMAIL"));
+    if (!userId) throw new Error("[e2e] test user must exist (created by global-setup)");
+
+    for (const t of titles) {
+      await createTask(page, t, projectName);
+    }
+
+    const stack = page.getByRole("list", { name: "タスクスタック" });
+    for (const t of titles) {
+      await expect(stack.getByRole("listitem").filter({ hasText: t })).toBeVisible();
+    }
+
+    // 先頭 X を末尾 Z の下にドロップ。
+    // findDropTarget は「どの行 midpoint 上にも当たらない」ケースで rects.length-1
+    // (= 末尾 idx) を返す挙動なので、Z の bottom より下に落とす。
+    await dragRowBelowRow(page, titles[0], titles[2]);
+
+    const movedX = await getTaskByTitle(admin, userId, titles[0]);
+    await waitForActionLog(
+      admin,
+      userId,
+      (l) =>
+        l.action_type === "task_reordered" &&
+        (l.metadata as { task_id?: string }).task_id === movedX.id &&
+        (l.metadata as { from_position?: number }).from_position === 0 &&
+        (l.metadata as { to_position?: number }).to_position === 2,
+      { description: "task_reordered log: 先頭→末尾" },
+    );
+
+    await expect
+      .poll(async () => await readStackOrderByTitle(admin, userId), {
+        message: "stack_order が Y(0) / Z(1) / X(2) になる",
+        timeout: 5_000,
+      })
+      .toEqual([
+        { title: titles[1], stack_order: 0 },
+        { title: titles[2], stack_order: 1 },
+        { title: titles[0], stack_order: 2 },
+      ]);
+  });
+});
+
+async function createTask(page: Page, title: string, projectName: string): Promise<void> {
+  await page.getByRole("button", { name: "新規追加" }).click();
+  const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+  await addDialog.getByRole("tab", { name: "タスク" }).click();
+  await addDialog.getByLabel("タイトル").fill(title);
+  await addDialog.getByLabel("プロジェクト").selectOption({ label: projectName });
+  await addDialog.getByRole("button", { name: "追加" }).click();
+  await expect(addDialog).toHaveCount(0);
+}
+
+/**
+ * `sourceTitle` の grip を掴んで `targetTitle` の上端より少し下にドロップする。
+ * useStackDnD は HTML5 DnD ではなく custom pointer events なので mouse API で
+ * pointermove を複数回 emit する必要がある (5px 以上動かさないと drag 判定が立たない)。
+ */
+async function dragRowAboveRow(
+  page: Page,
+  sourceTitle: string,
+  targetTitle: string,
+): Promise<void> {
+  const stack = page.getByRole("list", { name: "タスクスタック" });
+  const sourceRow = stack.getByRole("listitem").filter({ hasText: sourceTitle });
+  const targetRow = stack.getByRole("listitem").filter({ hasText: targetTitle });
+
+  const grip = sourceRow.locator(".cursor-grab").first();
+  const gripBox = await grip.boundingBox();
+  const targetBox = await targetRow.boundingBox();
+  if (!gripBox || !targetBox) throw new Error("row/grip not measurable");
+
+  const startX = gripBox.x + gripBox.width / 2;
+  const startY = gripBox.y + gripBox.height / 2;
+  // target の midline より上に落とす → findDropTarget が target idx を返す。
+  const endX = startX;
+  const endY = targetBox.y + 4;
+
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(startX, startY - 20, { steps: 5 });
+  await page.mouse.move(endX, endY, { steps: 10 });
+  await page.mouse.up();
+}
+
+/**
+ * `sourceTitle` を `targetTitle` の bottom より下にドロップする (= 末尾扱い)。
+ */
+async function dragRowBelowRow(
+  page: Page,
+  sourceTitle: string,
+  targetTitle: string,
+): Promise<void> {
+  const stack = page.getByRole("list", { name: "タスクスタック" });
+  const sourceRow = stack.getByRole("listitem").filter({ hasText: sourceTitle });
+  const targetRow = stack.getByRole("listitem").filter({ hasText: targetTitle });
+
+  const grip = sourceRow.locator(".cursor-grab").first();
+  const gripBox = await grip.boundingBox();
+  const targetBox = await targetRow.boundingBox();
+  if (!gripBox || !targetBox) throw new Error("row/grip not measurable");
+
+  const startX = gripBox.x + gripBox.width / 2;
+  const startY = gripBox.y + gripBox.height / 2;
+  const endX = startX;
+  // 全行 midline より下 → findDropTarget が末尾 idx を返す。
+  const endY = targetBox.y + targetBox.height + 20;
+
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(startX, startY + 20, { steps: 5 });
+  await page.mouse.move(endX, endY, { steps: 10 });
+  await page.mouse.up();
+}
+
+async function readStackOrderByTitle(
+  admin: ReturnType<typeof createAdminClient>,
+  userId: string,
+): Promise<{ title: string; stack_order: number | null }[]> {
+  const { data, error } = await admin
+    .from("tasks")
+    .select("title, stack_order")
+    .eq("user_id", userId)
+    .order("stack_order", { ascending: true, nullsFirst: false });
+  if (error) throw new Error(`[e2e] readStackOrder failed: ${error.message}`);
+  return (data ?? []) as { title: string; stack_order: number | null }[];
+}

--- a/src/entities/action-log/logger.test.ts
+++ b/src/entities/action-log/logger.test.ts
@@ -82,6 +82,22 @@ describe("log()", () => {
     });
   });
 
+  // action_logs.task_id → tasks.id の FK は ON DELETE SET NULL なので、
+  // 削除済み task を column 値に書こうとすると INSERT 自体が落ちる
+  // (logger は fire-and-forget なので「ログ欠損」として黙って消える)。
+  // task_deleted は metadata.task_id を一次の真実として残しつつ column は
+  // null で書く。
+  test("task_deleted は column.task_id を null にして insert する (FK 違反回避)", async () => {
+    log(ACTION_TYPES.TASK_DELETED, { task_id: "deleted-task" });
+    await flushMicrotasks();
+    expect(insertMock).toHaveBeenCalledWith({
+      user_id: "user-1",
+      action_type: "task_deleted",
+      task_id: null,
+      metadata: { task_id: "deleted-task" },
+    });
+  });
+
   test("未ログイン時は insert をスキップする", async () => {
     getUserMock.mockResolvedValueOnce({ data: { user: null }, error: null });
     log(ACTION_TYPES.TASK_COMPLETED, { task_id: "t1" });

--- a/src/entities/action-log/logger.ts
+++ b/src/entities/action-log/logger.ts
@@ -55,7 +55,19 @@ function getClient(): SupabaseClientLike | null {
   return cachedClient;
 }
 
-function extractTaskId(metadata: Record<string, unknown>): string | null {
+/**
+ * action_logs.task_id 列に書く値を決める。
+ *
+ * task_deleted のとき: 削除済みの task を参照する column 値を書くと
+ *   action_logs.task_id → tasks.id の FK 制約に違反して insert 自体が
+ *   失敗する (ON DELETE SET NULL は既存行向けで、INSERT 時には適用されない)。
+ *   metadata.task_id を一次の真実として残しつつ column は null で書く。
+ *   Phase 3 学習では metadata 経由で相関を取る前提 (vision.md / ADR 0001)。
+ *
+ * それ以外: metadata.task_id があればそれを column 値にする。
+ */
+function extractTaskId(actionType: ActionType, metadata: Record<string, unknown>): string | null {
+  if (actionType === "task_deleted") return null;
   const v = metadata["task_id"];
   return typeof v === "string" ? v : null;
 }
@@ -75,7 +87,7 @@ async function persist<T extends ActionType>(entry: ActionLogEntry<T>): Promise<
   const { error } = await supabase.from("action_logs").insert({
     user_id: user.id,
     action_type: entry.action_type,
-    task_id: extractTaskId(entry.metadata as unknown as Record<string, unknown>),
+    task_id: extractTaskId(entry.action_type, entry.metadata as unknown as Record<string, unknown>),
     metadata: entry.metadata as unknown as Json,
   });
   if (error) {


### PR DESCRIPTION
## 概要 (What)

Issue #67 の続き。🟥 残り action_type のうち `task_deleted` / `task_reordered` と 🟧 中断理由 3 種網羅 / DnD edge case をカバー。あわせて `signedInPageWithProject` fixture を追加し、プロジェクト作成の重複セットアップを減らせるようにした。

`task_deleted` の e2e を書く過程で、現状の logger だと FK 違反で `task_deleted` action_log が DB に書けない（fire-and-forget なので「ログ欠損」として黙って消えていた）バグが見つかったので、最小修正を同梱している。

## 関連 Issue

Refs #67

（PR #71 と同様、Issue #67 は段階 PR で進めるため `Refs` のみ。残り 🟥 (`task_dependency_set` / `task_dependency_cleared` / `calendar_synced`) と 🟨 / 🟩 系は別 PR。）

## 背景 (Why)

vision.md の差別化の核は行動データ（`action_logs` / `task_time_entries`）の品質。Phase 3 で AI が学習を始める前に、UI が「それっぽく」動いていても DB の不変条件が壊れていれば踏める状態にしておく必要がある。PR #71 で start/pause/resume/complete + state machine はカバー済み。本 PR でその次の塊（削除フロー / DnD / 中断理由バリエーション）を踏む。

## Before → After (概念・フロー・メンタルモデル)

**Before:**

- 削除フロー: cascade も `task_deleted` action_log も e2e から検証されていない
- DnD 並び替え: golden path で 1 パターンだけ視覚的に確認、`tasks.stack_order` と `task_reordered` ログは未検証
- 中断理由: voluntary だけ踏んでいて、meeting / interruption は通っていない
- logger: `task_deleted` の column.task_id は削除済み id を書こうとして FK 違反 → insert 自体が落ちる（黙って欠損）

**After:**

- 削除: tasks 行が消える / task_time_entries が CASCADE で消える / `task_deleted` ログが残る / 過去ログの task_id 列が SET NULL になり metadata は残ることまで踏む
- DnD: 末尾→先頭 / 先頭→末尾 で `from_position` / `to_position` が UI と一致 + `tasks.stack_order` が 0,1,2 で再採番されることを poll で確認
- 中断理由: meeting / interruption を data-driven で網羅、`metadata.pause_reason` と `time_entries.pause_reason` の一致を踏む
- logger: `extractTaskId` が action_type を見て、`task_deleted` のときだけ column を null にする（`calendar_synced` と同じ「column null + metadata 詳細」パターン）。Phase 3 学習では metadata 経由で相関を取る前提（vision.md / ADR 0001）

## 追加したテスト (How verified)

- [x] `e2e/task-crud.spec.ts`:
  - 削除で tasks 行 + task_time_entries が消える（CASCADE）
  - `task_deleted` 行が `column.task_id=null` / `metadata.task_id=<id>` で残る
  - 過去の `task_started` ログの column.task_id が SET NULL になり、metadata.task_id は jsonb で残る
- [x] `e2e/task-reorder.spec.ts`:
  - 末尾→先頭: `from=2 / to=0` ログ + stack_order=[C,A,B]
  - 先頭→末尾: `from=0 / to=2` ログ + stack_order=[Y,Z,X]
- [x] `e2e/pause-reason.spec.ts`:
  - meeting / interruption の 2 ケースを data-driven で踏む（voluntary は #71 でカバー済み）
- [x] `src/entities/action-log/logger.test.ts`: `task_deleted` の column.task_id が null になる unit test を追加
- [x] `npm test` (228 passed) / `npm run lint` / `npm run format:check` / `npx tsc --noEmit` 全て green
- [ ] e2e 本体は手元に Docker / Supabase が無いため未実行。CI で踏ませる

## リリース前チェックリスト (When / Before merge)

- [x] logger 修正は backward compatible（column.task_id を null にしただけで、metadata は変わらない）
- [x] 既存テストへの破壊的影響なし（既存の logger.test.ts の expectation は `task_reordered` ベースで変更不要）

## このPRの範囲外 (Out of scope)

Issue #67 の以下は別 PR で対応:

- 🟥 残り action_type: `task_dependency_set` / `task_dependency_cleared` / `calendar_synced`
- 🟧 CRUD 網羅の残り（タスク本文編集 / プロジェクト作成 / manual イベント CRUD）
- 🟨 auth セッション保全 / タイマー累積 + リロード復元 / google_calendar イベント編集制約 / sync 401
- 🟩 PoC レイアウト系
- 構造改善: 既存 spec を `signedInPageWithProject` で書き直す（fixture を入れただけにとどめ、既存 spec の refactor は別 PR で）

過去 ログの cascade SET NULL によって correlation が失われる構造的問題（メタデータ経由で再構成する前提が成立しているか）は ADR 0001 のスコープ。本 PR ではログ自体が永続化されることだけを担保する。

---
_Generated by [Claude Code](https://claude.ai/code/session_01ToMFiSGGhSeXSKHzcCKPGp)_