### PR TITLE
test(e2e): auth / タイマー復元 / 依存イベント / GCal 編集制約 / sync 401 を踏む

### DIFF
--- a/e2e/auth-session.spec.ts
+++ b/e2e/auth-session.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "./fixtures";
+
+/**
+ * Issue #67 🟨 7 (auth セッション保全):
+ *   middleware (`src/shared/supabase/middleware.ts`) が PUBLIC_PATHS 以外を
+ *   未ログインで弾き、`/login` に redirect する経路。UserMenu からのログアウト後に
+ *   ブラウザバックで保護ページに戻れないことも併せて踏む。
+ *
+ * これは「実装が壊れていることに気づきにくい」典型例。session 検証ロジックの
+ * regression が起きると未ログイン状態でホームが表示される事故が発生し得る。
+ */
+test.describe("auth セッション保全 (middleware redirect / logout)", () => {
+  test("未ログインで `/` にアクセスすると `/login` に redirect される", async ({
+    page,
+    baseURL,
+  }) => {
+    // signedInPage を意図的に使わず素の page。Cookie / session が無い状態で
+    // 保護パスに踏み込む。middleware が 302 で /login に飛ばす想定。
+    await page.goto(`${baseURL ?? ""}/`);
+    await expect(page).toHaveURL(/\/login(?:\?.*)?$/);
+    // login ページの目印 (E2E ログインフォーム or Google OAuth ボタン)
+    // が見えることまで踏んで「render が間に合わずに / が一瞬出た」を弾く。
+    await expect(page.getByTestId("e2e-login-form")).toBeVisible();
+  });
+
+  test("`/tree` のような保護パスも未ログインでは `/login` に redirect される", async ({
+    page,
+    baseURL,
+  }) => {
+    // PUBLIC_PATHS の前方一致境界を踏む。`/login`/`/auth/callback` 以外は
+    // 全て保護される (middleware.ts L42)。
+    await page.goto(`${baseURL ?? ""}/tree`);
+    await expect(page).toHaveURL(/\/login(?:\?.*)?$/);
+  });
+
+  test("UserMenu からログアウトすると `/login` に戻り、ブラウザバックでも保護ページに戻れない", async ({
+    signedInPage: page,
+  }) => {
+    // ログイン済み状態でホームを開いたところからスタート
+    // (signedInPage は / への hard nav を待ってから返す)。
+    await expect(page).toHaveURL(/\/$/);
+
+    // UserMenu を開く: アバターは aria-label="アカウントメニュー"
+    // (UserMenu.tsx L50)。
+    await page.getByRole("button", { name: "アカウントメニュー" }).click();
+
+    // ログアウトボタン: pending 中は文言が「ログアウト中...」になるが、
+    // 押下時点では "ログアウト" のはず (UserMenu.tsx L100)。
+    await page.getByRole("button", { name: "ログアウト", exact: true }).click();
+
+    // signOut → router.replace("/login") の遷移を待つ。
+    await page.waitForURL((url) => url.pathname === "/login", { timeout: 15_000 });
+    await expect(page.getByTestId("e2e-login-form")).toBeVisible();
+
+    // ブラウザバック: 直前の history は `/`。middleware が再度 session を検証し、
+    // 失効済みなので /login に再 redirect する想定。client routing で戻るため、
+    // URL が `/login` のままになる (or 一瞬 `/` を経由してから戻る) のを待つ。
+    await page.goBack();
+    await page.waitForURL((url) => url.pathname === "/login", { timeout: 15_000 });
+    await expect(page.getByTestId("e2e-login-form")).toBeVisible();
+  });
+});

