### PR TITLE
test(e2e): タスク作成/編集 + プロジェクト + manual イベント作成の DB 整合を踏む

### DIFF
--- a/e2e/db.ts
+++ b/e2e/db.ts
@@ -128,10 +128,35 @@ export type TaskRow = {
   user_id: string;
   project_id: string | null;
   title: string;
+  body: string;
+  estimated_minutes: number | null;
   status: "idle" | "active" | "paused" | "done";
   stack_order: number | null;
   depends_on_event_id: string | null;
   completed_at: string | null;
+};
+
+export type ProjectRow = {
+  id: string;
+  user_id: string;
+  name: string;
+  color: string;
+  is_primary: boolean;
+  created_at: string;
+};
+
+export type EventRow = {
+  id: string;
+  user_id: string;
+  title: string;
+  start_time: string;
+  end_time: string;
+  project_id: string | null;
+  meet_url: string | null;
+  has_attachments: boolean;
+  description: string;
+  source: "manual" | "google_calendar";
+  external_id: string | null;
 };
 
 /** ユーザーの action_logs を created_at 昇順で取得する。 */
@@ -215,6 +240,40 @@ export async function getTaskByTitle(
     throw new Error(`[e2e] getTaskByTitle(${title}) failed: ${error?.message ?? "not found"}`);
   }
   return data as TaskRow;
