### PR TITLE
feat(project): プロジェクト編集 / 削除 UI + cascade SET NULL の e2e (#75)

### DIFF
--- a/e2e/project-event-crud.spec.ts
+++ b/e2e/project-event-crud.spec.ts
@@ -1,4 +1,4 @@
-import { createAdminClient, getEventByTitle, getProjectByName } from "./db";
+import { createAdminClient, getEventByTitle, getProjectByName, getTaskByTitle } from "./db";
 import { expect, test } from "./fixtures";
 
 /**
@@ -9,11 +9,13 @@ import { expect, test } from "./fixtures";
  * `projects` / `events (source='manual')` 行が UI 入力通りに落ちることを
  * service_role で踏みにいく。
  *
+ * Issue #75 で追加: プロジェクト編集 / 削除 + cascade (tasks.project_id /
+ * events.project_id が `ON DELETE SET NULL` で null 化) も同 spec で踏む。
+ *
  * **スコープアウト** (現状コードに UI が無い):
  *   - manual イベントの編集 / 削除 UI (EventDetailPanel に未実装、
  *     EventDetailPanel.test の「どの source でも『削除』ボタンは表示されない」
  *     と整合)。
- *   - ProjectForm 経由の編集 / 削除 (該当 UI なし)。
  *   実装が入った段階で本 spec を拡張する。
  */
 test.describe("プロジェクト作成 (projects 行整合)", () => {
@@ -110,5 +112,102 @@ test.describe("manual イベント作成 (events 行整合)", () => {
     expect(ev.source).toBe("manual");
     expect(ev.project_id).toBeNull();
     expect(ev.meet_url).toBeNull();
+  });
+});
+
+test.describe("プロジェクト編集 (projects 行整合)", () => {
+  test("名前 / 色 / 本業フラグ を編集すると projects 行に反映される", async ({
+    signedInPageWithProject: page,
+    projectName,
+    testUserId: userId,
+  }) => {
+    const newName = "E2E 編集後プロジェクト";
+    const newColor = "#0096C7";
+
+    const admin = createAdminClient();
+
+    await page.getByRole("button", { name: "新規追加" }).click();
+    const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+    await addDialog.getByRole("tab", { name: "プロジェクト" }).click();
+    await addDialog.getByRole("button", { name: `${projectName} を編集` }).click();
+
+    const editDialog = page.getByRole("dialog", { name: "プロジェクト編集" });
+    await expect(editDialog).toBeVisible();
+
+    await editDialog.getByLabel("名前").fill(newName);
+    await editDialog.getByRole("button", { name: newColor }).click();
+    await editDialog.getByRole("checkbox", { name: "本業として扱う" }).check();
+    await editDialog.getByRole("button", { name: "保存" }).click();
+    await expect(editDialog).toHaveCount(0);
+
+    const project = await getProjectByName(admin, userId, newName);
+    expect(project.name).toBe(newName);
+    expect(project.color).toBe(newColor);
+    expect(project.is_primary).toBe(true);
+    expect(project.user_id).toBe(userId);
+  });
+});
+
+test.describe("プロジェクト削除 (cascade SET NULL)", () => {
+  test("削除すると projects 行が消え、紐付くタスク / イベント の project_id が null になる", async ({
+    signedInPageWithProject: page,
+    projectName,
+    testUserId: userId,
+  }) => {
+    const admin = createAdminClient();
+    const project = await getProjectByName(admin, userId, projectName);
+
+    // 1. プロジェクトに紐付くタスクを 1 件作る
+    const taskTitle = "E2E 削除前のタスク";
+    await page.getByRole("button", { name: "新規追加" }).click();
+    let addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+    await addDialog.getByLabel("タイトル").fill(taskTitle);
+    await addDialog
+      .getByLabel("プロジェクト", { exact: true })
+      .selectOption({ label: projectName });
+    await addDialog.getByRole("button", { name: "追加" }).click();
+    await expect(addDialog).toHaveCount(0);
+
+    // 2. プロジェクトに紐付く manual イベントを 1 件作る
+    const eventTitle = "E2E 削除前のイベント";
+    await page.getByRole("button", { name: "新規追加" }).click();
+    addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+    await addDialog.getByRole("tab", { name: "イベント" }).click();
+    await addDialog.getByLabel("タイトル").fill(eventTitle);
+    await addDialog.getByLabel("開始").fill("2030-08-01T10:00");
+    await addDialog.getByLabel("終了").fill("2030-08-01T11:00");
+    await addDialog.getByLabel("プロジェクト (任意)").selectOption({ label: projectName });
+    await addDialog.getByRole("button", { name: "追加" }).click();
+    await expect(addDialog).toHaveCount(0);
+
+    // 3. プロジェクトを削除 (window.confirm を accept)
+    await page.getByRole("button", { name: "新規追加" }).click();
+    addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+    await addDialog.getByRole("tab", { name: "プロジェクト" }).click();
+    await addDialog.getByRole("button", { name: `${projectName} を編集` }).click();
+
+    const editDialog = page.getByRole("dialog", { name: "プロジェクト編集" });
+    await expect(editDialog).toBeVisible();
+
+    page.once("dialog", (dialog) => dialog.accept());
+    await editDialog.getByRole("button", { name: "削除" }).click();
+    await expect(editDialog).toHaveCount(0);
+
+    // 4. DB 検証
+    // - projects 行が消えている
+    const { data: remaining, error } = await admin
+      .from("projects")
+      .select("*")
+      .eq("id", project.id);
+    expect(error).toBeNull();
+    expect(remaining).toEqual([]);
+
+    // - tasks.project_id が null になっている (cascade SET NULL)
+    const task = await getTaskByTitle(admin, userId, taskTitle);
+    expect(task.project_id).toBeNull();
+
+    // - events.project_id が null になっている (cascade SET NULL)
+    const ev = await getEventByTitle(admin, userId, eventTitle);
+    expect(ev.project_id).toBeNull();
   });
 });

--- a/e2e/project-event-crud.spec.ts
+++ b/e2e/project-event-crud.spec.ts
@@ -161,10 +161,9 @@ test.describe("プロジェクト削除 (cascade SET NULL)", () => {
     const taskTitle = "E2E 削除前のタスク";
     await page.getByRole("button", { name: "新規追加" }).click();
     let addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+    await addDialog.getByRole("tab", { name: "タスク" }).click();
     await addDialog.getByLabel("タイトル").fill(taskTitle);
-    await addDialog
-      .getByLabel("プロジェクト", { exact: true })
-      .selectOption({ label: projectName });
+    await addDialog.getByLabel("プロジェクト").selectOption({ label: projectName });
     await addDialog.getByRole("button", { name: "追加" }).click();
     await expect(addDialog).toHaveCount(0);
 

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ACTION_TYPES, log } from "@/entities/action-log/logger";
 import type { CreateEventInput } from "@/entities/event/gateway";
 import type { Event } from "@/entities/event/types";
-import type { CreateProjectInput } from "@/entities/project/gateway";
+import type { CreateProjectInput, UpdateProjectInput } from "@/entities/project/gateway";
 import { ProjectsProvider } from "@/entities/project/ProjectsContext";
 import type { Project } from "@/entities/project/types";
 import type { CreateTaskInput } from "@/entities/task/gateway";
@@ -16,6 +16,7 @@ import { AddButton } from "@/features/add-forms/AddButton";
 import { AddPanel } from "@/features/add-forms/AddPanel";
 import { DayTimeline } from "@/features/day-timeline/DayTimeline";
 import { EventDetailPanel } from "@/features/event-detail/EventDetailPanel";
+import { ProjectDetailPanel } from "@/features/project-detail/ProjectDetailPanel";
 import { CalendarSyncButton } from "@/features/sync/CalendarSyncButton";
 import { ReauthBanner } from "@/features/sync/ReauthBanner";
 import { useCalendarSync } from "@/features/sync/useCalendarSync";
@@ -88,6 +89,7 @@ export function AppShell({ initialView, user }: AppShellProps) {
 
   const [detailId, setDetailId] = useState<string | null>(null);
   const [eventDetailId, setEventDetailId] = useState<string | null>(null);
+  const [projectDetailId, setProjectDetailId] = useState<string | null>(null);
   const [addOpen, setAddOpen] = useState(false);
   // ms 表現の「今」。SSR は 0 placeholder で hydration mismatch を回避し、
   // mount 後に実時刻へ差し替える。nowMin (タイムライン用) と依存イベント比較用に共用する。
@@ -281,6 +283,47 @@ export function AppShell({ initialView, user }: AppShellProps) {
     },
   });
 
+  const updateProjectMutation = useMutation({
+    mutationFn: ({ id, patch }: { id: string; patch: UpdateProjectInput }) =>
+      projectGateway.update(id, patch),
+    onMutate: async ({ id, patch }) => {
+      await queryClient.cancelQueries({ queryKey: keys.projects });
+      const previous = queryClient.getQueryData<Project[]>(keys.projects);
+      queryClient.setQueryData<Project[]>(keys.projects, (prev) =>
+        (prev ?? []).map((p) => (p.id === id ? { ...p, ...patch } : p)),
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(keys.projects, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: keys.projects });
+    },
+  });
+
+  // schema 上 `ON DELETE SET NULL` で tasks.project_id / events.project_id が
+  // null 化される。UI 側はそれを反映するため tasks / events も invalidate する。
+  const deleteProjectMutation = useMutation({
+    mutationFn: (id: string) => projectGateway.delete(id),
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: keys.projects });
+      const previous = queryClient.getQueryData<Project[]>(keys.projects);
+      queryClient.setQueryData<Project[]>(keys.projects, (prev) =>
+        (prev ?? []).filter((p) => p.id !== id),
+      );
+      return { previous };
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(keys.projects, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: keys.projects });
+      queryClient.invalidateQueries({ queryKey: keys.tasks });
+      queryClient.invalidateQueries({ queryKey: keys.events });
+    },
+  });
+
   // タスク削除は TASK_DELETED action_log も記録する (SupabaseTaskGateway.delete 内)。
   const deleteTaskMutation = useMutation({
     mutationFn: (id: string) => taskGateway.delete(id),
@@ -366,6 +409,9 @@ export function AppShell({ initialView, user }: AppShellProps) {
   const pendingTasks = useMemo(() => tasks.filter((t) => !isDone(t)), [tasks]);
   const doneTasks = useMemo(() => tasks.filter((t) => isDone(t)), [tasks]);
   const detailTask = detailId ? tasks.find((t) => t.id === detailId) : null;
+  const projectDetail = projectDetailId
+    ? (projects.find((p) => p.id === projectDetailId) ?? null)
+    : null;
 
   // タスクスタックのトップタスク = タイマー対象。
   // pendingTasks は stack_order 昇順なので [0] がトップ。
@@ -523,8 +569,22 @@ export function AppShell({ initialView, user }: AppShellProps) {
             onCreateProject={async (input) => {
               await createProjectMutation.mutateAsync(input);
             }}
+            onOpenProject={setProjectDetailId}
           />
         ) : null}
+
+        {projectDetail && (
+          <ProjectDetailPanel
+            project={projectDetail}
+            onClose={() => setProjectDetailId(null)}
+            onUpdate={async (id, patch) => {
+              await updateProjectMutation.mutateAsync({ id, patch });
+            }}
+            onDelete={async (id) => {
+              await deleteProjectMutation.mutateAsync(id);
+            }}
+          />
+        )}
 
         {pauseModalOpen ? (
           <PauseReasonModal onSelect={handlePauseSelect} onClose={() => setPauseModalOpen(false)} />

--- a/src/features/add-forms/AddPanel.tsx
+++ b/src/features/add-forms/AddPanel.tsx
@@ -22,6 +22,11 @@ type AddPanelProps = {
   onCreateTask: (input: CreateTaskInput) => Promise<void>;
   onCreateEvent: (input: CreateEventInput) => Promise<void>;
   onCreateProject: (input: CreateProjectInput) => Promise<void>;
+  /**
+   * 既存プロジェクト行クリック時のハンドラ。Issue #75 で編集 / 削除導線として追加。
+   * 未指定なら一覧は read-only 表示として描画する (テスト等での省略可)。
+   */
+  onOpenProject?: (id: string) => void;
 };
 
 /**
@@ -35,6 +40,7 @@ export function AddPanel({
   onCreateTask,
   onCreateEvent,
   onCreateProject,
+  onOpenProject,
 }: AddPanelProps) {
   const [tab, setTab] = useState<Tab>(initialTab);
 
@@ -95,9 +101,56 @@ export function AddPanel({
           {tab === "event" ? (
             <EventForm projects={projects} onSubmit={onCreateEvent} onClose={onClose} />
           ) : null}
-          {tab === "project" ? <ProjectForm onSubmit={onCreateProject} onClose={onClose} /> : null}
+          {tab === "project" ? (
+            <div className="flex flex-col gap-4">
+              {projects.length > 0 ? (
+                <ProjectList projects={projects} onOpen={onOpenProject} />
+              ) : null}
+              <div className="flex flex-col gap-2">
+                {projects.length > 0 ? (
+                  <span className="font-jp text-[10px] text-fg-weak">新しいプロジェクト</span>
+                ) : null}
+                <ProjectForm onSubmit={onCreateProject} onClose={onClose} />
+              </div>
+            </div>
+          ) : null}
         </div>
       </div>
+    </div>
+  );
+}
+
+function ProjectList({
+  projects,
+  onOpen,
+}: {
+  projects: readonly Project[];
+  onOpen: ((id: string) => void) | undefined;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="font-jp text-[10px] text-fg-weak">既存プロジェクト</span>
+      <ul className="flex flex-col gap-1">
+        {projects.map((p) => (
+          <li key={p.id}>
+            <button
+              type="button"
+              onClick={() => onOpen?.(p.id)}
+              disabled={!onOpen}
+              aria-label={`${p.name} を編集`}
+              className="flex w-full items-center gap-2 rounded border border-bg-divider bg-bg-elevated px-3 py-2 text-left transition-colors hover:bg-bg-divider disabled:cursor-default disabled:hover:bg-bg-elevated"
+            >
+              <span className="h-2 w-2 rounded-full" style={{ background: p.color }} />
+              <span className="flex-1 font-jp text-[12px] text-fg-default">{p.name}</span>
+              {p.isPrimary ? (
+                <span className="rounded bg-bg-divider px-1.5 py-px font-jp text-[9px] text-fg-muted">
+                  本業
+                </span>
+              ) : null}
+            </button>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/src/features/project-detail/ProjectDetailPanel.tsx
+++ b/src/features/project-detail/ProjectDetailPanel.tsx
@@ -86,6 +86,20 @@ export function ProjectDetailPanel({
           <div className="h-[3px] w-8 rounded-[2px] bg-bg-divider" />
         </div>
 
+        <div className="flex justify-end px-5 pt-1">
+          {/* 削除はパネル下端ではなく上部に置く。下端は Next.js dev mode の
+              ビルドインジケータ (<nextjs-portal>) と重なって e2e の click が
+              吸われるのと、TaskDetailPanel と整合させる目的。 */}
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={pending}
+            className="rounded border border-accent-red/40 bg-transparent px-3 py-1 font-jp text-[10px] text-accent-red disabled:opacity-60"
+          >
+            削除
+          </button>
+        </div>
+
         <form onSubmit={submit} className="flex flex-col gap-3 px-5 pb-6 pt-2">
           <label className="flex flex-col gap-1">
             <span className="font-jp text-[10px] text-fg-weak">名前</span>
@@ -142,31 +156,21 @@ export function ProjectDetailPanel({
             </div>
           ) : null}
 
-          <div className="mt-1 flex items-center justify-between gap-2">
+          <div className="mt-1 flex justify-end gap-2">
             <button
               type="button"
-              onClick={handleDelete}
-              disabled={pending}
-              className="rounded border border-accent-red/40 bg-transparent px-3 py-1.5 font-jp text-[11px] text-accent-red disabled:opacity-60"
+              onClick={onClose}
+              className="rounded border border-bg-divider bg-transparent px-3 py-1.5 font-jp text-[11px] text-fg-subtle"
             >
-              削除
+              キャンセル
             </button>
-            <div className="flex gap-2">
-              <button
-                type="button"
-                onClick={onClose}
-                className="rounded border border-bg-divider bg-transparent px-3 py-1.5 font-jp text-[11px] text-fg-subtle"
-              >
-                キャンセル
-              </button>
-              <button
-                type="submit"
-                disabled={pending}
-                className="rounded bg-accent-blue px-4 py-1.5 font-jp text-[11px] font-semibold text-fg-invert disabled:opacity-60"
-              >
-                {pending ? "保存中..." : "保存"}
-              </button>
-            </div>
+            <button
+              type="submit"
+              disabled={pending}
+              className="rounded bg-accent-blue px-4 py-1.5 font-jp text-[11px] font-semibold text-fg-invert disabled:opacity-60"
+            >
+              {pending ? "保存中..." : "保存"}
+            </button>
           </div>
         </form>
       </div>

--- a/src/features/project-detail/ProjectDetailPanel.tsx
+++ b/src/features/project-detail/ProjectDetailPanel.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useState } from "react";
+
+import type { UpdateProjectInput } from "@/entities/project/gateway";
+import type { Project } from "@/entities/project/types";
+
+type ProjectDetailPanelProps = {
+  project: Project;
+  onClose: () => void;
+  onUpdate: (id: string, patch: UpdateProjectInput) => Promise<void>;
+  onDelete: (id: string) => Promise<void>;
+};
+
+const DEFAULT_COLORS = ["#E85D04", "#0096C7", "#2D9F45", "#9B5DE5", "#58A6FF", "#EF4444"];
+
+/**
+ * Issue #75: 既存プロジェクトの編集 / 削除パネル。
+ * 削除時の cascade (tasks.project_id / events.project_id を null) は schema 側
+ * `ON DELETE SET NULL` で担当する。UI は AppShell 側で tasks / events query を
+ * invalidate するだけでよい。
+ */
+export function ProjectDetailPanel({
+  project,
+  onClose,
+  onUpdate,
+  onDelete,
+}: ProjectDetailPanelProps) {
+  const [name, setName] = useState(project.name);
+  const [color, setColor] = useState(project.color);
+  const [isPrimary, setIsPrimary] = useState(project.isPrimary);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (pending) return;
+    if (!name.trim()) {
+      setError("名前は必須です");
+      return;
+    }
+    setPending(true);
+    setError(null);
+    try {
+      await onUpdate(project.id, { name: name.trim(), color, isPrimary });
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "保存に失敗しました");
+      setPending(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (pending) return;
+    if (
+      !window.confirm(
+        `プロジェクト「${project.name}」を削除しますか?\n紐付くタスク・イベントの所属は外れます。`,
+      )
+    ) {
+      return;
+    }
+    setPending(true);
+    setError(null);
+    try {
+      await onDelete(project.id);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "削除に失敗しました");
+      setPending(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="プロジェクト編集"
+      className="fixed inset-0 z-[230] flex flex-col"
+    >
+      <div onClick={onClose} className="absolute inset-0 bg-black/60 backdrop-blur-[4px]" />
+      <div
+        className="relative mt-auto flex max-h-[85vh] animate-panel-slide-up flex-col rounded-t-2xl bg-bg-surface"
+        style={{ borderTop: `2px solid ${color}40` }}
+      >
+        <div className="flex justify-center pb-1 pt-2.5">
+          <div className="h-[3px] w-8 rounded-[2px] bg-bg-divider" />
+        </div>
+
+        <form onSubmit={submit} className="flex flex-col gap-3 px-5 pb-6 pt-2">
+          <label className="flex flex-col gap-1">
+            <span className="font-jp text-[10px] text-fg-weak">名前</span>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              autoFocus
+              className="rounded border border-bg-divider bg-bg-elevated px-3 py-2 text-[13px] text-fg-default outline-none focus:border-accent-blue"
+            />
+          </label>
+
+          <div className="flex flex-col gap-1">
+            <span className="font-jp text-[10px] text-fg-weak">色</span>
+            <div className="flex flex-wrap gap-2">
+              {DEFAULT_COLORS.map((c) => (
+                <button
+                  type="button"
+                  key={c}
+                  onClick={() => setColor(c)}
+                  className={`h-7 w-7 rounded-full transition-all ${
+                    color === c ? "ring-2 ring-offset-2 ring-offset-bg-primary" : ""
+                  }`}
+                  style={{ background: c, boxShadow: color === c ? `0 0 0 2px ${c}` : undefined }}
+                  aria-label={c}
+                />
+              ))}
+              <label className="flex h-7 w-7 cursor-pointer items-center justify-center overflow-hidden rounded-full border border-bg-divider">
+                <input
+                  type="color"
+                  value={color}
+                  onChange={(e) => setColor(e.target.value)}
+                  className="h-10 w-10 cursor-pointer border-0 bg-transparent p-0"
+                />
+              </label>
+            </div>
+          </div>
+
+          <label className="flex items-center gap-2 font-jp text-[11px] text-fg-muted">
+            <input
+              type="checkbox"
+              checked={isPrimary}
+              onChange={(e) => setIsPrimary(e.target.checked)}
+            />
+            本業として扱う
+          </label>
+
+          {error ? (
+            <div
+              role="alert"
+              className="rounded bg-[#ef444420] px-2 py-1.5 text-[11px] text-accent-red"
+            >
+              {error}
+            </div>
+          ) : null}
+
+          <div className="mt-1 flex items-center justify-between gap-2">
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={pending}
+              className="rounded border border-accent-red/40 bg-transparent px-3 py-1.5 font-jp text-[11px] text-accent-red disabled:opacity-60"
+            >
+              削除
+            </button>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded border border-bg-divider bg-transparent px-3 py-1.5 font-jp text-[11px] text-fg-subtle"
+              >
+                キャンセル
+              </button>
+              <button
+                type="submit"
+                disabled={pending}
+                className="rounded bg-accent-blue px-4 py-1.5 font-jp text-[11px] font-semibold text-fg-invert disabled:opacity-60"
+              >
+                {pending ? "保存中..." : "保存"}
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要 (What)

Phase 1 で「作成のみ」だったプロジェクト管理に編集 / 削除導線を入れて
CRUD を完成させる。削除時の cascade (`tasks.project_id` /
`events.project_id` を null) が UI と DB の両側で揃うことを e2e で踏む。

## 関連 Issue

Closes #75

## 背景 (Why)

- プロジェクトを「作る」一択だと、無効化された (使われなくなった)
  プロジェクトに紐付くタスク / イベントが残り続け、Phase 3 で行動
  パターンを学習するときの分析品質が落ちる。
- 編集が無いと「色 / 名前 / 本業フラグ」を間違えた瞬間に新規作成し直す
  しか手段が無く、プロジェクトが乱立する。
- Phase 3 着手前に Phase 1 CRUD の取りこぼしを潰しておく目的。

## Before → After (概念・フロー・メンタルモデル)

**Before:**
プロジェクトは「作るだけ」。一度作ったら名前 / 色 / 本業フラグは
固定。不要になっても DB に残り続け、紐付くタスク / イベントは
project_id を抱えたまま。

**After:**
AddPanel「プロジェクト」タブが「既存一覧 + 新規追加」の二段構成。
既存行をタップ → ProjectDetailPanel で 名前 / 色 / 本業 を編集 or
削除。削除時は schema 側 `ON DELETE SET NULL` で紐付く tasks /
events の project_id が null になり、UI も `tasks` / `events`
クエリ invalidate でその状態を取り込む。

## 追加したテスト (How verified)

- e2e (`project-event-crud.spec.ts`)
  - [x] 編集: 名前 / 色 / 本業フラグ が `projects` 行に反映される
  - [x] 削除: `projects` 行が消え、紐付く task / event の
        `project_id` が null になる (cascade SET NULL を service_role で踏む)
- 既存 vitest (228 件) green
- 既存 e2e (project-event-crud.spec.ts のスコープアウト記述) を本実装に合わせて更新

## このPRの範囲外 (Out of scope)

- アーカイブ機能（削除との切り分けは別議論）
- プロジェクト並び替え
- manual イベントの編集 / 削除 UI（#76 で別途）

https://claude.ai/code/session_014JknAEUjzN9URymZqmFXeT