--- a/e2e/dependency-event.spec.ts
+++ b/e2e/dependency-event.spec.ts
@@ -1,0 +1,192 @@
+import { createAdminClient, getEventByTitle, getTaskByTitle, waitForActionLog } from "./db";
+import { expect, test } from "./fixtures";
+
+/**
+ * Issue #67 🟨 9 / P2-5 (#53):
+ *   タスクの依存イベント設定 UI (TaskDetailPanel) と DB / バッジ表示の整合。
+ *
+ * `tasks.depends_on_event_id` は Phase 4 の「依存設定が着手順に効いたか」の
+ * 学習データになる (AppShell.tsx L204-234 / ADR 0001 の TASK_DEPENDENCY_*)。
+ * UI が壊れて action_log を吐かない / DB に書かない regression が起きると、
+ * Phase 4 の学習基盤が静かに腐る。
+ *
+ * バッジは TopTaskCard / TaskRow の双方に出る (TopTaskCard.tsx L87-96 /
+ * TaskRow.tsx L59-68)。両方の経路を踏む。
+ */
+test.describe("依存イベント設定 (TaskDetailPanel → DB → バッジ)", () => {
+  test("TopTaskCard でタスク → イベントの依存設定が DB / action_log / バッジに反映される", async ({
+    signedInPageWithProject: page,
+    projectName,
+    testUserId: userId,
+  }) => {
+    const taskTitle = "依存先を持つタスク";
+    const eventTitle = "依存先 MTG";
+    const startLocal = "2030-06-15T13:00";
+    const endLocal = "2030-06-15T14:00";
+
+    const admin = createAdminClient();
+
+    // --- 依存先イベントを先に作る (depCandidates は startTime >= now で絞られる) ---
+    await page.getByRole("button", { name: "新規追加" }).click();
+    const addEvent = page.getByRole("dialog", { name: "追加メニュー" });
+    await addEvent.getByRole("tab", { name: "イベント" }).click();
+    await addEvent.getByLabel("タイトル").fill(eventTitle);
+    await addEvent.getByLabel("開始").fill(startLocal);
+    await addEvent.getByLabel("終了").fill(endLocal);
+    await addEvent.getByRole("button", { name: "追加" }).click();
+    await expect(addEvent).toHaveCount(0);
+
+    const event = await getEventByTitle(admin, userId, eventTitle);
+
+    // --- タスクを 1 件 (= TopTaskCard) ----------------------------------------
+    await page.getByRole("button", { name: "新規追加" }).click();
+    const addTask = page.getByRole("dialog", { name: "追加メニュー" });
+    await addTask.getByRole("tab", { name: "タスク" }).click();
+    await addTask.getByLabel("タイトル").fill(taskTitle);
+    await addTask.getByLabel("プロジェクト").selectOption({ label: projectName });
+    await addTask.getByRole("button", { name: "追加" }).click();
+    await expect(addTask).toHaveCount(0);
+
+    const stack = page.getByRole("list", { name: "タスクスタック" });
+    const row = stack.getByRole("listitem").filter({ hasText: taskTitle });
+    await expect(row).toBeVisible();
+
+    const task = await getTaskByTitle(admin, userId, taskTitle);
+    expect(task.depends_on_event_id).toBeNull();
+
+    // --- 詳細パネルを開いて依存イベントを設定 -------------------------------
+    // TopTaskCard 全体に onClick (詳細を開く) があり、grip / アクションボタンは
+    // stopPropagation 済み。タイトル文字を狙うと detail に遷移する (task-crud
+    // spec と同じパターン)。
+    await row.getByText(taskTitle).first().click();
+
+    // 初期状態の依存編集ボタンは「なし を変更」(TaskDetailPanel.tsx L142-144)。
+    await page.getByRole("button", { name: /なし\s+を変更/ }).click();
+
+    // editingDep=true で <select autoFocus> が render される。option の value は
+    // event.id なので relative-time の表記揺れに依存しない (TaskDetailPanel.tsx L131)。
+    await page.locator("select").first().selectOption({ value: event.id });
+
+    // --- DB: tasks.depends_on_event_id 更新 ---------------------------------
+    await expect
+      .poll(async () => (await getTaskByTitle(admin, userId, taskTitle)).depends_on_event_id, {
+        message: "tasks.depends_on_event_id should equal the selected event id",
+        timeout: 5_000,
+      })
+      .toBe(event.id);
+
+    // --- action_log: task_dependency_set ------------------------------------
+    const setLog = await waitForActionLog(
+      admin,
+      userId,
+      (l) =>
+        l.action_type === "task_dependency_set" &&
+        (l.metadata as { event_id?: string }).event_id === event.id,
+      { description: "task_dependency_set log" },
+    );
+    expect((setLog.metadata as { task_id?: string }).task_id).toBe(task.id);
+    expect((setLog.metadata as { was?: string | null }).was).toBeNull();
+
+    // --- TopTaskCard のバッジに依存先イベントの title が表示される ----------
+    // panel は overlay で前面にあるが listitem 自体は DOM にあるので textContent
+    // は取れる (toContainText は表示有無に関係なく DOM を見る)。
+    await expect(row).toContainText(eventTitle);
+
+    // --- 依存をクリアして task_dependency_cleared が記録される -------------
+    // 依存設定後はボタン文言が "<relative> <title> を変更" になる。
+    // 文言の relative-time 部分 (例: "5/14" / "3年後" など) に依存しないよう
+    // suffix `を変更` で取る。
+    await page.getByRole("button", { name: /を変更$/ }).click();
+    await page.locator("select").first().selectOption({ value: "" });
+
+    await expect
+      .poll(async () => (await getTaskByTitle(admin, userId, taskTitle)).depends_on_event_id, {
+        message: "tasks.depends_on_event_id should be null after clear",
+        timeout: 5_000,
+      })
+      .toBeNull();
+
+    const clearedLog = await waitForActionLog(
+      admin,
+      userId,
+      (l) =>
+        l.action_type === "task_dependency_cleared" &&
+        (l.metadata as { task_id?: string }).task_id === task.id,
+      { description: "task_dependency_cleared log" },
+    );
+    expect((clearedLog.metadata as { was?: string }).was).toBe(event.id);
+  });
+
+  test("TaskRow (非トップ) のタスクにも依存イベントバッジが表示される", async ({
+    signedInPageWithProject: page,
+    projectName,
+    testUserId: userId,
+  }) => {
+    const topTaskTitle = "トップのダミータスク";
+    const subTaskTitle = "依存先を持つサブタスク";
+    const eventTitle = "サブタスクの依存先";
+    const startLocal = "2030-08-01T10:00";
+    const endLocal = "2030-08-01T11:00";
+
+    const admin = createAdminClient();
+
+    // --- 依存先イベント -----------------------------------------------------
+    await page.getByRole("button", { name: "新規追加" }).click();
+    const addEvent = page.getByRole("dialog", { name: "追加メニュー" });
+    await addEvent.getByRole("tab", { name: "イベント" }).click();
+    await addEvent.getByLabel("タイトル").fill(eventTitle);
+    await addEvent.getByLabel("開始").fill(startLocal);
+    await addEvent.getByLabel("終了").fill(endLocal);
+    await addEvent.getByRole("button", { name: "追加" }).click();
+    await expect(addEvent).toHaveCount(0);
+
+    const event = await getEventByTitle(admin, userId, eventTitle);
+
+    // --- タスクを 2 件作る (1件目=TopTaskCard, 2件目=TaskRow) -----------------
+    for (const title of [topTaskTitle, subTaskTitle]) {
+      await page.getByRole("button", { name: "新規追加" }).click();
+      const addTask = page.getByRole("dialog", { name: "追加メニュー" });
+      await addTask.getByRole("tab", { name: "タスク" }).click();
+      await addTask.getByLabel("タイトル").fill(title);
+      await addTask.getByLabel("プロジェクト").selectOption({ label: projectName });
+      await addTask.getByRole("button", { name: "追加" }).click();
+      await expect(addTask).toHaveCount(0);
+    }
+
+    const stack = page.getByRole("list", { name: "タスクスタック" });
+    const subRow = stack.getByRole("listitem").filter({ hasText: subTaskTitle });
+    await expect(subRow).toBeVisible();
+
+    // --- 2件目 (TaskRow) を開いて依存設定 -----------------------------------
+    await subRow.getByText(subTaskTitle).first().click();
+    await page.getByRole("button", { name: /なし\s+を変更/ }).click();
+    await page.locator("select").first().selectOption({ value: event.id });
+
+    const subTask = await getTaskByTitle(admin, userId, subTaskTitle);
+    await expect
+      .poll(async () => (await getTaskByTitle(admin, userId, subTaskTitle)).depends_on_event_id, {
+        message: "sub task depends_on_event_id reflects in DB",
+        timeout: 5_000,
+      })
+      .toBe(event.id);
+
+    // --- TaskRow のバッジに event title が乗る ------------------------------
+    // TaskRow.tsx L59-68: `← {relative} {title}` の <span>。
+    await expect(subRow).toContainText(eventTitle);
+    // top の row に同じ文字列が紛れ込んでないことも軽く担保 (依存設定したのは sub のみ)
+    const topRow = stack.getByRole("listitem").filter({ hasText: topTaskTitle });
+    await expect(topRow).not.toContainText(eventTitle);
+
+    // metadata にも task_id が乗っていることを確認 (Phase 4 学習で task との
+    // 紐付けが取れる必要がある)
+    const setLog = await waitForActionLog(
+      admin,
+      userId,
+      (l) =>
+        l.action_type === "task_dependency_set" &&
+        (l.metadata as { task_id?: string }).task_id === subTask.id,
+      { description: "task_dependency_set log for sub task" },
+    );
+    expect((setLog.metadata as { event_id?: string }).event_id).toBe(event.id);
+  });
+});