+}
+
+export async function getProjectByName(
+  admin: SupabaseClient,
+  userId: string,
+  name: string,
+): Promise<ProjectRow> {
+  const { data, error } = await admin
+    .from("projects")
+    .select("*")
+    .eq("user_id", userId)
+    .eq("name", name)
+    .single();
+  if (error || !data) {
+    throw new Error(`[e2e] getProjectByName(${name}) failed: ${error?.message ?? "not found"}`);
+  }
+  return data as ProjectRow;
+}
+
+export async function getEventByTitle(
+  admin: SupabaseClient,
+  userId: string,
+  title: string,
+): Promise<EventRow> {
+  const { data, error } = await admin
+    .from("events")
+    .select("*")
+    .eq("user_id", userId)
+    .eq("title", title)
+    .single();
+  if (error || !data) {
+    throw new Error(`[e2e] getEventByTitle(${title}) failed: ${error?.message ?? "not found"}`);
+  }
+  return data as EventRow;
 }
 
 /**

--- a/e2e/project-event-crud.spec.ts
+++ b/e2e/project-event-crud.spec.ts
@@ -1,0 +1,121 @@
+import {
+  createAdminClient,
+  findTestUserId,
+  getEventByTitle,
+  getProjectByName,
+  requiredEnv,
+} from "./db";
+import { expect, test } from "./fixtures";
+
+/**
+ * Issue #67 🟧:
+ *   プロジェクト / manual イベント作成の DB 整合。
+ *
+ * golden-path / 他の spec はプロジェクトを使う側にしか居ないため、
+ * `projects` / `events (source='manual')` 行が UI 入力通りに落ちることを
+ * service_role で踏みにいく。
+ *
+ * **スコープアウト** (現状コードに UI が無い):
+ *   - manual イベントの編集 / 削除 UI (EventDetailPanel に未実装、
+ *     EventDetailPanel.test の「どの source でも『削除』ボタンは表示されない」
+ *     と整合)。
+ *   - ProjectForm 経由の編集 / 削除 (該当 UI なし)。
+ *   実装が入った段階で本 spec を拡張する。
+ */
+test.describe("プロジェクト作成 (projects 行整合)", () => {
+  test("名前 / 色 / 本業フラグ が projects 行に正しく落ちる", async ({ signedInPage: page }) => {
+    const projectName = "本業プロジェクト";
+    const projectColor = "#0096C7"; // ProjectForm DEFAULT_COLORS の 2 番目
+
+    const admin = createAdminClient();
+    const userId = await findTestUserId(admin, requiredEnv("E2E_TEST_USER_EMAIL"));
+    if (!userId) throw new Error("[e2e] test user must exist (created by global-setup)");
+
+    await page.getByRole("button", { name: "新規追加" }).click();
+    const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+    await addDialog.getByRole("tab", { name: "プロジェクト" }).click();
+    await addDialog.getByLabel("名前").fill(projectName);
+    // 色ボタンは `aria-label={色}` で取れる (ProjectForm.tsx)。
+    await addDialog.getByRole("button", { name: projectColor }).click();
+    await addDialog.getByRole("checkbox", { name: "本業として扱う" }).check();
+    await addDialog.getByRole("button", { name: "追加" }).click();
+    await expect(addDialog).toHaveCount(0);
+
+    const project = await getProjectByName(admin, userId, projectName);
+    expect(project.name).toBe(projectName);
+    expect(project.color).toBe(projectColor);
+    expect(project.is_primary).toBe(true);
+    expect(project.user_id).toBe(userId);
+  });
+});
+
+test.describe("manual イベント作成 (events 行整合)", () => {
+  test("title / start_time / end_time / meet_url / project / source=manual で events 行に落ちる", async ({
+    signedInPageWithProject: page,
+    projectName,
+  }) => {
+    const eventTitle = "E2E SLO レビュー MTG";
+    const startLocal = "2030-06-15T13:00";
+    const endLocal = "2030-06-15T14:00";
+    const meetUrl = "https://meet.google.com/e2e-slo-review";
+
+    const admin = createAdminClient();
+    const userId = await findTestUserId(admin, requiredEnv("E2E_TEST_USER_EMAIL"));
+    if (!userId) throw new Error("[e2e] test user must exist (created by global-setup)");
+
+    const project = await getProjectByName(admin, userId, projectName);
+
+    await page.getByRole("button", { name: "新規追加" }).click();
+    const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+    await addDialog.getByRole("tab", { name: "イベント" }).click();
+    await addDialog.getByLabel("タイトル").fill(eventTitle);
+    // datetime-local は string で fill する (Playwright は ISO ローカルを受け付ける)。
+    await addDialog.getByLabel("開始").fill(startLocal);
+    await addDialog.getByLabel("終了").fill(endLocal);
+    await addDialog.getByLabel("プロジェクト (任意)").selectOption({ label: projectName });
+    await addDialog.getByLabel("会議URL (任意)").fill(meetUrl);
+    await addDialog.getByRole("button", { name: "追加" }).click();
+    await expect(addDialog).toHaveCount(0);
+
+    const ev = await getEventByTitle(admin, userId, eventTitle);
+    expect(ev.title).toBe(eventTitle);
+    expect(ev.source).toBe("manual");
+    expect(ev.external_id).toBeNull();
+    expect(ev.project_id).toBe(project.id);
+    expect(ev.meet_url).toBe(meetUrl);
+    expect(ev.has_attachments).toBe(false);
+    expect(ev.description).toBe("");
+
+    // datetime-local はローカル tz で送信され DB に timestamptz として保存される。
+    // tz 環境差で文字列比較は壊れやすいので、エポック ms に揃えて比較する。
+    // EventForm: `${startLocal}:00` を渡すので "2030-06-15T13:00:00" 相当。
+    expect(new Date(ev.start_time).getTime()).toBe(new Date(`${startLocal}:00`).getTime());
+    expect(new Date(ev.end_time).getTime()).toBe(new Date(`${endLocal}:00`).getTime());
+  });
+
+  test("プロジェクト / 会議URL を空のままでも events 行が作れる", async ({
+    signedInPage: page,
+  }) => {
+    const eventTitle = "E2E 任意項目なしイベント";
+    const startLocal = "2030-07-01T09:00";
+    const endLocal = "2030-07-01T10:00";
+
+    const admin = createAdminClient();
+    const userId = await findTestUserId(admin, requiredEnv("E2E_TEST_USER_EMAIL"));
+    if (!userId) throw new Error("[e2e] test user must exist (created by global-setup)");
+
+    await page.getByRole("button", { name: "新規追加" }).click();
+    const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+    await addDialog.getByRole("tab", { name: "イベント" }).click();
+    await addDialog.getByLabel("タイトル").fill(eventTitle);
+    await addDialog.getByLabel("開始").fill(startLocal);
+    await addDialog.getByLabel("終了").fill(endLocal);
+    await addDialog.getByRole("button", { name: "追加" }).click();
+    await expect(addDialog).toHaveCount(0);
+
+    const ev = await getEventByTitle(admin, userId, eventTitle);
+    expect(ev.source).toBe("manual");
+    expect(ev.project_id).toBeNull();
+    expect(ev.meet_url).toBeNull();
+  });
+});

--- a/e2e/task-crud.spec.ts
+++ b/e2e/task-crud.spec.ts
@@ -2,12 +2,128 @@ import {
   createAdminClient,
   findTestUserId,
   getActionLogs,
+  getProjectByName,
   getTaskByTitle,
   getTimeEntries,
   requiredEnv,
   waitForActionLog,
 } from "./db";
 import { expect, test } from "./fixtures";
