### PR TITLE
ci(e2e): e2e job を 4m 21s → 3m 27s に高速化 (-21%)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,8 +181,28 @@ jobs:
           } >> "$GITHUB_ENV"
       - name: Install npm deps
         run: npm ci
+      # Playwright の browser binary (~/.cache/ms-playwright) を Playwright の
+      # version で key 付けして cache する。version が変わったら自動で miss する。
+      # cache hit でも system deps (apt) は別途 install-deps で入れる必要がある
+      # (apt 部分は数秒なので browser DL の 25s と比べると誤差)。
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: |
+          version=$(node -p "require('./package-lock.json').packages['node_modules/@playwright/test'].version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        run: |
+          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
+            npx playwright install-deps chromium
+          else
+            npx playwright install --with-deps chromium
+          fi
       - name: Run Playwright
         env:
           E2E_TEST_USER_EMAIL: e2e@kozutsumi.local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,41 +165,12 @@ jobs:
       - uses: supabase/setup-cli@v1
         with:
           version: latest
-      # supabase start で pull する Docker image (postgres / kong / gotrue /
-      # postgrest / postgres-meta 等) を tar に固めて actions/cache に乗せる。
-      # 初回は MISS で 2m13s ぶん丸ごと払うが、2 回目以降は load + start で
-      # pull をスキップできる。key は config.toml の hash + 手動 reset 用 v1。
-      # supabase CLI が image version を bump した場合は cache stale になるが、
-      # そのときは v2 に bump するか CLI version を pin する。
-      - name: Restore Supabase Docker images cache
-        id: supabase-docker-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/supabase-docker-images.tar
-          key: supabase-docker-${{ runner.os }}-${{ hashFiles('supabase/config.toml') }}-v1
-      - name: Load cached Supabase Docker images
-        if: steps.supabase-docker-cache.outputs.cache-hit == 'true'
-        run: docker load -i ~/.cache/supabase-docker-images.tar
       # ADR 0011: e2e は本物の Supabase スタック + password sign-in でログインする。
       # auth は必要、studio / storage 等は不要なので最小構成で起動する。
       - name: Start Supabase local stack
         run: |
           supabase start \
             -x studio,inbucket,storage-api,imgproxy,edge-runtime,logflare,vector,pgsodium,realtime
-      # cache miss だった場合のみ、起動後の image set を tar 化して保存する。
-      # save 失敗が test を止めないよう continue-on-error。
-      - name: Save Supabase Docker images for cache
-        if: steps.supabase-docker-cache.outputs.cache-hit != 'true'
-        continue-on-error: true
-        run: |
-          mkdir -p ~/.cache
-          images=$(docker ps --format '{{.Image}}' | sort -u)
-          if [ -n "$images" ]; then
-            echo "Saving images:"
-            echo "$images"
-            docker save -o ~/.cache/supabase-docker-images.tar $images
-            ls -lh ~/.cache/supabase-docker-images.tar
-          fi
       - name: Export Supabase keys into env
         run: |
           supabase status -o env > /tmp/sb.env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,11 +151,19 @@ jobs:
         run: supabase stop --no-backup || true
 
   e2e:
-    name: E2E (Playwright)
+    # B (sharding): e2e tests を 2 shard に分割し別 runner で並走させる。
+    # 各 shard は独自に Supabase を立てる (140s) ため起動コストは shard 数だけ
+    # 払うが、test 実行 (51s) が半分に減るので wall は -30s 程度短縮できる。
+    # public repo なので分課金は無料。
+    name: E2E (shard ${{ matrix.shard }}/${{ strategy.job-total }})
     needs: changes
     if: needs.changes.outputs.node == 'true' || needs.changes.outputs.supabase == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -165,6 +173,15 @@ jobs:
       - uses: supabase/setup-cli@v1
         with:
           version: latest
+      # D-(1): docker daemon の layer 並列 DL を 3 → 20 に bump。
+      # postgres image は layer が多く、標準の 3 並列だと pull が支配的になる。
+      # daemon 設定を上書き → restart して supabase start 前に効かせる。
+      - name: Bump docker daemon parallel pull
+        run: |
+          sudo mkdir -p /etc/docker
+          echo '{"max-concurrent-downloads": 20, "max-concurrent-uploads": 20}' \
+            | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
       # ADR 0011: e2e は本物の Supabase スタック + password sign-in でログインする。
       # auth は必要、studio / storage 等は不要なので最小構成で起動する。
       #
@@ -236,12 +253,13 @@ jobs:
         env:
           E2E_TEST_USER_EMAIL: e2e@kozutsumi.local
           E2E_TEST_USER_PASSWORD: e2e-ci-password
-        run: npm run test:e2e
+        run: npm run test:e2e -- --shard=${{ matrix.shard }}/${{ strategy.job-total }}
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
+          # shard ごとに別 artifact 名で upload する (同名は upload-artifact@v4 で衝突)。
+          name: playwright-report-shard-${{ matrix.shard }}
           path: playwright-report/
           retention-days: 7
           if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,18 +167,20 @@ jobs:
           version: latest
       # ADR 0011: e2e は本物の Supabase スタック + password sign-in でログインする。
       # auth は必要、studio / storage 等は不要なので最小構成で起動する。
-      - name: Start Supabase local stack
+      #
+      # Step 並列化: supabase start は image pull + container init で 2m+ かかる
+      # ので、background 起動 → npm ci / playwright install を overlap → 後段で
+      # 完了を待つ、の順にする。Supabase 起動 (~133s) > install (~30s) なので
+      # install のぶん丸ごと隠れる (期待 -30s)。
+      - name: Start Supabase local stack (background)
         run: |
-          supabase start \
-            -x studio,inbucket,storage-api,imgproxy,edge-runtime,logflare,vector,pgsodium,realtime
-      - name: Export Supabase keys into env
-        run: |
-          supabase status -o env > /tmp/sb.env
-          {
-            echo "NEXT_PUBLIC_SUPABASE_URL=$(grep '^API_URL=' /tmp/sb.env | cut -d= -f2- | tr -d '\"')"
-            echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=$(grep '^ANON_KEY=' /tmp/sb.env | cut -d= -f2- | tr -d '\"')"
-            echo "SUPABASE_SERVICE_ROLE_KEY=$(grep '^SERVICE_ROLE_KEY=' /tmp/sb.env | cut -d= -f2- | tr -d '\"')"
-          } >> "$GITHUB_ENV"
+          rm -f /tmp/supabase-start.exit /tmp/supabase-start.log
+          nohup bash -c '
+            supabase start \
+              -x studio,inbucket,storage-api,imgproxy,edge-runtime,logflare,vector,pgsodium,realtime
+            echo "$?" > /tmp/supabase-start.exit
+          ' > /tmp/supabase-start.log 2>&1 &
+          echo $! > /tmp/supabase-start.pid
       - name: Install npm deps
         run: npm ci
       # Playwright の browser binary (~/.cache/ms-playwright) を Playwright の
@@ -203,6 +205,33 @@ jobs:
           else
             npx playwright install --with-deps chromium
           fi
+      # background の supabase start が完了するまで待つ。pid が消えたら exit
+      # code を読み、log を出力する (失敗時の診断)。
+      - name: Wait for Supabase to be ready
+        run: |
+          pid=$(cat /tmp/supabase-start.pid)
+          while kill -0 "$pid" 2>/dev/null; do
+            sleep 2
+          done
+          if [ ! -f /tmp/supabase-start.exit ]; then
+            echo "::error::supabase start did not record exit code"
+            cat /tmp/supabase-start.log || true
+            exit 1
+          fi
+          code=$(cat /tmp/supabase-start.exit)
+          cat /tmp/supabase-start.log
+          if [ "$code" -ne 0 ]; then
+            echo "::error::supabase start exited with code $code"
+            exit "$code"
+          fi
+      - name: Export Supabase keys into env
+        run: |
+          supabase status -o env > /tmp/sb.env
+          {
+            echo "NEXT_PUBLIC_SUPABASE_URL=$(grep '^API_URL=' /tmp/sb.env | cut -d= -f2- | tr -d '\"')"
+            echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=$(grep '^ANON_KEY=' /tmp/sb.env | cut -d= -f2- | tr -d '\"')"
+            echo "SUPABASE_SERVICE_ROLE_KEY=$(grep '^SERVICE_ROLE_KEY=' /tmp/sb.env | cut -d= -f2- | tr -d '\"')"
+          } >> "$GITHUB_ENV"
       - name: Run Playwright
         env:
           E2E_TEST_USER_EMAIL: e2e@kozutsumi.local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,12 +165,41 @@ jobs:
       - uses: supabase/setup-cli@v1
         with:
           version: latest
+      # supabase start で pull する Docker image (postgres / kong / gotrue /
+      # postgrest / postgres-meta 等) を tar に固めて actions/cache に乗せる。
+      # 初回は MISS で 2m13s ぶん丸ごと払うが、2 回目以降は load + start で
+      # pull をスキップできる。key は config.toml の hash + 手動 reset 用 v1。
+      # supabase CLI が image version を bump した場合は cache stale になるが、
+      # そのときは v2 に bump するか CLI version を pin する。
+      - name: Restore Supabase Docker images cache
+        id: supabase-docker-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/supabase-docker-images.tar
+          key: supabase-docker-${{ runner.os }}-${{ hashFiles('supabase/config.toml') }}-v1
+      - name: Load cached Supabase Docker images
+        if: steps.supabase-docker-cache.outputs.cache-hit == 'true'
+        run: docker load -i ~/.cache/supabase-docker-images.tar
       # ADR 0011: e2e は本物の Supabase スタック + password sign-in でログインする。
       # auth は必要、studio / storage 等は不要なので最小構成で起動する。
       - name: Start Supabase local stack
         run: |
           supabase start \
             -x studio,inbucket,storage-api,imgproxy,edge-runtime,logflare,vector,pgsodium,realtime
+      # cache miss だった場合のみ、起動後の image set を tar 化して保存する。
+      # save 失敗が test を止めないよう continue-on-error。
+      - name: Save Supabase Docker images for cache
+        if: steps.supabase-docker-cache.outputs.cache-hit != 'true'
+        continue-on-error: true
+        run: |
+          mkdir -p ~/.cache
+          images=$(docker ps --format '{{.Image}}' | sort -u)
+          if [ -n "$images" ]; then
+            echo "Saving images:"
+            echo "$images"
+            docker save -o ~/.cache/supabase-docker-images.tar $images
+            ls -lh ~/.cache/supabase-docker-images.tar
+          fi
       - name: Export Supabase keys into env
         run: |
           supabase status -o env > /tmp/sb.env

--- a/e2e/action-log-time-entry.spec.ts
+++ b/e2e/action-log-time-entry.spec.ts
@@ -2,11 +2,9 @@ import {
   assertTimeEntriesInvariants,
   createAdminClient,
   expectTaskStatus,
-  findTestUserId,
   getActionLogs,
   getTaskByTitle,
   getTimeEntries,
-  requiredEnv,
   waitForActionLog,
   waitForTimeEntries,
 } from "./db";
@@ -27,13 +25,12 @@ import { expect, test } from "./fixtures";
 test.describe("行動データ整合 (action_logs / task_time_entries / tasks.status)", () => {
   test("start → pause → resume → complete で DB が ADR 通りに更新される", async ({
     signedInPage: page,
+    testUserId: userId,
   }) => {
     const projectName = "行動ログ検証プロジェクト";
     const taskTitle = "行動ログ検証タスク";
 
     const admin = createAdminClient();
-    const userId = await findTestUserId(admin, requiredEnv("E2E_TEST_USER_EMAIL"));
-    if (!userId) throw new Error("[e2e] test user must exist (created by global-setup)");
 
     // --- セットアップ: プロジェクト + タスク 1 件を UI から作る ---------------
     await page.getByRole("button", { name: "新規追加" }).click();

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,9 +1,16 @@
 import { test as base, expect, type Page } from "@playwright/test";
 
 import { createAdminClient, findTestUserId, purgeUserData, requiredEnv } from "./db";
+import { getWorkerEmail } from "./users";
 
 /**
  * e2e 共通 fixture (ADR 0011)。
+ *
+ * `testEmail` / `testUserId`: workers >1 化に伴う per-worker test user。
+ *   Playwright の testInfo.parallelIndex で worker を識別し、各 worker は
+ *   別 user (e2e-w0@... / e2e-w1@... / ...) を扱う。これによって purge / DB
+ *   assert が干渉しない。spec 側は env を読まずに `testEmail` / `testUserId`
+ *   を destructure するだけで自分の worker の user に届く。
  *
  * `signedInPage` を使うと:
  *   1. service_role で当該ユーザーの projects / tasks / events / action_logs を purge する
@@ -19,21 +26,37 @@ import { createAdminClient, findTestUserId, purgeUserData, requiredEnv } from ".
  * 重複セットアップを減らすための fixture。
  */
 type Fixtures = {
+  testEmail: string;
+  testUserId: string;
   signedInPage: Page;
   projectName: string;
   signedInPageWithProject: Page;
 };
 
 export const test = base.extend<Fixtures>({
-  signedInPage: async ({ page, baseURL }, use) => {
-    const email = requiredEnv("E2E_TEST_USER_EMAIL");
+  // eslint-disable-next-line no-empty-pattern
+  testEmail: async ({}, use, testInfo) => {
+    const baseEmail = requiredEnv("E2E_TEST_USER_EMAIL");
+    await use(getWorkerEmail(baseEmail, testInfo.parallelIndex));
+  },
+
+  testUserId: async ({ testEmail }, use) => {
+    const admin = createAdminClient();
+    const id = await findTestUserId(admin, testEmail);
+    if (!id) {
+      throw new Error(`[e2e] test user ${testEmail} must exist (created by global-setup)`);
+    }
+    await use(id);
+  },
+
+  signedInPage: async ({ page, baseURL, testEmail }, use) => {
     const password = requiredEnv("E2E_TEST_USER_PASSWORD");
 
     // --- 1. DB を per-test で clean に戻す ---------------------------------
     // global-setup の purge は 1 回しか走らないため、retry や複数 spec 間で
     // データが持ち越される。ここで毎回 purge して isolation を保つ。
     const admin = createAdminClient();
-    const userId = await findTestUserId(admin, email);
+    const userId = await findTestUserId(admin, testEmail);
     if (userId) {
       await purgeUserData(admin, userId);
     }
@@ -50,7 +73,7 @@ export const test = base.extend<Fixtures>({
     // --- 3. password sign-in でログイン ------------------------------------
     await page.goto(`${baseURL ?? ""}/login`);
     await expect(page.getByTestId("e2e-login-form")).toBeVisible();
-    await page.getByTestId("e2e-login-email").fill(email);
+    await page.getByTestId("e2e-login-email").fill(testEmail);
     await page.getByTestId("e2e-login-password").fill(password);
     await page.getByTestId("e2e-login-submit").click();
 

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,21 +1,28 @@
 import { createAdminClient, ensureTestUser, purgeUserData, requiredEnv } from "./db";
+import { getAllWorkerEmails } from "./users";
 
 /**
  * e2e 共通 setup (ADR 0011)。
  *
- * 1. テストユーザーを idempotent に用意する (createUser または password 上書き)
- * 2. ユーザーの projects / tasks / events / action_logs を purge して clean state にする
+ * 1. workers >1 化 (Issue #67 系の並列化) のため、N 人分の test user を
+ *    idempotent に用意する (createUser または password 上書き)
+ * 2. 各ユーザーの projects / tasks / events / action_logs を purge して
+ *    clean state にする
  *
  * テストごとの purge は fixtures.ts (`signedInPage`) で重ねて行うため、
  * ここは defense-in-depth (CI 全体の最初の clean) と user 作成の両方を担う。
  */
 async function globalSetup(): Promise<void> {
-  const email = requiredEnv("E2E_TEST_USER_EMAIL");
   const password = requiredEnv("E2E_TEST_USER_PASSWORD");
-
   const admin = createAdminClient();
-  const userId = await ensureTestUser(admin, email, password);
-  await purgeUserData(admin, userId);
+  const emails = getAllWorkerEmails();
+
+  await Promise.all(
+    emails.map(async (email) => {
+      const userId = await ensureTestUser(admin, email, password);
+      await purgeUserData(admin, userId);
+    }),
+  );
 }
 
 export default globalSetup;

--- a/e2e/pause-reason.spec.ts
+++ b/e2e/pause-reason.spec.ts
@@ -4,9 +4,7 @@ import {
   assertTimeEntriesInvariants,
   createAdminClient,
   expectTaskStatus,
-  findTestUserId,
   getTaskByTitle,
-  requiredEnv,
   waitForActionLog,
   waitForTimeEntries,
 } from "./db";
@@ -37,11 +35,10 @@ test.describe("中断理由の網羅 (action_log.pause_reason / time_entries.pau
     test(`pause_reason=${c.reason} で中断すると DB に同じ値が入る`, async ({
       signedInPageWithProject: page,
       projectName,
+      testUserId: userId,
     }) => {
       const taskTitle = `中断理由テスト (${c.reason})`;
       const admin = createAdminClient();
-      const userId = await findTestUserId(admin, requiredEnv("E2E_TEST_USER_EMAIL"));
-      if (!userId) throw new Error("[e2e] test user must exist (created by global-setup)");
 
       await createTask(page, taskTitle, projectName);
       const task = await getTaskByTitle(admin, userId, taskTitle);

--- a/e2e/project-event-crud.spec.ts
+++ b/e2e/project-event-crud.spec.ts
@@ -1,10 +1,4 @@
-import {
-  createAdminClient,
-  findTestUserId,
-  getEventByTitle,
-  getProjectByName,
-  requiredEnv,
-} from "./db";
+import { createAdminClient, getEventByTitle, getProjectByName } from "./db";
 import { expect, test } from "./fixtures";
 
 /**
@@ -23,13 +17,14 @@ import { expect, test } from "./fixtures";
  *   実装が入った段階で本 spec を拡張する。
  */
 test.describe("プロジェクト作成 (projects 行整合)", () => {
-  test("名前 / 色 / 本業フラグ が projects 行に正しく落ちる", async ({ signedInPage: page }) => {
+  test("名前 / 色 / 本業フラグ が projects 行に正しく落ちる", async ({
+    signedInPage: page,
+    testUserId: userId,
+  }) => {
     const projectName = "本業プロジェクト";
     const projectColor = "#0096C7"; // ProjectForm DEFAULT_COLORS の 2 番目
 
     const admin = createAdminClient();
-    const userId = await findTestUserId(admin, requiredEnv("E2E_TEST_USER_EMAIL"));
-    if (!userId) throw new Error("[e2e] test user must exist (created by global-setup)");
 
     await page.getByRole("button", { name: "新規追加" }).click();
     const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
@@ -53,6 +48,7 @@ test.describe("manual イベント作成 (events 行整合)", () => {
   test("title / start_time / end_time / meet_url / project / source=manual で events 行に落ちる", async ({
     signedInPageWithProject: page,
     projectName,
+    testUserId: userId,
   }) => {
     const eventTitle = "E2E SLO レビュー MTG";
     const startLocal = "2030-06-15T13:00";
@@ -60,8 +56,6 @@ test.describe("manual イベント作成 (events 行整合)", () => {
     const meetUrl = "https://meet.google.com/e2e-slo-review";
 
     const admin = createAdminClient();
-    const userId = await findTestUserId(admin, requiredEnv("E2E_TEST_USER_EMAIL"));
-    if (!userId) throw new Error("[e2e] test user must exist (created by global-setup)");
 
     const project = await getProjectByName(admin, userId, projectName);
 
@@ -95,14 +89,13 @@ test.describe("manual イベント作成 (events 行整合)", () => {
 
   test("プロジェクト / 会議URL を空のままでも events 行が作れる", async ({
     signedInPage: page,
+    testUserId: userId,
   }) => {
     const eventTitle = "E2E 任意項目なしイベント";
     const startLocal = "2030-07-01T09:00";
     const endLocal = "2030-07-01T10:00";
 
     const admin = createAdminClient();
-    const userId = await findTestUserId(admin, requiredEnv("E2E_TEST_USER_EMAIL"));
-    if (!userId) throw new Error("[e2e] test user must exist (created by global-setup)");
 
     await page.getByRole("button", { name: "新規追加" }).click();
     const addDialog = page.getByRole("dialog", { name: "追加メニュー" });

--- a/e2e/task-crud.spec.ts
+++ b/e2e/task-crud.spec.ts
@@ -1,11 +1,9 @@
 import {
   createAdminClient,
-  findTestUserId,
   getActionLogs,
   getProjectByName,
   getTaskByTitle,
   getTimeEntries,
-  requiredEnv,
   waitForActionLog,
 } from "./db";
 import { expect, test } from "./fixtures";
@@ -24,13 +22,12 @@ test.describe("タスク作成 (tasks 行整合)", () => {
   test("title / project / 見積もり時間 が tasks 行に正しく落ちる", async ({
     signedInPageWithProject: page,
     projectName,
+    testUserId: userId,
   }) => {
     const taskTitle = "見積もり付きタスク";
     const estimatedMinutes = 45;
 
     const admin = createAdminClient();
-    const userId = await findTestUserId(admin, requiredEnv("E2E_TEST_USER_EMAIL"));
-    if (!userId) throw new Error("[e2e] test user must exist (created by global-setup)");
 
     const project = await getProjectByName(admin, userId, projectName);
 
@@ -76,13 +73,12 @@ test.describe("タスク編集 (TaskDetailPanel body)", () => {
   test("body を編集して保存すると tasks.body が更新される", async ({
     signedInPageWithProject: page,
     projectName,
+    testUserId: userId,
   }) => {
     const taskTitle = "詳細を書くタスク";
     const newBody = "## 準備\n- 資料を集める\n- アジェンダを書く";
 
     const admin = createAdminClient();
-    const userId = await findTestUserId(admin, requiredEnv("E2E_TEST_USER_EMAIL"));
-    if (!userId) throw new Error("[e2e] test user must exist (created by global-setup)");
 
     await page.getByRole("button", { name: "新規追加" }).click();
     const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
@@ -138,12 +134,11 @@ test.describe("タスク削除 (task_deleted + cascade)", () => {
   test("削除すると task_time_entries が cascade で消え、task_deleted ログが残る", async ({
     signedInPageWithProject: page,
     projectName,
+    testUserId: userId,
   }) => {
     const taskTitle = "削除されるタスク";
 
     const admin = createAdminClient();
-    const userId = await findTestUserId(admin, requiredEnv("E2E_TEST_USER_EMAIL"));
-    if (!userId) throw new Error("[e2e] test user must exist (created by global-setup)");
 
     // --- タスク追加 ----------------------------------------------------------
     await page.getByRole("button", { name: "新規追加" }).click();

--- a/e2e/task-reorder.spec.ts
+++ b/e2e/task-reorder.spec.ts
@@ -1,12 +1,6 @@
 import type { Page } from "@playwright/test";
 
-import {
-  createAdminClient,
-  findTestUserId,
-  getTaskByTitle,
-  requiredEnv,
-  waitForActionLog,
-} from "./db";
+import { createAdminClient, getTaskByTitle, waitForActionLog } from "./db";
 import { expect, test } from "./fixtures";
 
 /**
@@ -21,11 +15,10 @@ test.describe("DnD 並び替え (task_reordered + tasks.stack_order)", () => {
   test("末尾を先頭に持ち上げると stack_order が 0,1,2 で再採番され、from/to ログが残る", async ({
     signedInPageWithProject: page,
     projectName,
+    testUserId: userId,
   }) => {
     const titles = ["並べ替え A", "並べ替え B", "並べ替え C"] as const;
     const admin = createAdminClient();
-    const userId = await findTestUserId(admin, requiredEnv("E2E_TEST_USER_EMAIL"));
-    if (!userId) throw new Error("[e2e] test user must exist (created by global-setup)");
 
     for (const t of titles) {
       await createTask(page, t, projectName);
@@ -74,11 +67,10 @@ test.describe("DnD 並び替え (task_reordered + tasks.stack_order)", () => {
   test("先頭を末尾に下ろすと stack_order が更新される", async ({
     signedInPageWithProject: page,
     projectName,
+    testUserId: userId,
   }) => {
     const titles = ["逆方向 X", "逆方向 Y", "逆方向 Z"] as const;
     const admin = createAdminClient();
-    const userId = await findTestUserId(admin, requiredEnv("E2E_TEST_USER_EMAIL"));
-    if (!userId) throw new Error("[e2e] test user must exist (created by global-setup)");
 
     for (const t of titles) {
       await createTask(page, t, projectName);

--- a/e2e/users.ts
+++ b/e2e/users.ts
@@ -1,0 +1,31 @@
+import { requiredEnv } from "./db";
+
+/**
+ * e2e の per-worker test user 採番 (Issue #67 系の e2e 並列化)。
+ *
+ * Playwright の workers >1 で実行する場合、各 worker が同じ test user の
+ * tasks/projects を購入&purge すると test 間で干渉する。worker ごとに別 user に
+ * 分けることで、purge / login / DB assert の isolation を保つ。
+ *
+ * email 規則:
+ *   base: `e2e@kozutsumi.local` (E2E_TEST_USER_EMAIL)
+ *   per-worker: `e2e-w0@kozutsumi.local` / `e2e-w1@...` / ...
+ *
+ * `+` だと一部の Supabase auth 経路で展開される懸念があるので `-` で連結する。
+ */
+export const E2E_WORKER_COUNT = 4;
+
+export function getWorkerEmail(baseEmail: string, workerIndex: number): string {
+  const atIdx = baseEmail.indexOf("@");
+  if (atIdx < 0) {
+    throw new Error(`[e2e] invalid base email (no @): ${baseEmail}`);
+  }
+  const local = baseEmail.slice(0, atIdx);
+  const domain = baseEmail.slice(atIdx + 1);
+  return `${local}-w${workerIndex}@${domain}`;
+}
+
+export function getAllWorkerEmails(count: number = E2E_WORKER_COUNT): string[] {
+  const baseEmail = requiredEnv("E2E_TEST_USER_EMAIL");
+  return Array.from({ length: count }, (_, i) => getWorkerEmail(baseEmail, i));
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,10 +18,13 @@ const BASE_URL = `http://localhost:${PORT}`;
 
 export default defineConfig({
   testDir: "./e2e",
-  fullyParallel: false,
+  // worker 間 isolation は per-worker test user (e2e/users.ts) で担保。
+  // ローカルは 1 worker (debug しやすさ + Supabase 1 stack の負荷上限)、
+  // CI は 4 worker (ubuntu-latest 2 vCPU + 7GB RAM 想定の上限近く)。
+  fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  workers: 1,
+  workers: process.env.CI ? 4 : 1,
   reporter: [["list"], ["html", { open: "never" }]],
   globalSetup: "./e2e/global-setup.ts",
   use: {


### PR DESCRIPTION
## 概要 (What)

e2e (Playwright) job を **4m 21s → 3m 27s（-54s, -21%）** に短縮。各段階で実測しながら進めた結果、想定どおり効いたものと効かなかったものがあり、後者は revert している。

## 背景 (Why)

PR #73 時点の e2e job (4m 21s) の step 内訳を実測したところ、準備が支配的 (76%) で実テストは 25%。

| step | 時間 | 比率 | 性質 |
|---|---|---|---|
| Start Supabase local stack | 2m 13s | 51% | 準備 |
| Run Playwright | 1m 4s | 25% | 実テスト |
| Install Playwright browsers | 25s | 10% | 準備 |
| Stop Supabase | 15s | 6% | 後片付け |
| Install npm deps | 13s | 5% | 準備 |

vision の差別化は行動データの品質 (action_logs / time_entries / tasks.status) なので e2e は今後も成長する前提。準備コストを今のうちに削っておく。

関連 ADR:
- [ADR 0011](docs/adr/0011-e2e-auth-bypass-with-test-user-form.md) (e2e は本物の Supabase + password sign-in)

## Before → After (概念・フロー・メンタルモデル)

**Before:**
- Playwright の chromium binary を毎 CI で download (~25s)
- Playwright を `workers: 1` で直列実行 (11 tests = ~64s)
- step は完全直列。Supabase 起動と npm ci / playwright install が overlap しない
- e2e job 全体が 1 runner で連続実行

**After:**
- `~/.cache/ms-playwright` を Playwright version 単位で `actions/cache` に乗せる
- per-worker 別 test user (`e2e-w0@..` 〜 `e2e-w3@..`) を導入し、workers=4 で並列実行
- `supabase start` を nohup で background 起動 → npm ci / playwright install と overlap → Wait for Supabase で完了確認
- e2e job を 2 shard に matrix 分割し、別 runner で並走 (`--shard=N/M`)
- docker daemon の `max-concurrent-downloads` を 3 → 20 に bump

## 実測結果 (How verified)

各段階で CI を回して step 別に実測:

| 段階 | wall | 累積削減 | コメント |
|---|---|---|---|
| baseline (PR #73, 1 job) | 4m 21s | — | |
| run 4 (browser cache + workers + 並列化) | 3m 45s | **-36s** | 並列化 install 48s が overlap で隠れた |
| run 5 最終 (+ sharding + docker parallel) | **3m 27s** (worst), 2m 55s (best) | **-54s (-21%)** | wall = max(shard) 律速 |

最終 run 5 の shard 別内訳:

| step | shard 1 | shard 2 |
|---|---|---|
| Bump docker daemon parallel pull | 1s | 4s |
| Start Supabase (background) | 0s | 0s |
| Install npm deps | 18s | 14s |
| Cache Playwright browsers (HIT) | 5s | 5s |
| Install Playwright browsers (apt) | 22s | 21s |
| **Wait for Supabase** | **1m 36s** | **1m 14s** |
| **Run Playwright (--shard=N/2)** | **33s** | **29s** |
| Stop Supabase | 16s | 14s |
| **合計** | **3m 27s** | **2m 55s** |

### 採用した変更（効果）

- [x] **Playwright browser cache**: -6s (apt deps の固定コストが残るので、想定の -23s より小)
- [x] **workers=4 + per-worker test user**: Run Playwright 1m 4s → 50s 程度 (Issue #67 系の test user 体系を `e2e/users.ts` に集約)
- [x] **Step 並列化** (Supabase 起動を background 化): -17s (install 48s が Supabase 起動 ~140s の影に隠れる)
- [x] **Sharding** (matrix 2 shard): wall -18s (test 実行が半分配で 33s/29s)
- [x] **docker daemon `max-concurrent-downloads` 3 → 20**: 効果は variance に埋もれて分離計測できなかったが、害は無く確認

### 試して revert したもの

- [x] **Supabase Docker image cache** (`docker save`/`load` 経由): cache HIT 時の `docker load` が **1m 17s** かかり `docker pull` の ~67s より遅く逆効果。run 3 で確認後 revert。GHA の `docker load` は per-layer metadata 処理で律速されるため。

### 結局なぜ 2m 切らないのか

支配項は **Supabase 起動 ~140s**（しかも shard 間で 1m14s〜1m36s の variance あり）。GHA runner の network / disk pull に起因し、こちらでコントロールできない。

更に削るには、Supabase CLI を捨てて GHA `services:` で postgres/gotrue/postgrest を直起動する案 (services 化) や、cloud Supabase を e2e に使う案がある。いずれも **ADR 0011 の supersede レベル**（test の本物度合い / 並行 CI 衝突 / 別 Supabase project の運用 / PR #68 の guard 解除）になるので、本 PR スコープ外。

## このPRの範囲外 (Out of scope)

別 issue で検討する案件:

- **Supabase CLI を GHA `services:` 化**: -1m 以上見込めるが、ADR 0011 supersede と migration / JWT secret / Kong の glue を自前で書く運用コスト
- **Cloud Supabase を e2e に使う**: 起動 0s だが、PR #68 で入れた `assertLocalSupabaseUrl` guard を緩める判断 + 並行 CI run の test user namespace 設計 + dedicated Supabase project の運用 + migration 同期が必要
- **Test の手動 rebalance** (shard 間の偏り 32s を縮める): brittle なので skip
- **`next dev` → `next build && next start`**: dev compile cost が想定より小さいので ROI 薄い

## リリース前チェックリスト (When / Before merge)

- [x] CI で 5 回回して `success` を確認 (browser cache MISS → HIT、Supabase cache 試行 → revert、workers / 並列化 / sharding 各段階)
- [x] 既存 spec の test user lookup (`requiredEnv("E2E_TEST_USER_EMAIL")` + `findTestUserId`) を `testUserId` fixture に置き換え (6 spec 全て)
- [x] `npm run typecheck` / `npm run lint` / `npm run format:check` 全て green
- [x] e2e の 11 tests 全て pass (run 5 / shard 1, 2 共に success)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGBCfvUGwGrdEuCEvuCMz5)_