--- a/e2e/gcal-event-readonly.spec.ts
+++ b/e2e/gcal-event-readonly.spec.ts
@@ -1,0 +1,157 @@
+import { createAdminClient, getEventByTitle, getProjectByName } from "./db";
+import { expect, test } from "./fixtures";
+
+/**
+ * Issue #67 🟨 10 / ADR 0010:
+ *   `source='google_calendar'` のイベントに対する編集制約を踏む。
+ *
+ * ADR 0010 の挙動:
+ *   - title / start_time / end_time / meet_url / description は kozutsumi 側で
+ *     編集不可 (Google 側が正)
+ *   - project_id だけ kozutsumi 側で書き換えできる
+ *   - 削除ボタンも出さない (Google 側で削除すれば次回同期で消える)
+ *
+ * UI 経由で `source='google_calendar'` のイベントを作る正規ルートは Google
+ * Calendar 同期 (OAuth) しか無いので、e2e では service_role で events 行を
+ * 直接 insert して再現する。
+ */
+test.describe("google_calendar イベントの編集制約 (ADR 0010)", () => {
+  test("title / 時刻 / meetUrl / description は read-only、削除ボタンも出ない", async ({
+    signedInPage: page,
+    testUserId: userId,
+  }) => {
+    const eventTitle = "GCal 由来の MTG";
+    const meetUrl = "https://meet.google.com/gcal-readonly-e2e";
+    const description = "## 議題\n- read-only テスト用";
+
+    const admin = createAdminClient();
+
+    // --- service_role で GCal イベントを 1 件 insert -------------------------
+    // start_time は今日のローカル 14:00 とし、DayTimeline に確実に出すために
+    // 必ず "minutesOfDay" の範囲内に収まる時間帯を選ぶ。
+    const start = todayAt(14, 0);
+    const end = todayAt(15, 0);
+    const { error: insertErr } = await admin.from("events").insert({
+      user_id: userId,
+      title: eventTitle,
+      start_time: start.toISOString(),
+      end_time: end.toISOString(),
+      project_id: null,
+      meet_url: meetUrl,
+      has_attachments: false,
+      description,
+      source: "google_calendar",
+      external_id: "gcal-readonly-e2e",
+    });
+    if (insertErr) throw new Error(`[e2e] insert gcal event failed: ${insertErr.message}`);
+
+    // events query は AppShell の `["events"]` キーで管理されるので、page.reload
+    // で再 fetch させて DayTimeline に GCal イベントを出す。
+    await page.reload();
+
+    // --- DayTimeline の EventCard をクリックして詳細を開く -------------------
+    // EventCard は role を持たない div だが、表示テキストに event.title が含まれる。
+    await page.getByText(eventTitle).first().click();
+
+    // EventDetailPanel が開く (role=dialog は付いていない)。
+    // 手がかりとして、GCal 由来であることを示すバッジ + 由来説明文の存在を踏む。
+    await expect(page.getByTestId("google-calendar-badge").first()).toBeVisible();
+    await expect(
+      page.getByText("Google Calendar で編集した内容は次回同期で反映されます"),
+    ).toBeVisible();
+
+    // --- 削除ボタンが出ない (ADR 0010) ---------------------------------------
+    // 注意: TaskDetailPanel など他 panel の「削除」と区別するため、現在開いて
+    // いるのが EventDetailPanel であることは GoogleCalendarBadge の存在で担保。
+    await expect(page.getByRole("button", { name: "削除" })).toHaveCount(0);
+
+    // --- title は h2 表示 / 編集 input は無い -------------------------------
+    // h2 element が title を持つ (EventDetailPanel.tsx L61-63)。
+    const titleHeading = page.getByRole("heading", { level: 2, name: eventTitle });
+    await expect(titleHeading).toBeVisible();
+    // title 用の <input> や <textarea> は無い。
+    await expect(page.locator("input[type='text']")).toHaveCount(0);
+    await expect(page.locator("textarea")).toHaveCount(0);
+
+    // --- 時刻は表示テキスト (anchor / button では無い) -----------------------
+    // 編集用の datetime-local input が紛れ込んでいないことを確認する。
+    await expect(page.locator("input[type='datetime-local']")).toHaveCount(0);
+
+    // --- meet_url は anchor 表示 (リンクとしてだけ機能、編集不可) ------------
+    const meetAnchor = page.getByRole("link", {
+      name: /Google Meetに参加|Zoomに参加|会議リンクに参加/,
+    });
+    await expect(meetAnchor).toBeVisible();
+    await expect(meetAnchor).toHaveAttribute("href", meetUrl);
+
+    // --- description は markdown render (input/textarea ではない) -----------
+    // renderMarkdown は h2 / li 等を生成する。本文の "議題" が見える時点で
+    // 「テキスト表示」されていることが取れる。
+    await expect(page.getByText("議題", { exact: false })).toBeVisible();
+
+    // 補強: DB 側の制約も並走している (ADR 0010)。e2e から直接 update を投げると
+    // SupabaseEventGateway.update が touchesGoogleOwned を見て弾く: ここでは UI の
+    // 観測責務に留め、gateway 単体テスト (supabase-gateway.test.ts) と分担する。
+  });
+
+  test("project_id だけは編集可能で、events.project_id が DB に反映される", async ({
+    signedInPageWithProject: page,
+    projectName,
+    testUserId: userId,
+  }) => {
+    const eventTitle = "GCal 由来のプロジェクト紐付けテスト";
+
+    const admin = createAdminClient();
+    const project = await getProjectByName(admin, userId, projectName);
+
+    // --- GCal イベントを project_id=null で insert ---------------------------
+    const start = todayAt(15, 0);
+    const end = todayAt(16, 0);
+    const { error: insertErr } = await admin.from("events").insert({
+      user_id: userId,
+      title: eventTitle,
+      start_time: start.toISOString(),
+      end_time: end.toISOString(),
+      project_id: null,
+      meet_url: null,
+      has_attachments: false,
+      description: "",
+      source: "google_calendar",
+      external_id: "gcal-project-edit-e2e",
+    });
+    if (insertErr) throw new Error(`[e2e] insert gcal event failed: ${insertErr.message}`);
+
+    await page.reload();
+
+    // --- DayTimeline → 詳細を開く -------------------------------------------
+    await page.getByText(eventTitle).first().click();
+    await expect(page.getByTestId("google-calendar-badge").first()).toBeVisible();
+
+    // --- 「未設定 を変更」 → select 表示 → プロジェクトを選ぶ ----------------
+    await page.getByRole("button", { name: /未設定\s+を変更/ }).click();
+    // ADR 0010: option の value は project.id。DB 値で選ぶことで relative 表記に
+    // 依存しない。
+    await page.locator("select").first().selectOption({ value: project.id });
+
+    // --- DB: events.project_id 反映 -----------------------------------------
+    await expect
+      .poll(async () => (await getEventByTitle(admin, userId, eventTitle)).project_id, {
+        message: "events.project_id should be updated for google_calendar source",
+        timeout: 5_000,
+      })
+      .toBe(project.id);
+
+    // --- title / 時刻 等は触っていないので変わっていない (regression check) -
+    const after = await getEventByTitle(admin, userId, eventTitle);
+    expect(after.title).toBe(eventTitle);
+    expect(after.source).toBe("google_calendar");
+    expect(after.external_id).toBe("gcal-project-edit-e2e");
+  });
+});
+
+/** 今日のローカル時刻を H/M で組み立てた Date を返す。 */
+function todayAt(hour: number, minute: number): Date {
+  const d = new Date();
+  d.setHours(hour, minute, 0, 0);
+  return d;
+}