+
+/**
+ * Issue #67 🟧 / ADR 0001:
+ *   タスク作成フローの DB 整合 (tasks 行 + projects FK + estimated_minutes)。
+ *
+ * golden-path.spec はタスク作成を踏むが UI 側しか見ていない。ここでは
+ * 「title / project_id / estimated_minutes / status=idle / stack_order」が
+ * tasks 行に正しく落ちることを service_role で踏む。
+ * estimated_minutes は DB 制約 (tasks_estimated_minutes_positive) で守られて
+ * いるが、Form は分単位で受けて DB も分単位で保存する (gateway の素通し)。
+ */
+test.describe("タスク作成 (tasks 行整合)", () => {
+  test("title / project / 見積もり時間 が tasks 行に正しく落ちる", async ({
+    signedInPageWithProject: page,
+    projectName,
+  }) => {
+    const taskTitle = "見積もり付きタスク";
+    const estimatedMinutes = 45;
+
+    const admin = createAdminClient();
+    const userId = await findTestUserId(admin, requiredEnv("E2E_TEST_USER_EMAIL"));
+    if (!userId) throw new Error("[e2e] test user must exist (created by global-setup)");
+
+    const project = await getProjectByName(admin, userId, projectName);
+
+    await page.getByRole("button", { name: "新規追加" }).click();
+    const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+    await addDialog.getByRole("tab", { name: "タスク" }).click();
+    await addDialog.getByLabel("タイトル").fill(taskTitle);
+    await addDialog.getByLabel("プロジェクト").selectOption({ label: projectName });
+    await addDialog.getByLabel("見積もり (分)").fill(String(estimatedMinutes));
+    await addDialog.getByRole("button", { name: "追加" }).click();
+    await expect(addDialog).toHaveCount(0);
+
+    const stack = page.getByRole("list", { name: "タスクスタック" });
+    await expect(stack.getByRole("listitem").filter({ hasText: taskTitle })).toBeVisible();
+
+    const task = await getTaskByTitle(admin, userId, taskTitle);
+    expect(task.title).toBe(taskTitle);
+    expect(task.project_id).toBe(project.id);
+    expect(task.estimated_minutes).toBe(estimatedMinutes);
+    expect(task.body).toBe("");
+    expect(task.status).toBe("idle");
+    // AppShell.onCreateTask は pending 件数を stackOrder に渡す。
+    // 直前まで pending タスクは 0 件だったので 0 が入るはず。
+    expect(task.stack_order).toBe(0);
+    expect(task.depends_on_event_id).toBeNull();
+
+    // 作成自体は action_log を吐かない (ADR 0001 の対象 type に task_created が無い)。
+    // 他の action_log が混入していないことだけ軽く担保しておく。
+    const logs = await getActionLogs(admin, userId);
+    expect(logs.filter((l) => l.task_id === task.id)).toHaveLength(0);
+  });
+});
+
+/**
+ * Issue #67 🟧:
+ *   TaskDetailPanel から body を編集すると DB に永続化される。
+ *
+ * TaskDetailPanel は body のみ編集可。estimated_minutes / title の編集 UI は
+ * 現状無い (TaskDetailPanel.tsx)。ユーザーの「タスクの中身を書く」体験は
+ * Phase 1 の体験仕様に含まれるので、UI から DB まで通ることを踏む。
+ */
+test.describe("タスク編集 (TaskDetailPanel body)", () => {
+  test("body を編集して保存すると tasks.body が更新される", async ({
+    signedInPageWithProject: page,
+    projectName,
+  }) => {
+    const taskTitle = "詳細を書くタスク";
+    const newBody = "## 準備\n- 資料を集める\n- アジェンダを書く";
+
+    const admin = createAdminClient();
+    const userId = await findTestUserId(admin, requiredEnv("E2E_TEST_USER_EMAIL"));
+    if (!userId) throw new Error("[e2e] test user must exist (created by global-setup)");
+
+    await page.getByRole("button", { name: "新規追加" }).click();
+    const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+    await addDialog.getByRole("tab", { name: "タスク" }).click();
+    await addDialog.getByLabel("タイトル").fill(taskTitle);
+    await addDialog.getByLabel("プロジェクト").selectOption({ label: projectName });
+    await addDialog.getByRole("button", { name: "追加" }).click();
+    await expect(addDialog).toHaveCount(0);
+
+    const stack = page.getByRole("list", { name: "タスクスタック" });
+    const row = stack.getByRole("listitem").filter({ hasText: taskTitle });
+    await expect(row).toBeVisible();
+
+    const task = await getTaskByTitle(admin, userId, taskTitle);
+    expect(task.body).toBe("");
+
+    // 詳細パネルを開く (TopTaskCard 全体が onClick、title 文字を狙う)。
+    await row.getByText(taskTitle).first().click();
+
+    await page.getByRole("button", { name: "編集" }).click();
+    // textarea は role=textbox では取れない (placeholder ベース)。
+    const textarea = page.getByPlaceholder("Markdownで詳細を入力...");
+    await expect(textarea).toBeVisible();
+    await textarea.fill(newBody);
+    await page.getByRole("button", { name: "保存" }).click();
+
+    // 保存後はパネルが view モードに戻り「編集」ボタンが再度見える。
+    await expect(page.getByRole("button", { name: "編集" })).toBeVisible();
+
+    // DB は楽観的更新と非同期 mutation の間に小ラグがあり得るので poll。
+    await expect
+      .poll(
+        async () => {
+          const t = await getTaskByTitle(admin, userId, taskTitle);
+          return t.body;
+        },
+        { message: "tasks.body が新しい本文に更新される", timeout: 5_000 },
+      )
+      .toBe(newBody);
+  });
+});
 
 /**
  * Issue #67 🟥 / 🟧 / ADR 0001:


### PR DESCRIPTION
## 概要 (What)

Issue #67 🟧 CRUD 網羅の続き。#71 (行動データ) / #72 (削除 / DnD / 中断理由) に続いて、作成系 + body 編集の DB 整合をカバーする。

## 関連 Issue

Refs #67

## 背景 (Why)

vision の差別化の核は **行動データの品質**。`#71` / `#72` で 🟥 最優先と 🟧 高 (削除 / DnD / 中断理由) を踏んだが、最頻操作である作成系 (タスク / プロジェクト / manual イベント) と TaskDetailPanel からの編集はまだ DB 直接 assert で踏んでいなかった。

UI が "それっぽく" 動いていても、`tasks.estimated_minutes` / `events.source='manual'` / `projects.is_primary` 等が正しく書かれていなければ Phase 3 の学習・Phase 4 の本業時間分析が崩れる。ここで踏み台にしておく。

関連 ADR:
- ADR 0001 (action_logs)
- ADR 0011 (e2e auth bypass)

## Before → After

**Before:**

`golden-path.spec` がプロジェクト作成 / タスク作成を踏むが、UI 側 (リストに表示される) しか見ていない。`task-crud.spec` には削除しか居なかった。manual イベント / プロジェクトの DB 整合は完全に未カバー。

**After:**

`task-crud.spec` に「作成」「body 編集」テストを追加し、`project-event-crud.spec` を新設。`getProjectByName` / `getEventByTitle` を `e2e/db.ts` に足し、すべての CRUD 検証で同じパターンの service_role assert が書けるようにした。

## 追加したテスト (How verified)

- [x] `task-crud.spec` 「タスク作成 (tasks 行整合)」: title / project_id / estimated_minutes=45 / status=idle / stack_order=0 / depends_on_event_id=null。作成自体は action_log を吐かないことも軽く担保。
- [x] `task-crud.spec` 「タスク編集 (TaskDetailPanel body)」: 編集 → 保存 → `tasks.body` が新本文に更新されるまで poll。
- [x] `project-event-crud.spec` 「プロジェクト作成」: 名前 / 色 (`aria-label={色}` ボタン) / 本業フラグ (checkbox) が `projects` 行に落ちる。
- [x] `project-event-crud.spec` 「manual イベント作成」: title / start_time / end_time / meet_url / project_id / source='manual' / external_id=null。datetime-local の tz 差を避けるためエポック ms で比較。
- [x] `project-event-crud.spec` 「任意項目空でも作れる」: project_id / meet_url が null でも source='manual' で行が作られる。
- [x] ローカル: `npm run typecheck` / `npm run lint` / `npm run format:check` / 228 件の `npm test` すべて green。
- [ ] e2e 本体: ローカルに Supabase CLI が無いため CI に委ねる。

## このPRの範囲外 (Out of scope)

Issue #67 本文には書かれているが、現状コードに UI が無いため本 PR では踏めない。実装が入った段階で同じ pattern で spec を増やす:

- **TaskDetailPanel での estimated_minutes / title 編集** — 現 UI は body のみ編集可。
- **EventDetailPanel での manual event 編集 / 削除** — 既存 unit test (`EventDetailPanel.test.tsx`) で「どの source でも『削除』ボタンは表示されない」と確認済みの通り、UI 自体が未実装。
- **ProjectForm 経由のプロジェクト編集 / 削除** — 該当 UI なし。

これらは UI feature の追加が必要なので、Issue #67 の checkbox はチェックせず、別 issue 化が必要 (本 PR では起票しない)。

Issue #67 の残作業 (🟨 / 🟩) — auth 保全 / リロード復元 / 依存イベント / google_calendar 編集制約 / sync 401 / イベント追加 (AddPanel タブ別経路) / TreeView mock — は次の段階 PR で踏む。


---
_Generated by [Claude Code](https://claude.ai/code/session_01YbQQuo9XrcYM13NCbbthk7)_