### PR TITLE
test(e2e): TreeView mock history の描画を semantic locator で踏む

### DIFF
--- a/e2e/tree-view-history.spec.ts
+++ b/e2e/tree-view-history.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "./fixtures";
+
+/**
+ * Issue #78: Tree View が mock history を期待通り描画することを e2e で保証する。
+ *
+ * Phase 1 では TreeView は `src/mocks/history.ts` の固定データを描画する PoC。
+ * 将来 (Phase 3) AI 提案の根拠として TreeView を活用する前提があるため、
+ * 描画が壊れたことを golden-path 以外でも検知できるようにしておく。
+ *
+ * AppShell は user の projects が空のとき history mock の projectId
+ * (`career` / `slo` / `loadtest` / `tasuki`) を `projectOrderForTree` の
+ * fallback に使う。signedInPage fixture は purge 済みなので必ずこの分岐を踏む。
+ */
+test("Tree View renders mock history grouped by date with project legend", async ({
+  signedInPage: page,
+}) => {
+  // Tree View へ遷移 (golden-path と同じ semantic locator)。
+  await page.getByRole("link", { name: "Tree" }).click();
+  await page.waitForURL((url) => url.pathname === "/tree");
+
+  // TreeView 全体は role=region (aria-label="作業履歴") で scope する。
+  const treeView = page.getByRole("region", { name: "作業履歴" });
+  await expect(treeView).toBeVisible();
+
+  // --- プロジェクト凡例 -----------------------------------------------------
+  // history mock の 4 slug が PROJECT_SEEDS 由来の表示名で並ぶ
+  // (mergeTreeProjects: career=転職活動 / slo=SLO推進 / loadtest=負荷試験 / tasuki=Tasuki)。
+  const legend = treeView.getByRole("list", { name: "プロジェクト凡例" });
+  const legendItems = legend.getByRole("listitem");
+  await expect(legendItems).toHaveCount(4);
+  await expect(legendItems.filter({ hasText: "転職活動" })).toBeVisible();
+  await expect(legendItems.filter({ hasText: "SLO推進" })).toBeVisible();
+  await expect(legendItems.filter({ hasText: "負荷試験" })).toBeVisible();
+  await expect(legendItems.filter({ hasText: "Tasuki" })).toBeVisible();
+
+  // --- 日付見出し -----------------------------------------------------------
+  // mock は 2026-04-05〜04-10 の 6 日付。groupByDateDesc により降順。
+  const dateHeadings = treeView.getByRole("heading", { level: 3 });
+  await expect(dateHeadings).toHaveCount(6);
+  await expect(dateHeadings.first()).toHaveText("4/10 (金)");
+  await expect(dateHeadings.last()).toHaveText("4/5 (日)");
+
+  // --- 各日付ごとの履歴 -----------------------------------------------------
+  // DateGroup の <ul> は aria-label="<date> の履歴"。日付スコープで listitem を取れる。
+  const apr5 = treeView.getByRole("list", { name: "4/5 (日) の履歴" });
+  await expect(apr5.getByRole("listitem")).toHaveCount(2);
+  await expect(apr5.getByRole("listitem").filter({ hasText: "転職ドラフト応募完了" })).toBeVisible();
+  await expect(apr5.getByRole("listitem").filter({ hasText: "SLI候補の洗い出し" })).toBeVisible();
+
+  const apr10 = treeView.getByRole("list", { name: "4/10 (金) の履歴" });
+  await expect(apr10.getByRole("listitem")).toHaveCount(2);
+  await expect(
+    apr10.getByRole("listitem").filter({ hasText: "エラーバジェットポリシー草案" }),
+  ).toBeVisible();
+  await expect(apr10.getByRole("listitem").filter({ hasText: "ECS Fargate構成設計" })).toBeVisible();
+
+  // --- 全 11 件の網羅的な確認 -----------------------------------------------
+  // legend (4) + 履歴エントリ (11) = 15 listitem が treeView 配下に存在するはず。
+  // 「合計件数」で守ることで、items の追加漏れ / 重複描画を検知できる。
+  await expect(treeView.getByRole("listitem")).toHaveCount(4 + 11);
+
+  // 残り 7 件 (4/5 と 4/10 で確認した 4 件以外) が描画されていることもサンプル確認。
+  for (const title of [
+    "Locust環境セットアップ",
+    "php-parser PoC完了",
+    "Finatext オファー検討",
+    "New Relicアラート設定",
+    "WireMock導入調査",
+    "ULS企業研究メモ作成",
+    "Terminal埋め込みPoC",
+  ]) {
+    await expect(treeView.getByRole("listitem").filter({ hasText: title })).toBeVisible();
+  }
+});