--- a/e2e/sync-reauth.spec.ts
+++ b/e2e/sync-reauth.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "./fixtures";
+
+/**
+ * Issue #67 🟨 11:
+ *   `/api/calendar/sync` が 401 (provider_token_missing) を返した時に
+ *   `ReauthBanner` が表示され、ユーザーが Google と再連携できる状態に戻れること。
+ *
+ * 構造的に幸いなことに、e2e テストユーザーは password sign-in (ADR 0011) で
+ * 作られていて Google OAuth を経ていないため、`provider_token` を持っていない。
+ * そのため `/api/calendar/sync` は **本物の** 401 (provider_token_missing) を
+ * 返す。`useLazyCalendarSync` (起動時遅延同期, ADR 0007) が初回マウント時に
+ * 必ず発火するので、それだけで 401 → ReauthBanner の経路が踏める。
+ *
+ * これは「e2e で 401 を再現するために fetch を mock する」より素直で、
+ * 本番経路 (route handler / useCalendarSync) のロジックを実物のまま通せる。
+ */
+test.describe("calendar 同期 401 ハンドリング (ReauthBanner)", () => {
+  test("provider_token を持たない state で 401 を受けると ReauthBanner が表示される", async ({
+    signedInPage: page,
+  }) => {
+    // ReauthBanner の root は role="alert"、文言は固定 (ReauthBanner.tsx L51-56)。
+    const banner = page
+      .getByRole("alert")
+      .filter({ hasText: "Google カレンダーの連携が失効しました" });
+
+    // useLazyCalendarSync は mount 後の useEffect で fire するので少し待つ。
+    // 401 → setNeedsReauth(true) → banner 描画までを 15s で待つ。
+    await expect(banner).toBeVisible({ timeout: 15_000 });
+
+    // 再連携ボタンも見えていること (押下で signInWithOAuth が走る経路は OAuth 本体
+    // を踏むので e2e のスコープ外。ボタン presence までで止める)。
+    await expect(banner.getByRole("button", { name: /Google と連携し直す/ })).toBeVisible();
+  });
+
+  test("ReauthBanner は × ボタンで dismiss できる", async ({ signedInPage: page }) => {
+    const banner = page
+      .getByRole("alert")
+      .filter({ hasText: "Google カレンダーの連携が失効しました" });
+    await expect(banner).toBeVisible({ timeout: 15_000 });
+
+    await banner.getByRole("button", { name: "バナーを閉じる" }).click();
+    await expect(banner).toHaveCount(0);
+  });
+
+  test("手動同期ボタン押下で /api/calendar/sync に POST が再度飛ぶ", async ({
+    signedInPage: page,
+  }) => {
+    const posts: string[] = [];
+    page.on("request", (req) => {
+      if (req.method() === "POST" && req.url().endsWith("/api/calendar/sync")) {
+        posts.push(req.url());
+      }
+    });
+
+    // signedInPage は既に / にいるので、リロードで request listener 設置後に
+    // mount を一度通す (lazy sync の POST を確実に補足するため)。
+    await page.reload();
+
+    // lazy sync の POST が飛ぶ。応答 (本物の 401) を待ってボタンが enable に
+    // 戻るところまで踏む。
+    await expect
+      .poll(() => posts.length, { message: "lazy sync POST should fire", timeout: 15_000 })
+      .toBeGreaterThanOrEqual(1);
+    const syncButton = page.getByRole("button", { name: "カレンダーを同期" });
+    await expect(syncButton).toBeEnabled({ timeout: 15_000 });
+
+    const before = posts.length;
+    await syncButton.click();
+
+    await expect
+      .poll(() => posts.length, { message: "manual sync POST should fire", timeout: 15_000 })
+      .toBeGreaterThanOrEqual(before + 1);
+  });
+});

--- a/e2e/timer-restore.spec.ts
+++ b/e2e/timer-restore.spec.ts
@@ -1,0 +1,105 @@
+import { createAdminClient, expectTaskStatus, getTaskByTitle, waitForTimeEntries } from "./db";
+import { expect, test } from "./fixtures";
+
+/**
+ * Issue #67 🟨 8 (タイマー累積 + リロード復元) / ADR 0004:
+ *   active 中のタイマーがブラウザリロード後も DB 由来 (tasks.status +
+ *   task_time_entries.open) で復元されるかを踏む。
+ *
+ * useTaskTimer (`src/features/task-stack/useTaskTimer.ts`) は
+ *   - localStorage に依存しない (entries / task は React Query から fetch)
+ *   - tickMs を 1秒ごと進めて open entry の経過を再計算する
+ * という構造なので、リロード後もタイマーが「DB の真実」から再生される。
+ *
+ * `signedInPage` fixture は localStorage を `kozutsumi.sample-data.v1=cleared`
+ * に固定するので、復元の出所が DB であることはここで担保される。
+ */
+test.describe("タイマーのリロード復元 (DB 由来 / tick 継続)", () => {
+  test("active 状態でリロードしても 中断 ボタン + 経過秒数が復元され、tick が増分する", async ({
+    signedInPageWithProject: page,
+    projectName,
+    testUserId: userId,
+  }) => {
+    const taskTitle = "タイマー復元タスク";
+    const admin = createAdminClient();
+
+    // --- タスク作成 + 開始 ---------------------------------------------------
+    await page.getByRole("button", { name: "新規追加" }).click();
+    const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+    await addDialog.getByRole("tab", { name: "タスク" }).click();
+    await addDialog.getByLabel("タイトル").fill(taskTitle);
+    await addDialog.getByLabel("プロジェクト").selectOption({ label: projectName });
+    await addDialog.getByRole("button", { name: "追加" }).click();
+    await expect(addDialog).toHaveCount(0);
+
+    const stack = page.getByRole("list", { name: "タスクスタック" });
+    await expect(stack.getByRole("listitem").filter({ hasText: taskTitle })).toBeVisible();
+
+    await page.getByRole("button", { name: "開始" }).click();
+    await expect(page.getByRole("button", { name: "中断" })).toBeVisible();
+
+    const task = await getTaskByTitle(admin, userId, taskTitle);
+    await expectTaskStatus(admin, task.id, "active");
+    // open entry が DB に書かれてからリロードしないと、リロード後に entry が無くて
+    // useTaskTimer が isRunning=false に倒れてしまう。
+    await waitForTimeEntries(admin, task.id, (es) => es.length === 1 && es[0].paused_at === null, {
+      description: "1 open entry before reload",
+    });
+
+    // --- 経過秒数が表示されていることを確認 ------------------------------------
+    // TopTaskCard.tsx L97-104: <span aria-label="経過時間">● MM:SS</span>
+    const elapsed = page.getByLabel("経過時間");
+    await expect(elapsed).toBeVisible();
+
+    // 表示が tick で進む (= setInterval が動いている) ことを最低 1 秒待って確認。
+    // 直後だと 00:00 → 00:01 になる手前で取りこぼすことがあるので 1.5 秒待つ。
+    await page.waitForTimeout(1500);
+    const beforeReloadText = (await elapsed.textContent())?.trim() ?? "";
+    const beforeReloadSeconds = parseElapsed(beforeReloadText);
+    expect(beforeReloadSeconds).toBeGreaterThanOrEqual(1);
+
+    // --- リロード ------------------------------------------------------------
+    await page.reload();
+
+    // 復元の証跡: 「中断」ボタン (= active 状態) と aria-label="経過時間" が再描画される。
+    // signedInPage は localStorage に `cleared` を入れるので、DB が唯一の真実。
+    await expect(page.getByRole("button", { name: "中断" })).toBeVisible({ timeout: 15_000 });
+    await expect(elapsed).toBeVisible();
+
+    // --- リロード後に tick が継続して増分する -------------------------------
+    // open entry の started_at は変わらないので、経過秒数 ≧ before の秒数 になる。
+    const afterReloadInitialText = (await elapsed.textContent())?.trim() ?? "";
+    const afterReloadInitialSeconds = parseElapsed(afterReloadInitialText);
+    expect(afterReloadInitialSeconds).toBeGreaterThanOrEqual(beforeReloadSeconds);
+
+    // 数秒待って増分を確認。setInterval(1000) なので 3 秒で +2〜+3 入るはず。
+    await page.waitForTimeout(3000);
+    const afterReloadLaterText = (await elapsed.textContent())?.trim() ?? "";
+    const afterReloadLaterSeconds = parseElapsed(afterReloadLaterText);
+    expect(afterReloadLaterSeconds).toBeGreaterThanOrEqual(afterReloadInitialSeconds + 2);
+  });
+});
+
+/**
+ * `aria-label="経過時間"` の textContent をパースして総秒数を返す。
+ * formatElapsed (useTaskTimer.ts L162-172) の format は:
+ *   - h > 0 → "H:MM:SS"
+ *   - else  → "MM:SS"
+ * 表示の prefix "● " が付くのでそれも剥がす。
+ */
+function parseElapsed(text: string): number {
+  const stripped = text.replace(/^●\s*/, "").trim();
+  const parts = stripped.split(":").map((p) => Number(p));
+  if (parts.some((n) => Number.isNaN(n))) {
+    throw new Error(`[e2e] cannot parse elapsed: ${text}`);
+  }
+  if (parts.length === 3) {
+    const [h, m, s] = parts;
+    return h * 3600 + m * 60 + s;
+  }
+  if (parts.length === 2) {
+    const [m, s] = parts;
+    return m * 60 + s;
+  }
+  throw new Error(`[e2e] unexpected elapsed format: ${text}`);
+}