--- a/e2e/tree-view-history.spec.ts
+++ b/e2e/tree-view-history.spec.ts
@@ -44,7 +44,9 @@ test("Tree View renders mock history grouped by date with project legend", async
   // DateGroup の <ul> は aria-label="<date> の履歴"。日付スコープで listitem を取れる。
   const apr5 = treeView.getByRole("list", { name: "4/5 (日) の履歴" });
   await expect(apr5.getByRole("listitem")).toHaveCount(2);
-  await expect(apr5.getByRole("listitem").filter({ hasText: "転職ドラフト応募完了" })).toBeVisible();
+  await expect(
+    apr5.getByRole("listitem").filter({ hasText: "転職ドラフト応募完了" }),
+  ).toBeVisible();
   await expect(apr5.getByRole("listitem").filter({ hasText: "SLI候補の洗い出し" })).toBeVisible();
 
   const apr10 = treeView.getByRole("list", { name: "4/10 (金) の履歴" });
@@ -52,7 +54,9 @@ test("Tree View renders mock history grouped by date with project legend", async
   await expect(
     apr10.getByRole("listitem").filter({ hasText: "エラーバジェットポリシー草案" }),
   ).toBeVisible();
-  await expect(apr10.getByRole("listitem").filter({ hasText: "ECS Fargate構成設計" })).toBeVisible();
+  await expect(
+    apr10.getByRole("listitem").filter({ hasText: "ECS Fargate構成設計" }),
+  ).toBeVisible();
 
   // --- 全 11 件の網羅的な確認 -----------------------------------------------
   // legend (4) + 履歴エントリ (11) = 15 listitem が treeView 配下に存在するはず。

--- a/src/features/tree-view/DateGroup.tsx
+++ b/src/features/tree-view/DateGroup.tsx
@@ -17,30 +17,38 @@ export function DateGroup({ date, items, projectOrder }: DateGroupProps) {
   const { projectsById } = useProjects();
   const lanesWidth = lanesWidthPx(projectOrder.length);
 
+  const dateLabel = formatDate(date);
   return (
     <div>
       <div className="flex items-center px-4 pb-0.5 pt-2.5">
         <div style={{ width: lanesWidth }} />
-        <span className="text-[10px] text-fg-weak">{formatDate(date)}</span>
-        <div className="ml-2 h-px flex-1 bg-bg-elevated" />
+        <h3 className="m-0 text-[10px] font-normal text-fg-weak">{dateLabel}</h3>
+        <div aria-hidden="true" className="ml-2 h-px flex-1 bg-bg-elevated" />
       </div>
-      {items.map((task) => {
-        const pi = projectOrder.indexOf(task.projectId);
-        const nodeLeft = nodeCenterPx(pi);
-        return (
-          <div key={task.id} className="relative flex min-h-[30px] items-center px-4 py-0.5">
-            <div
-              className="absolute top-1/2 z-[3] h-2 w-2 -translate-y-1/2 rounded-full bg-bg-primary"
-              style={{
-                left: nodeLeft - 4,
-                border: `2px solid ${getProject(projectsById, task.projectId).color}`,
-              }}
-            />
-            <div className="shrink-0" style={{ width: lanesWidth }} />
-            <span className="font-jp text-[11px] text-fg-subtle">{task.title}</span>
-          </div>
-        );
-      })}
+      <ul
+        role="list"
+        aria-label={`${dateLabel} の履歴`}
+        className="m-0 list-none p-0"
+      >
+        {items.map((task) => {
+          const pi = projectOrder.indexOf(task.projectId);
+          const nodeLeft = nodeCenterPx(pi);
+          return (
+            <li key={task.id} className="relative flex min-h-[30px] items-center px-4 py-0.5">
+              <div
+                aria-hidden="true"
+                className="absolute top-1/2 z-[3] h-2 w-2 -translate-y-1/2 rounded-full bg-bg-primary"
+                style={{
+                  left: nodeLeft - 4,
+                  border: `2px solid ${getProject(projectsById, task.projectId).color}`,
+                }}
+              />
+              <div aria-hidden="true" className="shrink-0" style={{ width: lanesWidth }} />
+              <span className="font-jp text-[11px] text-fg-subtle">{task.title}</span>
+            </li>
+          );
+        })}
+      </ul>
     </div>
   );
 }

--- a/src/features/tree-view/DateGroup.tsx
+++ b/src/features/tree-view/DateGroup.tsx
@@ -25,11 +25,7 @@ export function DateGroup({ date, items, projectOrder }: DateGroupProps) {
         <h3 className="m-0 text-[10px] font-normal text-fg-weak">{dateLabel}</h3>
         <div aria-hidden="true" className="ml-2 h-px flex-1 bg-bg-elevated" />
       </div>
-      <ul
-        role="list"
-        aria-label={`${dateLabel} の履歴`}
-        className="m-0 list-none p-0"
-      >
+      <ul role="list" aria-label={`${dateLabel} の履歴`} className="m-0 list-none p-0">
         {items.map((task) => {
           const pi = projectOrder.indexOf(task.projectId);
           const nodeLeft = nodeCenterPx(pi);

--- a/src/features/tree-view/ProjectLanes.tsx
+++ b/src/features/tree-view/ProjectLanes.tsx
@@ -32,7 +32,11 @@ export function ProjectLanes({ projectOrder }: ProjectLanesProps) {
           const p = getProject(projectsById, k);
           return (
             <li key={k} className="flex items-center gap-1">
-              <div aria-hidden="true" className="h-1.5 w-1.5 rounded-full" style={{ background: p.color }} />
+              <div
+                aria-hidden="true"
+                className="h-1.5 w-1.5 rounded-full"
+                style={{ background: p.color }}
+              />
               <span className="font-jp text-[9px] text-fg-weak">{p.name}</span>
             </li>
           );

--- a/src/features/tree-view/ProjectLanes.tsx
+++ b/src/features/tree-view/ProjectLanes.tsx
@@ -23,17 +23,21 @@ export function ProjectLanes({ projectOrder }: ProjectLanesProps) {
           }}
         />
       ))}
-      <div className="relative z-[2] flex gap-3 px-4 pb-1.5 pt-3.5">
+      <ul
+        role="list"
+        aria-label="プロジェクト凡例"
+        className="relative z-[2] m-0 flex list-none gap-3 px-4 pb-1.5 pt-3.5"
+      >
         {projectOrder.map((k) => {
           const p = getProject(projectsById, k);
           return (
-            <div key={k} className="flex items-center gap-1">
-              <div className="h-1.5 w-1.5 rounded-full" style={{ background: p.color }} />
+            <li key={k} className="flex items-center gap-1">
+              <div aria-hidden="true" className="h-1.5 w-1.5 rounded-full" style={{ background: p.color }} />
               <span className="font-jp text-[9px] text-fg-weak">{p.name}</span>
-            </div>
+            </li>
           );
         })}
-      </div>
+      </ul>
     </>
   );
 }

--- a/src/features/tree-view/TreeView.tsx
+++ b/src/features/tree-view/TreeView.tsx
@@ -16,13 +16,13 @@ export function TreeView({ historyData, projectOrder }: TreeViewProps) {
   const dateGroups = groupByDateDesc(historyData);
 
   return (
-    <div className="relative pb-10">
+    <section aria-label="作業履歴" className="relative pb-10">
       <ProjectLanes projectOrder={projectOrder} />
       <div className="relative z-[2]">
         {dateGroups.map(([date, items]) => (
           <DateGroup key={date} date={date} items={items} projectOrder={projectOrder} />
         ))}
       </div>
-    </div>
+    </section>
   );
 }


### PR DESCRIPTION
## 概要 (What)

Tree View の mock history（`src/mocks/history.ts` の固定 11 件）が期待通り描画されることを e2e で保証する。あわせて TreeView 配下の DOM に semantic 構造（role / aria-label / heading）を立てて、locator を `getByRole` ベースで書けるようにした。

## 関連 Issue

Closes #78

## 背景 (Why)

`golden-path.spec.ts` は Tree View 画面への遷移自体は踏むが、画面内の描画（凡例 / 日付見出し / 履歴ノード）は assert していなかった。Phase 3 で AI 提案の根拠表示として TreeView を活用する想定がある以上、その手前で「現状の mock 描画が壊れていない」ことを CI で検知できる状態にしておきたい。

ただし TreeView 配下は `<div>` + `<span>` の塊で role / aria が一切立っておらず、`getByText` 直叩きしか選択肢がない状態だった。`kozutsumi-frontend-a11y` skill のとおり「e2e の locator 弱さ = semantic 構造不足のシグナル」として、テスト側で誤魔化す前に構造側を立てた。

## Before → After (概念・フロー・メンタルモデル)

**Before:**

- TreeView の DOM は装飾的な `<div>` / `<span>` のみ。スクリーンリーダーから見ても「ただの文字列の羅列」で、e2e からも `getByText` でしか取れない
- mock history の描画は golden-path の navigation 後にスルーされていた（描画が崩れても気づかない）

**After:**

- TreeView 全体が `role="region"`（aria-label="作業履歴"）として一塊で scope できる
- 凡例は `role="list"`（aria-label="プロジェクト凡例"）+ `role="listitem"`、日付は `<h3>`、各日付の履歴は `role="list"`（aria-label="`<date>` の履歴"）+ `role="listitem"` として階層が見える
- e2e は `region → list → listitem` の semantic chain で「凡例 4 + 履歴 11 = 15 listitem」「日付見出し 6 件、降順」「特定日付の特定エントリ」を assert できる

## 追加したテスト (How verified)

- [x] `e2e/tree-view-history.spec.ts` を新規追加（`signedInPage` fixture → `/tree` 遷移 → semantic locator で凡例 / 日付見出し / 各日付スコープでの履歴エントリ / 総 listitem 数を assert）
- [x] 既存の `src/features/tree-view/TreeView.test.tsx`（vitest, 5 件）は wrapper を増やしただけで text 検出は壊さないため引き続き pass（`npm test` 228 / 228 緑）
- [x] `npm run typecheck` / `npm run lint` クリーン
- [x] `npx playwright test --list` で新 spec が認識されることを確認
- e2e 実走は Supabase が無いため手元では未実施。CI で検証する

## このPRの範囲外 (Out of scope)

- 実 history（`tasks where status='done'` 由来）のロード — 現状 mock のままで、Phase 1 PoC のスコープを変えない
- TreeView の編集機能 / インタラクション
- `<h3>` 化に伴う heading レベル順序（h1/h2 の整理）— TreeView 単体での semantic 立て直しに留めた

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1j6WaVDcfwLgv2oHqEQXL)_