### PR DESCRIPTION
## 概要 (What)

Issue #67 🟨 中カテゴリ 5 項目 (auth / タイマー復元 / 依存イベント / GCal 編集制約 / sync 401) を 1 PR で消化する e2e spec 追加。

## 関連 Issue

Closes #67

## 背景 (Why)

Issue #67 は 🟥 最優先 / 🟧 高 / 🟨 中 / 🟩 低 と段階分けされた e2e カバレッジ拡張。実装監査の結果、🟥・🟧 はほぼ既存 spec で踏めており、🟨 5 項目と 🟩 2 項目、🟧 残り 2 項目（プロジェクト/イベント編集削除 UI）が未着手だった。うち 🟧 残りは UI 自体が未実装 / 🟩 は別観点なので別 issue に切り出し、本 PR では **既に実装が入っていて e2e で踏めるもの** を全部詰める方針に絞った。

vision 的には Phase 3 で AI が行動ログ (`action_logs` / `task_time_entries` / `tasks.depends_on_event_id`) を学習し始める前に、**ロジックが実装通りに動いていることを e2e で踏める状態**にしておく必要がある。

## Before → After (概念・フロー・メンタルモデル)

**Before:**
- 🟥 最優先 (action_logs / time_entries / status) と 🟧 高 (CRUD / DnD / 中断理由) は spec が揃っているが、その周辺の 🟨 中 が全部空白
- auth middleware / タイマー復元 / 依存イベント設定 / GCal 編集制約 / sync 401 の挙動は単体テスト or 手動確認頼み

**After:**
- 🟨 5 項目を網羅した spec を追加し、これらの挙動が壊れたら CI で気づける
- 🟧 残り (UI 自体未実装) と 🟩 (低優先 / 別観点) は #75 / #76 / #77 / #78 に分離し、Phase2.2 / Phase2.1 milestone で別途追跡
- Issue #67 の本来の趣旨である「既存実装の e2e 化」は完結

## 追加したテスト (How verified)

- [x] `e2e/auth-session.spec.ts` — middleware が未ログインで `/login` に redirect、UserMenu からログアウト後ブラウザバックでも保護ページに戻れない
- [x] `e2e/timer-restore.spec.ts` — active 状態でリロード後 DB 由来 (`tasks.status` + `task_time_entries.open`) で復元、tick 増分継続 (ADR 0004)
- [x] `e2e/dependency-event.spec.ts` — TaskDetailPanel から `tasks.depends_on_event_id` 設定 / クリア、`task_dependency_set` / `task_dependency_cleared` action_log、TopTaskCard / TaskRow バッジ (P2-5 / ADR 0001)
- [x] `e2e/gcal-event-readonly.spec.ts` — `source='google_calendar'` の title / 時刻 / meetUrl / description が read-only、削除ボタン非表示、`project_id` だけ書き換え可 (ADR 0010)。GCal イベントは service_role で events 行を直接 insert して再現
- [x] `e2e/sync-reauth.spec.ts` — e2e ユーザーは provider_token を持たないので `/api/calendar/sync` が本物の 401 を返し、`useLazyCalendarSync` 経由で `ReauthBanner` が表示される。dismiss / 手動同期ボタンの再 POST も踏む
- [x] typecheck / lint / format:check 全部 green
- [ ] ローカル e2e 実行はこの環境に Supabase CLI が無いためスキップ → CI で検証

## リリース前チェックリスト (When / Before merge)

- [x] CI の e2e shard が両方 green であることを確認

## このPRの範囲外 (Out of scope)

- 🟧 プロジェクト編集・削除 UI 実装 + e2e → #75 (Phase2.2)
- 🟧 manual イベント編集・削除 UI 実装 + e2e → #76 (Phase2.2)
- 🟩 AddPanel イベントタブ → DayTimeline 表示の e2e → #77 (Phase2.1)
- 🟩 TreeView history mock 描画の e2e → #78 (Phase2.1)
- ReauthBanner の「Google と連携し直す」押下経路は OAuth 本体を踏むので e2e 対象外（ボタン presence までで止める）
- `/auth/callback` フロー / provider token refresh は ADR 0011 のスコープアウトに準拠

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQ9VxLwaqjLMd3aG75jTsX)_