### PR TITLE
feat(event): manual イベント編集 / 削除 UI + e2e (#76)

### DIFF
--- a/e2e/gcal-event-readonly.spec.ts
+++ b/e2e/gcal-event-readonly.spec.ts
@@ -53,17 +53,19 @@ test.describe("google_calendar イベントの編集制約 (ADR 0010)", () => {
     // EventCard は role を持たない div だが、表示テキストに event.title が含まれる。
     await page.getByText(eventTitle).first().click();
 
-    // EventDetailPanel が開く (role=dialog は付いていない)。
-    // 手がかりとして、GCal 由来であることを示すバッジ + 由来説明文の存在を踏む。
-    await expect(page.getByTestId("google-calendar-badge").first()).toBeVisible();
+    // EventDetailPanel が開く (Issue #76 で role="dialog" + aria-label="イベント詳細"
+    // を付与済み)。GCal 由来であることを示すバッジ + 由来説明文の存在を踏む。
+    const detailDialog = page.getByRole("dialog", { name: "イベント詳細" });
+    await expect(detailDialog).toBeVisible();
+    await expect(detailDialog.getByTestId("google-calendar-badge").first()).toBeVisible();
     await expect(
-      page.getByText("Google Calendar で編集した内容は次回同期で反映されます"),
+      detailDialog.getByText("Google Calendar で編集した内容は次回同期で反映されます"),
     ).toBeVisible();
 
-    // --- 削除ボタンが出ない (ADR 0010) ---------------------------------------
-    // 注意: TaskDetailPanel など他 panel の「削除」と区別するため、現在開いて
-    // いるのが EventDetailPanel であることは GoogleCalendarBadge の存在で担保。
-    await expect(page.getByRole("button", { name: "削除" })).toHaveCount(0);
+    // --- 削除ボタン / 編集ボタンが出ない (ADR 0010) -------------------------
+    // dialog 内に絞ることで TaskDetailPanel など他 panel との誤検知を防ぐ。
+    await expect(detailDialog.getByRole("button", { name: "削除" })).toHaveCount(0);
+    await expect(detailDialog.getByRole("button", { name: "編集" })).toHaveCount(0);
 
     // --- title は h2 表示 / 編集 input は無い -------------------------------
     // h2 element が title を持つ (EventDetailPanel.tsx L61-63)。

--- a/e2e/project-event-crud.spec.ts
+++ b/e2e/project-event-crud.spec.ts
@@ -2,8 +2,8 @@ import { createAdminClient, getEventByTitle, getProjectByName, getTaskByTitle } 
 import { expect, test } from "./fixtures";
 
 /**
- * Issue #67 🟧:
- *   プロジェクト / manual イベント作成の DB 整合。
+ * Issue #67 🟧 / Issue #76:
+ *   プロジェクト / manual イベントの create / edit / delete DB 整合。
  *
  * golden-path / 他の spec はプロジェクトを使う側にしか居ないため、
  * `projects` / `events (source='manual')` 行が UI 入力通りに落ちることを
@@ -12,11 +12,9 @@ import { expect, test } from "./fixtures";
  * Issue #75 で追加: プロジェクト編集 / 削除 + cascade (tasks.project_id /
  * events.project_id が `ON DELETE SET NULL` で null 化) も同 spec で踏む。
  *
- * **スコープアウト** (現状コードに UI が無い):
- *   - manual イベントの編集 / 削除 UI (EventDetailPanel に未実装、
- *     EventDetailPanel.test の「どの source でも『削除』ボタンは表示されない」
- *     と整合)。
- *   実装が入った段階で本 spec を拡張する。
+ * Issue #76 で追加: manual イベントの編集 / 削除 UI (`EventDetailPanel`)。
+ * google_calendar 側の read-only 制約 (ADR 0010) は `gcal-event-readonly.spec.ts`
+ * 側で踏んでいる。
  */
 test.describe("プロジェクト作成 (projects 行整合)", () => {
   test("名前 / 色 / 本業フラグ が projects 行に正しく落ちる", async ({
@@ -115,6 +113,160 @@ test.describe("manual イベント作成 (events 行整合)", () => {
   });
 });
 
+test.describe("manual イベント編集 (events 行整合, Issue #76)", () => {
+  test("title / 時刻 / プロジェクト / Meet URL / 本文 を編集すると events 行に反映される", async ({
+    signedInPageWithProject: page,
+    projectName,
+    testUserId: userId,
+  }) => {
+    const initialTitle = "E2E 編集前 MTG";
+    const newTitle = "E2E 編集後 MTG";
+    const newBody = "## 議題\n- 編集テスト";
+    const newMeetUrl = "https://meet.google.com/edited-e2e";
+    // DayTimeline は「今日」のイベントしか描画しないので、開始日付は今日にする。
+    const todayLocal = todayDateStr();
+    const startLocal = `${todayLocal}T13:00`;
+    const endLocal = `${todayLocal}T14:00`;
+    const editedStartLocal = `${todayLocal}T15:00`;
+    const editedEndLocal = `${todayLocal}T16:30`;
+
+    const admin = createAdminClient();
+    const project = await getProjectByName(admin, userId, projectName);
+
+    // --- create: AddPanel から initialTitle / project なし / Meet URL なしで ---
+    await page.getByRole("button", { name: "新規追加" }).click();
+    let addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+    await addDialog.getByRole("tab", { name: "イベント" }).click();
+    await addDialog.getByLabel("タイトル").fill(initialTitle);
+    await addDialog.getByLabel("開始").fill(startLocal);
+    await addDialog.getByLabel("終了").fill(endLocal);
+    await addDialog.getByRole("button", { name: "追加" }).click();
+    await expect(addDialog).toHaveCount(0);
+
+    const created = await getEventByTitle(admin, userId, initialTitle);
+    expect(created.project_id).toBeNull();
+    expect(created.meet_url).toBeNull();
+    expect(created.description).toBe("");
+
+    // --- open EventDetailPanel: DayTimeline 上の event card をクリック ---
+    await page.getByText(initialTitle).first().click();
+    const detailDialog = page.getByRole("dialog", { name: "イベント詳細" });
+    await expect(detailDialog).toBeVisible();
+
+    // --- edit: 「編集」 → form 表示 → 全フィールド書き換え → 保存 ---
+    await detailDialog.getByRole("button", { name: "編集" }).click();
+    await detailDialog.getByLabel("タイトル").fill(newTitle);
+    await detailDialog.getByLabel("開始").fill(editedStartLocal);
+    await detailDialog.getByLabel("終了").fill(editedEndLocal);
+    await detailDialog.getByLabel("プロジェクト (任意)").selectOption({ label: projectName });
+    await detailDialog.getByLabel("会議URL (任意)").fill(newMeetUrl);
+    await detailDialog.getByLabel("本文 (任意, Markdown)").fill(newBody);
+    await detailDialog.getByRole("button", { name: "保存" }).click();
+
+    // --- 保存後はパネルが view モードに戻る (form input が消える) ---
+    await expect(detailDialog.getByLabel("タイトル")).toHaveCount(0);
+
+    // --- DB 検証 ---
+    // title が変わっているので getEventByTitle(newTitle) で取り直す。
+    await expect
+      .poll(async () => (await getEventByTitle(admin, userId, newTitle)).title, {
+        message: "events.title should be updated",
+        timeout: 5_000,
+      })
+      .toBe(newTitle);
+    const after = await getEventByTitle(admin, userId, newTitle);
+    expect(after.id).toBe(created.id);
+    expect(after.source).toBe("manual");
+    expect(after.project_id).toBe(project.id);
+    expect(after.meet_url).toBe(newMeetUrl);
+    expect(after.description).toBe(newBody);
+    expect(new Date(after.start_time).getTime()).toBe(new Date(`${editedStartLocal}:00`).getTime());
+    expect(new Date(after.end_time).getTime()).toBe(new Date(`${editedEndLocal}:00`).getTime());
+  });
+});
+
+test.describe("manual イベント削除 (events 行消滅, Issue #76)", () => {
+  test("削除ボタン → 確認 OK で events 行が消える", async ({
+    signedInPage: page,
+    testUserId: userId,
+  }) => {
+    const eventTitle = "E2E 削除対象イベント";
+    const todayLocal = todayDateStr();
+    const startLocal = `${todayLocal}T11:00`;
+    const endLocal = `${todayLocal}T12:00`;
+
+    const admin = createAdminClient();
+
+    // --- create ---
+    await page.getByRole("button", { name: "新規追加" }).click();
+    const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+    await addDialog.getByRole("tab", { name: "イベント" }).click();
+    await addDialog.getByLabel("タイトル").fill(eventTitle);
+    await addDialog.getByLabel("開始").fill(startLocal);
+    await addDialog.getByLabel("終了").fill(endLocal);
+    await addDialog.getByRole("button", { name: "追加" }).click();
+    await expect(addDialog).toHaveCount(0);
+
+    const created = await getEventByTitle(admin, userId, eventTitle);
+
+    // --- open detail → 削除 (confirm を accept) ---
+    await page.getByText(eventTitle).first().click();
+    const detailDialog = page.getByRole("dialog", { name: "イベント詳細" });
+    await expect(detailDialog).toBeVisible();
+
+    page.once("dialog", (dialog) => dialog.accept());
+    await detailDialog.getByRole("button", { name: "削除" }).click();
+    await expect(detailDialog).toHaveCount(0);
+
+    // --- DB: events 行が消えている ---
+    await expect
+      .poll(
+        async () => {
+          const { data } = await admin.from("events").select("id").eq("id", created.id);
+          return data?.length ?? -1;
+        },
+        { message: "events row should be deleted", timeout: 5_000 },
+      )
+      .toBe(0);
+  });
+
+  test("確認ダイアログをキャンセルすると events 行は残る", async ({
+    signedInPage: page,
+    testUserId: userId,
+  }) => {
+    const eventTitle = "E2E 削除キャンセル対象";
+    const todayLocal = todayDateStr();
+    const startLocal = `${todayLocal}T08:00`;
+    const endLocal = `${todayLocal}T09:00`;
+
+    const admin = createAdminClient();
+
+    await page.getByRole("button", { name: "新規追加" }).click();
+    const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+    await addDialog.getByRole("tab", { name: "イベント" }).click();
+    await addDialog.getByLabel("タイトル").fill(eventTitle);
+    await addDialog.getByLabel("開始").fill(startLocal);
+    await addDialog.getByLabel("終了").fill(endLocal);
+    await addDialog.getByRole("button", { name: "追加" }).click();
+    await expect(addDialog).toHaveCount(0);
+
+    const created = await getEventByTitle(admin, userId, eventTitle);
+
+    await page.getByText(eventTitle).first().click();
+    const detailDialog = page.getByRole("dialog", { name: "イベント詳細" });
+    await expect(detailDialog).toBeVisible();
+
+    page.once("dialog", (dialog) => dialog.dismiss());
+    await detailDialog.getByRole("button", { name: "削除" }).click();
+    // キャンセル時は detail panel が開いたまま (削除も close も走らない)。
+    await expect(detailDialog).toBeVisible();
+
+    // DB の行は残っている。
+    const after = await getEventByTitle(admin, userId, eventTitle);
+    expect(after.id).toBe(created.id);
+  });
+});
+
 test.describe("プロジェクト編集 (projects 行整合)", () => {
   test("名前 / 色 / 本業フラグ を編集すると projects 行に反映される", async ({
     signedInPageWithProject: page,
@@ -210,3 +362,16 @@ test.describe("プロジェクト削除 (cascade SET NULL)", () => {
     expect(ev.project_id).toBeNull();
   });
 });
+
+/**
+ * DayTimeline は「今日」のローカル日付のイベントだけ描画する。e2e で
+ * EventDetailPanel を開く動線（DayTimeline 上の event card クリック）を踏む
+ * ためには、開始日付を実行日のローカルに合わせる必要がある。
+ */
+function todayDateStr(): string {
+  const d = new Date();
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { ACTION_TYPES, log } from "@/entities/action-log/logger";
-import type { CreateEventInput } from "@/entities/event/gateway";
+import type { CreateEventInput, UpdateEventInput } from "@/entities/event/gateway";
 import type { Event } from "@/entities/event/types";
 import type { CreateProjectInput, UpdateProjectInput } from "@/entities/project/gateway";
 import { ProjectsProvider } from "@/entities/project/ProjectsContext";
@@ -269,6 +269,65 @@ export function AppShell({ initialView, user }: AppShellProps) {
       return { previous };
     },
     onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(keys.events, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: keys.events });
+    },
+  });
+
+  // ADR 0010: manual イベントの全フィールド編集 (title / start_time / end_time /
+  // meet_url / project_id / description)。optimistic に反映し、失敗したら roll
+  // back する。SupabaseEventGateway.update 側で source='google_calendar' の行は
+  // Google 側属性を弾くので、UI が誤ってここに google_calendar を流しても DB
+  // 書き込みは守られる (ADR 0010 の defense in depth)。
+  const updateEventMutation = useMutation({
+    mutationFn: ({ id, patch }: { id: string; patch: UpdateEventInput }) =>
+      eventGateway.update(id, patch),
+    onMutate: async ({ id, patch }) => {
+      await queryClient.cancelQueries({ queryKey: keys.events });
+      const previous = queryClient.getQueryData<Event[]>(keys.events);
+      queryClient.setQueryData<Event[]>(keys.events, (prev) =>
+        (prev ?? []).map((e) =>
+          e.id === id
+            ? {
+                ...e,
+                ...(patch.title !== undefined ? { title: patch.title } : {}),
+                ...(patch.startTime !== undefined ? { startTime: patch.startTime } : {}),
+                ...(patch.endTime !== undefined ? { endTime: patch.endTime } : {}),
+                ...(patch.projectId !== undefined ? { projectId: patch.projectId } : {}),
+                ...(patch.meetUrl !== undefined ? { meetUrl: patch.meetUrl } : {}),
+                ...(patch.hasAttachments !== undefined
+                  ? { hasAttachments: patch.hasAttachments }
+                  : {}),
+                ...(patch.description !== undefined ? { description: patch.description } : {}),
+              }
+            : e,
+        ),
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(keys.events, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: keys.events });
+    },
+  });
+
+  // ADR 0010: manual イベントだけが UI から削除可能。google_calendar は
+  // SupabaseEventGateway.delete が source を見て弾く。
+  const deleteEventMutation = useMutation({
+    mutationFn: (id: string) => eventGateway.delete(id),
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: keys.events });
+      const previous = queryClient.getQueryData<Event[]>(keys.events);
+      queryClient.setQueryData<Event[]>(keys.events, (prev) =>
+        (prev ?? []).filter((e) => e.id !== id),
+      );
+      return { previous };
+    },
+    onError: (_err, _id, ctx) => {
       if (ctx?.previous) queryClient.setQueryData(keys.events, ctx.previous);
     },
     onSettled: () => {
@@ -547,6 +606,12 @@ export function AppShell({ initialView, user }: AppShellProps) {
                 onChangeProject={(id, projectId) =>
                   updateEventProjectMutation.mutate({ id, projectId })
                 }
+                onUpdate={async (id, patch) => {
+                  await updateEventMutation.mutateAsync({ id, patch });
+                }}
+                onDelete={async (id) => {
+                  await deleteEventMutation.mutateAsync(id);
+                }}
               />
             ) : null;
           })()}

--- a/src/features/event-detail/EventDetailPanel.test.tsx
+++ b/src/features/event-detail/EventDetailPanel.test.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, render as rtlRender } from "@testing-library/react";
-import { describe, expect, test, vi } from "vitest";
+import { fireEvent, render as rtlRender, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { UpdateEventInput } from "../../entities/event/gateway";
 import type { Event } from "../../entities/event/types";
 import type { Project } from "../../entities/project/types";
 import { ProjectsProvider } from "../../entities/project/ProjectsContext";
@@ -40,6 +41,8 @@ function renderPanel(
     event: Event;
     onClose: () => void;
     onChangeProject: (id: string, projectId: string | null) => void;
+    onUpdate: (id: string, patch: UpdateEventInput) => Promise<void> | void;
+    onDelete: (id: string) => Promise<void> | void;
   }> = {},
 ) {
   const props = { event: baseEvent, onClose: noop, ...overrides };
@@ -107,10 +110,17 @@ describe("EventDetailPanel", () => {
   test("backdrop クリックで onClose が呼ばれる", () => {
     const onClose = vi.fn();
     const { container } = renderPanel({ onClose });
-    // Backdrop は fixed コンテナの最初の子 div
+    // Backdrop は role=dialog コンテナの最初の子 div
     const backdrop = container.firstElementChild!.firstElementChild!;
     fireEvent.click(backdrop);
     expect(onClose).toHaveBeenCalled();
+  });
+
+  test("role='dialog' + aria-modal で modal landmark を立てる (a11y)", () => {
+    const { getByRole } = renderPanel();
+    const dialog = getByRole("dialog", { name: "イベント詳細" });
+    expect(dialog).toBeTruthy();
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
   });
 
   // ADR 0010 / P2-4: source 別の編集制約
@@ -121,6 +131,7 @@ describe("EventDetailPanel", () => {
       });
       expect(queryByTestId("google-calendar-badge")).toBeNull();
       expect(queryByText(/Google Calendar で編集した内容は次回同期で反映されます/)).toBeNull();
+      // canEditProject = isGoogleCalendar && !!onChangeProject なので manual では出ない
       expect(queryByText(/を変更$/)).toBeNull();
     });
 
@@ -168,14 +179,188 @@ describe("EventDetailPanel", () => {
       expect(onChangeProject).toHaveBeenCalledWith("g1", null);
     });
 
-    test("どの source でも「削除」ボタンは表示されない", () => {
-      const m = renderPanel();
-      expect(m.queryByText("削除")).toBeNull();
-      const g = renderPanel({
+    test("manual: onUpdate / onDelete 未指定なら編集 / 削除ボタンを出さない", () => {
+      const { queryByRole } = renderPanel();
+      expect(queryByRole("button", { name: "編集" })).toBeNull();
+      expect(queryByRole("button", { name: "削除" })).toBeNull();
+    });
+
+    test("google_calendar: onUpdate / onDelete を渡しても編集 / 削除ボタンを出さない (ADR 0010)", () => {
+      const { queryByRole } = renderPanel({
         event: googleEvent,
         onChangeProject: vi.fn(),
+        onUpdate: vi.fn(),
+        onDelete: vi.fn(),
       });
-      expect(g.queryByText("削除")).toBeNull();
+      expect(queryByRole("button", { name: "編集" })).toBeNull();
+      expect(queryByRole("button", { name: "削除" })).toBeNull();
+    });
+  });
+
+  describe("manual イベントの編集 (ADR 0010 / Issue #76)", () => {
+    test("onUpdate を渡すと「編集」ボタンが出る", () => {
+      const { getByRole } = renderPanel({ onUpdate: vi.fn() });
+      expect(getByRole("button", { name: "編集" })).toBeTruthy();
+    });
+
+    test("「編集」をクリックするとフォームが現れ、各フィールドが event 値で初期化される", () => {
+      const { getByRole, getByLabelText } = renderPanel({
+        event: {
+          ...baseEvent,
+          meetUrl: "https://meet.google.com/old",
+          description: "old body",
+        },
+        onUpdate: vi.fn(),
+      });
+      fireEvent.click(getByRole("button", { name: "編集" }));
+      expect((getByLabelText("タイトル") as HTMLInputElement).value).toBe("SLO レビュー");
+      // datetime-local はローカル tz の YYYY-MM-DDTHH:MM
+      expect((getByLabelText("開始") as HTMLInputElement).value).toBe("2026-04-11T10:00");
+      expect((getByLabelText("終了") as HTMLInputElement).value).toBe("2026-04-11T11:00");
+      expect((getByLabelText("プロジェクト (任意)") as HTMLSelectElement).value).toBe("slo");
+      expect((getByLabelText("会議URL (任意)") as HTMLInputElement).value).toBe(
+        "https://meet.google.com/old",
+      );
+      expect((getByLabelText("本文 (任意, Markdown)") as HTMLTextAreaElement).value).toBe(
+        "old body",
+      );
+    });
+
+    test("フォームを編集して保存すると onUpdate が patch 全量で呼ばれる", async () => {
+      const onUpdate = vi.fn().mockResolvedValue(undefined);
+      const { getByRole, getByLabelText } = renderPanel({ onUpdate });
+      fireEvent.click(getByRole("button", { name: "編集" }));
+      fireEvent.change(getByLabelText("タイトル"), { target: { value: "新タイトル" } });
+      fireEvent.change(getByLabelText("開始"), { target: { value: "2026-04-12T09:30" } });
+      fireEvent.change(getByLabelText("終了"), { target: { value: "2026-04-12T10:30" } });
+      fireEvent.change(getByLabelText("プロジェクト (任意)"), { target: { value: "career" } });
+      fireEvent.change(getByLabelText("会議URL (任意)"), {
+        target: { value: "https://zoom.us/j/999" },
+      });
+      fireEvent.change(getByLabelText("本文 (任意, Markdown)"), {
+        target: { value: "新しい本文" },
+      });
+      fireEvent.click(getByRole("button", { name: "保存" }));
+      await waitFor(() => {
+        expect(onUpdate).toHaveBeenCalledWith("e1", {
+          title: "新タイトル",
+          startTime: "2026-04-12T09:30:00",
+          endTime: "2026-04-12T10:30:00",
+          projectId: "career",
+          meetUrl: "https://zoom.us/j/999",
+          description: "新しい本文",
+        });
+      });
+    });
+
+    test("プロジェクト「なし」 / Meet URL 空白 は null で送る", async () => {
+      const onUpdate = vi.fn().mockResolvedValue(undefined);
+      const { getByRole, getByLabelText } = renderPanel({ onUpdate });
+      fireEvent.click(getByRole("button", { name: "編集" }));
+      fireEvent.change(getByLabelText("プロジェクト (任意)"), { target: { value: "" } });
+      fireEvent.change(getByLabelText("会議URL (任意)"), { target: { value: "  " } });
+      fireEvent.click(getByRole("button", { name: "保存" }));
+      await waitFor(() => {
+        expect(onUpdate).toHaveBeenCalledWith(
+          "e1",
+          expect.objectContaining({ projectId: null, meetUrl: null }),
+        );
+      });
+    });
+
+    test("タイトル空で保存するとエラー表示で onUpdate を呼ばない", () => {
+      const onUpdate = vi.fn();
+      const { getByRole, getByLabelText, getByRole: _gr, getByText } = renderPanel({ onUpdate });
+      fireEvent.click(getByRole("button", { name: "編集" }));
+      fireEvent.change(getByLabelText("タイトル"), { target: { value: "  " } });
+      fireEvent.click(getByRole("button", { name: "保存" }));
+      expect(onUpdate).not.toHaveBeenCalled();
+      expect(getByText("タイトルは必須です")).toBeTruthy();
+      void _gr;
+    });
+
+    test("終了 <= 開始 で保存するとエラー表示で onUpdate を呼ばない", () => {
+      const onUpdate = vi.fn();
+      const { getByRole, getByLabelText, getByText } = renderPanel({ onUpdate });
+      fireEvent.click(getByRole("button", { name: "編集" }));
+      fireEvent.change(getByLabelText("開始"), { target: { value: "2026-04-12T10:00" } });
+      fireEvent.change(getByLabelText("終了"), { target: { value: "2026-04-12T09:00" } });
+      fireEvent.click(getByRole("button", { name: "保存" }));
+      expect(onUpdate).not.toHaveBeenCalled();
+      expect(getByText("終了時刻は開始時刻より後にしてください")).toBeTruthy();
+    });
+
+    test("キャンセルで編集モードを抜けて元の表示に戻る", () => {
+      const onUpdate = vi.fn();
+      const { getByRole, queryByLabelText } = renderPanel({ onUpdate });
+      fireEvent.click(getByRole("button", { name: "編集" }));
+      expect(queryByLabelText("タイトル")).toBeTruthy();
+      fireEvent.click(getByRole("button", { name: "キャンセル" }));
+      expect(queryByLabelText("タイトル")).toBeNull();
+      expect(onUpdate).not.toHaveBeenCalled();
+    });
+
+    test("onUpdate が reject すると error が表示され編集モードに留まる", async () => {
+      const onUpdate = vi.fn().mockRejectedValue(new Error("DB error"));
+      const { getByRole, getByLabelText, findByText } = renderPanel({ onUpdate });
+      fireEvent.click(getByRole("button", { name: "編集" }));
+      fireEvent.click(getByRole("button", { name: "保存" }));
+      expect(await findByText("DB error")).toBeTruthy();
+      // 編集モードのまま (タイトル input が残る)
+      expect(getByLabelText("タイトル")).toBeTruthy();
+    });
+  });
+
+  describe("manual イベントの削除 (ADR 0010 / Issue #76)", () => {
+    // happy-dom は window.confirm を未実装。テストで上書きするため自前で stub する。
+    let originalConfirm: typeof window.confirm | undefined;
+    let confirmReturn = true;
+
+    beforeEach(() => {
+      originalConfirm = window.confirm;
+      confirmReturn = true;
+      window.confirm = vi.fn(() => confirmReturn) as typeof window.confirm;
+    });
+
+    afterEach(() => {
+      if (originalConfirm) window.confirm = originalConfirm;
+    });
+
+    test("onDelete を渡すと「削除」ボタンが出る", () => {
+      const { getByRole } = renderPanel({ onDelete: vi.fn() });
+      expect(getByRole("button", { name: "削除" })).toBeTruthy();
+    });
+
+    test("削除ボタン → confirm OK で onDelete + onClose が呼ばれる", async () => {
+      confirmReturn = true;
+      const onDelete = vi.fn().mockResolvedValue(undefined);
+      const onClose = vi.fn();
+      const { getByRole } = renderPanel({ onDelete, onClose });
+      fireEvent.click(getByRole("button", { name: "削除" }));
+      await waitFor(() => {
+        expect(onDelete).toHaveBeenCalledWith("e1");
+        expect(onClose).toHaveBeenCalled();
+      });
+    });
+
+    test("削除ボタン → confirm キャンセルなら onDelete を呼ばない", () => {
+      confirmReturn = false;
+      const onDelete = vi.fn();
+      const onClose = vi.fn();
+      const { getByRole } = renderPanel({ onDelete, onClose });
+      fireEvent.click(getByRole("button", { name: "削除" }));
+      expect(onDelete).not.toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    test("onDelete が reject すると error が表示され onClose を呼ばない", async () => {
+      confirmReturn = true;
+      const onDelete = vi.fn().mockRejectedValue(new Error("delete failed"));
+      const onClose = vi.fn();
+      const { getByRole, findByText } = renderPanel({ onDelete, onClose });
+      fireEvent.click(getByRole("button", { name: "削除" }));
+      expect(await findByText("delete failed")).toBeTruthy();
+      expect(onClose).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/features/event-detail/EventDetailPanel.tsx
+++ b/src/features/event-detail/EventDetailPanel.tsx
@@ -1,10 +1,16 @@
 import { useState } from "react";
 
+import type { UpdateEventInput } from "../../entities/event/gateway";
 import { EVENT_SOURCE, type Event } from "../../entities/event/types";
 import { GoogleCalendarBadge } from "../../entities/event/GoogleCalendarBadge";
 import { getProject } from "../../entities/project/projects";
 import { useProjects } from "../../entities/project/ProjectsContext";
-import { fmtDuration, formatClock, minutesOfDay } from "../../shared/lib/time";
+import {
+  fmtDuration,
+  formatClock,
+  minutesOfDay,
+  toDateTimeLocalInput,
+} from "../../shared/lib/time";
 import { renderMarkdown } from "../../shared/lib/markdown";
 
 type EventDetailPanelProps = {
@@ -15,9 +21,29 @@ type EventDetailPanelProps = {
    * 未指定なら project_id 編集 UI も表示しない (省略可で既存呼び出しを壊さない)。
    */
   onChangeProject?: (id: string, projectId: string | null) => void;
+  /**
+   * `source === 'manual'` のイベントを編集する時に呼ぶ。`UpdateEventInput` 全体を渡す。
+   * 未指定なら manual イベントの編集 UI も表示しない (テストや特殊呼び出しで省略可)。
+   * ADR 0010 により google_calendar イベントは Google 側属性 read-only なので、
+   * 本コールバックは manual のみで使用する。
+   */
+  onUpdate?: (id: string, patch: UpdateEventInput) => Promise<void> | void;
+  /**
+   * `source === 'manual'` のイベントを削除する時に呼ぶ。
+   * 未指定なら削除ボタンを表示しない。
+   * ADR 0010 により google_calendar イベントは UI から削除不可なので、本コール
+   * バックを渡しても source='google_calendar' では削除ボタンを表示しない。
+   */
+  onDelete?: (id: string) => Promise<void> | void;
 };
 
-export function EventDetailPanel({ event, onClose, onChangeProject }: EventDetailPanelProps) {
+export function EventDetailPanel({
+  event,
+  onClose,
+  onChangeProject,
+  onUpdate,
+  onDelete,
+}: EventDetailPanelProps) {
   const { projects, projectsById } = useProjects();
   const proj = event.projectId ? getProject(projectsById, event.projectId) : null;
   const evColor = proj ? proj.color : "#52525b";
@@ -31,13 +57,98 @@ export function EventDetailPanel({ event, onClose, onChangeProject }: EventDetai
       ? "Google Meet"
       : "会議リンク";
   const isGoogleCalendar = event.source === EVENT_SOURCE.GOOGLE_CALENDAR;
+  const isManual = event.source === EVENT_SOURCE.MANUAL;
   // ADR 0010: google_calendar イベントは project_id だけ kozutsumi 側で編集可。
   // onChangeProject が渡されている時のみ編集 UI を出す (テストや特殊呼び出しで省略可)。
   const canEditProject = isGoogleCalendar && !!onChangeProject;
+  // ADR 0010: manual イベントだけが全フィールド編集 / 削除可。
+  const canEdit = isManual && !!onUpdate;
+  const canDelete = isManual && !!onDelete;
   const [editingProject, setEditingProject] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // 編集フォームの draft 値。編集モードに入る時に event 値で初期化する。
+  const [draftTitle, setDraftTitle] = useState(event.title);
+  const [draftStart, setDraftStart] = useState(toDateTimeLocalInput(event.startTime));
+  const [draftEnd, setDraftEnd] = useState(toDateTimeLocalInput(event.endTime));
+  const [draftProjectId, setDraftProjectId] = useState(event.projectId ?? "");
+  const [draftMeetUrl, setDraftMeetUrl] = useState(event.meetUrl ?? "");
+  const [draftBody, setDraftBody] = useState(event.description ?? "");
+
+  const startEdit = () => {
+    setDraftTitle(event.title);
+    setDraftStart(toDateTimeLocalInput(event.startTime));
+    setDraftEnd(toDateTimeLocalInput(event.endTime));
+    setDraftProjectId(event.projectId ?? "");
+    setDraftMeetUrl(event.meetUrl ?? "");
+    setDraftBody(event.description ?? "");
+    setError(null);
+    setEditing(true);
+  };
+
+  const cancelEdit = () => {
+    setEditing(false);
+    setError(null);
+  };
+
+  const submitEdit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (pending || !onUpdate) return;
+    if (!draftTitle.trim()) {
+      setError("タイトルは必須です");
+      return;
+    }
+    if (!draftStart || !draftEnd) {
+      setError("開始/終了時刻は必須です");
+      return;
+    }
+    if (new Date(draftEnd).getTime() <= new Date(draftStart).getTime()) {
+      setError("終了時刻は開始時刻より後にしてください");
+      return;
+    }
+    setPending(true);
+    setError(null);
+    try {
+      await onUpdate(event.id, {
+        title: draftTitle.trim(),
+        // datetime-local はローカル tz-naive 値。EventForm と揃えて `:00` を補完する。
+        startTime: `${draftStart}:00`,
+        endTime: `${draftEnd}:00`,
+        projectId: draftProjectId || null,
+        meetUrl: draftMeetUrl.trim() || null,
+        description: draftBody,
+      });
+      setEditing(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "保存に失敗しました");
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (pending || !onDelete) return;
+    if (!window.confirm(`イベント「${event.title}」を削除しますか?`)) return;
+    setPending(true);
+    setError(null);
+    try {
+      await onDelete(event.id);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "削除に失敗しました");
+      setPending(false);
+    }
+  };
 
   return (
-    <div className="fixed inset-0 z-[200] flex flex-col">
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="イベント詳細"
+      className="fixed inset-0 z-[200] flex flex-col"
+    >
       <div onClick={onClose} className="absolute inset-0 bg-black/60 backdrop-blur-[4px]" />
       <div
         className="relative mt-auto flex max-h-[85vh] animate-panel-slide-up flex-col rounded-t-2xl bg-bg-surface"
@@ -49,123 +160,262 @@ export function EventDetailPanel({ event, onClose, onChangeProject }: EventDetai
           <div className="h-[3px] w-8 rounded-[2px] bg-bg-divider" />
         </div>
 
-        <div className="px-5 pb-3 pt-2">
-          <div className="mb-2 flex items-center gap-2">
-            {proj && <div className="h-2 w-2 rounded-full" style={{ background: evColor }} />}
-            {proj && <span className="font-jp text-[10px] text-fg-subtle">{proj.name}</span>}
-            <span className="text-[10px] tabular-nums text-fg-weak">
-              {formatClock(event.startTime)}–{formatClock(event.endTime)} ({fmtDuration(duration)})
-            </span>
-            {isGoogleCalendar && <GoogleCalendarBadge size="md" />}
-          </div>
-          <h2 className="m-0 font-jp text-[16px] font-bold leading-[1.4] text-fg-strong">
-            {event.title}
-          </h2>
-        </div>
-
-        {event.meetUrl && (
-          <div className="px-5 pb-2">
-            <a
-              href={event.meetUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 font-jp text-[11px] no-underline ${
-                isZoom
-                  ? "border border-[#2D8CFF30] bg-[#2D8CFF20] text-accent-zoomFg"
-                  : "border border-[#00AC4730] bg-[#00AC4720] text-accent-meetFg"
-              }`}
-            >
-              <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
-                <path
-                  d="M10 2H14V6"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path d="M14 2L8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-                <path
-                  d="M6 3H3V13H13V10"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-              {meetLabel}に参加
-            </a>
-          </div>
-        )}
-
-        {event.hasAttachments && (
-          <div className="px-5 pb-2">
-            <div className="flex items-center gap-1.5 rounded-[5px] bg-bg-elevated px-2.5 py-[5px] font-jp text-[11px] text-fg-muted">
-              <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
-                <path
-                  d="M9 2H4V14H12V5L9 2Z"
-                  stroke="#52525b"
-                  strokeWidth="1.2"
-                  strokeLinejoin="round"
-                />
-                <path d="M9 2V5H12" stroke="#52525b" strokeWidth="1.2" strokeLinejoin="round" />
-              </svg>
-              添付資料あり
+        {!editing ? (
+          <>
+            <div className="px-5 pb-3 pt-2">
+              <div className="mb-2 flex items-center gap-2">
+                {proj && <div className="h-2 w-2 rounded-full" style={{ background: evColor }} />}
+                {proj && <span className="font-jp text-[10px] text-fg-subtle">{proj.name}</span>}
+                <span className="text-[10px] tabular-nums text-fg-weak">
+                  {formatClock(event.startTime)}–{formatClock(event.endTime)} (
+                  {fmtDuration(duration)})
+                </span>
+                {isGoogleCalendar && <GoogleCalendarBadge size="md" />}
+                <div className="flex-1" />
+                {canDelete ? (
+                  <button
+                    type="button"
+                    onClick={handleDelete}
+                    disabled={pending}
+                    className="rounded-[4px] border border-accent-red/40 bg-transparent px-2.5 py-[3px] font-jp text-[10px] text-accent-red disabled:opacity-60"
+                  >
+                    削除
+                  </button>
+                ) : null}
+                {canEdit ? (
+                  <button
+                    type="button"
+                    onClick={startEdit}
+                    disabled={pending}
+                    className="rounded-[4px] border border-bg-divider bg-transparent px-2.5 py-[3px] font-jp text-[10px] text-fg-subtle disabled:opacity-60"
+                  >
+                    編集
+                  </button>
+                ) : null}
+              </div>
+              <h2 className="m-0 font-jp text-[16px] font-bold leading-[1.4] text-fg-strong">
+                {event.title}
+              </h2>
             </div>
-          </div>
-        )}
 
-        {canEditProject && (
-          <div className="px-5 pb-2">
-            <div className="flex items-center gap-2">
-              <span className="font-jp text-[10px] text-fg-weak">プロジェクト</span>
-              {editingProject ? (
-                <select
-                  autoFocus
-                  value={event.projectId ?? ""}
-                  onChange={(e) => {
-                    const next = e.target.value === "" ? null : e.target.value;
-                    onChangeProject!(event.id, next);
-                    setEditingProject(false);
-                  }}
-                  onBlur={() => setEditingProject(false)}
-                  className="flex-1 rounded border border-bg-divider bg-bg-elevated px-2 py-1 text-[11px] text-fg-default outline-none focus:border-accent-blue"
+            {event.meetUrl && (
+              <div className="px-5 pb-2">
+                <a
+                  href={event.meetUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 font-jp text-[11px] no-underline ${
+                    isZoom
+                      ? "border border-[#2D8CFF30] bg-[#2D8CFF20] text-accent-zoomFg"
+                      : "border border-[#00AC4730] bg-[#00AC4720] text-accent-meetFg"
+                  }`}
                 >
-                  <option value="">なし</option>
-                  {projects.map((p) => (
-                    <option key={p.id} value={p.id}>
-                      {p.name}
-                    </option>
-                  ))}
-                </select>
+                  <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+                    <path
+                      d="M10 2H14V6"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                    <path
+                      d="M14 2L8 8"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                    />
+                    <path
+                      d="M6 3H3V13H13V10"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                  {meetLabel}に参加
+                </a>
+              </div>
+            )}
+
+            {event.hasAttachments && (
+              <div className="px-5 pb-2">
+                <div className="flex items-center gap-1.5 rounded-[5px] bg-bg-elevated px-2.5 py-[5px] font-jp text-[11px] text-fg-muted">
+                  <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+                    <path
+                      d="M9 2H4V14H12V5L9 2Z"
+                      stroke="#52525b"
+                      strokeWidth="1.2"
+                      strokeLinejoin="round"
+                    />
+                    <path d="M9 2V5H12" stroke="#52525b" strokeWidth="1.2" strokeLinejoin="round" />
+                  </svg>
+                  添付資料あり
+                </div>
+              </div>
+            )}
+
+            {canEditProject && (
+              <div className="px-5 pb-2">
+                <div className="flex items-center gap-2">
+                  <span className="font-jp text-[10px] text-fg-weak">プロジェクト</span>
+                  {editingProject ? (
+                    <select
+                      autoFocus
+                      value={event.projectId ?? ""}
+                      onChange={(e) => {
+                        const next = e.target.value === "" ? null : e.target.value;
+                        onChangeProject!(event.id, next);
+                        setEditingProject(false);
+                      }}
+                      onBlur={() => setEditingProject(false)}
+                      className="flex-1 rounded border border-bg-divider bg-bg-elevated px-2 py-1 text-[11px] text-fg-default outline-none focus:border-accent-blue"
+                    >
+                      <option value="">なし</option>
+                      {projects.map((p) => (
+                        <option key={p.id} value={p.id}>
+                          {p.name}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => setEditingProject(true)}
+                      className="cursor-pointer rounded-[4px] border border-bg-divider bg-transparent px-2 py-[3px] font-jp text-[10px] text-fg-subtle"
+                    >
+                      {proj ? proj.name : "未設定"} を変更
+                    </button>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {error ? (
+              <div className="px-5 pb-2">
+                <div
+                  role="alert"
+                  className="rounded bg-[#ef444420] px-2 py-1.5 text-[11px] text-accent-red"
+                >
+                  {error}
+                </div>
+              </div>
+            ) : null}
+
+            <div className="mx-5 h-px bg-bg-border" />
+
+            <div className="flex-1 overflow-auto px-5 pb-6 pt-3">
+              {event.description ? (
+                <div>{renderMarkdown(event.description)}</div>
               ) : (
-                <button
-                  type="button"
-                  onClick={() => setEditingProject(true)}
-                  className="cursor-pointer rounded-[4px] border border-bg-divider bg-transparent px-2 py-[3px] font-jp text-[10px] text-fg-subtle"
-                >
-                  {proj ? proj.name : "未設定"} を変更
-                </button>
+                <div className="py-5 text-center font-jp text-[12px] italic text-fg-faint">
+                  詳細なし
+                </div>
+              )}
+              {isGoogleCalendar && (
+                <div className="mt-4 font-jp text-[10px] leading-[1.6] text-fg-faint">
+                  Google Calendar で編集した内容は次回同期で反映されます
+                </div>
               )}
             </div>
-          </div>
+          </>
+        ) : (
+          <form onSubmit={submitEdit} className="flex flex-col gap-3 px-5 pb-6 pt-2">
+            <label className="flex flex-col gap-1">
+              <span className="font-jp text-[10px] text-fg-weak">タイトル</span>
+              <input
+                type="text"
+                value={draftTitle}
+                onChange={(e) => setDraftTitle(e.target.value)}
+                autoFocus
+                className="rounded border border-bg-divider bg-bg-elevated px-3 py-2 text-[13px] text-fg-default outline-none focus:border-accent-blue"
+              />
+            </label>
+
+            <div className="flex gap-2">
+              <label className="flex flex-1 flex-col gap-1">
+                <span className="font-jp text-[10px] text-fg-weak">開始</span>
+                <input
+                  type="datetime-local"
+                  value={draftStart}
+                  onChange={(e) => setDraftStart(e.target.value)}
+                  className="rounded border border-bg-divider bg-bg-elevated px-3 py-2 text-[13px] text-fg-default outline-none focus:border-accent-blue"
+                />
+              </label>
+              <label className="flex flex-1 flex-col gap-1">
+                <span className="font-jp text-[10px] text-fg-weak">終了</span>
+                <input
+                  type="datetime-local"
+                  value={draftEnd}
+                  onChange={(e) => setDraftEnd(e.target.value)}
+                  className="rounded border border-bg-divider bg-bg-elevated px-3 py-2 text-[13px] text-fg-default outline-none focus:border-accent-blue"
+                />
+              </label>
+            </div>
+
+            <label className="flex flex-col gap-1">
+              <span className="font-jp text-[10px] text-fg-weak">プロジェクト (任意)</span>
+              <select
+                value={draftProjectId}
+                onChange={(e) => setDraftProjectId(e.target.value)}
+                className="rounded border border-bg-divider bg-bg-elevated px-3 py-2 text-[13px] text-fg-default outline-none focus:border-accent-blue"
+              >
+                <option value="">なし</option>
+                {projects.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="flex flex-col gap-1">
+              <span className="font-jp text-[10px] text-fg-weak">会議URL (任意)</span>
+              <input
+                type="url"
+                value={draftMeetUrl}
+                onChange={(e) => setDraftMeetUrl(e.target.value)}
+                className="rounded border border-bg-divider bg-bg-elevated px-3 py-2 text-[13px] text-fg-default outline-none focus:border-accent-blue"
+                placeholder="https://meet.google.com/..."
+              />
+            </label>
+
+            <label className="flex flex-col gap-1">
+              <span className="font-jp text-[10px] text-fg-weak">本文 (任意, Markdown)</span>
+              <textarea
+                value={draftBody}
+                onChange={(e) => setDraftBody(e.target.value)}
+                className="min-h-[120px] resize-y rounded border border-bg-divider bg-bg-elevated p-3 font-mono text-[12px] leading-[1.6] text-fg-default outline-none focus:border-accent-blue"
+                placeholder="Markdownで詳細を入力..."
+              />
+            </label>
+
+            {error ? (
+              <div
+                role="alert"
+                className="rounded bg-[#ef444420] px-2 py-1.5 text-[11px] text-accent-red"
+              >
+                {error}
+              </div>
+            ) : null}
+
+            <div className="mt-1 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={cancelEdit}
+                className="rounded border border-bg-divider bg-transparent px-3 py-1.5 font-jp text-[11px] text-fg-subtle"
+              >
+                キャンセル
+              </button>
+              <button
+                type="submit"
+                disabled={pending}
+                className="rounded bg-accent-blue px-4 py-1.5 font-jp text-[11px] font-semibold text-fg-invert disabled:opacity-60"
+              >
+                {pending ? "保存中..." : "保存"}
+              </button>
+            </div>
+          </form>
         )}
-
-        <div className="mx-5 h-px bg-bg-border" />
-
-        <div className="flex-1 overflow-auto px-5 pb-6 pt-3">
-          {event.description ? (
-            <div>{renderMarkdown(event.description)}</div>
-          ) : (
-            <div className="py-5 text-center font-jp text-[12px] italic text-fg-faint">
-              詳細なし
-            </div>
-          )}
-          {isGoogleCalendar && (
-            <div className="mt-4 font-jp text-[10px] leading-[1.6] text-fg-faint">
-              Google Calendar で編集した内容は次回同期で反映されます
-            </div>
-          )}
-        </div>
       </div>
     </div>
   );

--- a/src/shared/lib/time.test.ts
+++ b/src/shared/lib/time.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "vitest";
-import { formatDate, formatRelativeTime, fmtDuration, fmtMin, timeToMin } from "./time";
+import {
+  formatDate,
+  formatRelativeTime,
+  fmtDuration,
+  fmtMin,
+  timeToMin,
+  toDateTimeLocalInput,
+} from "./time";
 
 describe("formatDate", () => {
   test('"YYYY-MM-DD" を "M/D (曜)" 形式に整形する', () => {
@@ -74,5 +81,19 @@ describe("formatRelativeTime", () => {
   test("2日以上先は「M/D HH:MM」", () => {
     expect(formatRelativeTime("2026-04-15T10:00:00", now)).toBe("4/15 10:00");
     expect(formatRelativeTime("2026-05-02T18:30:00", now)).toBe("5/2 18:30");
+  });
+});
+
+describe("toDateTimeLocalInput", () => {
+  test("ISO 8601 (tz なし) を datetime-local の YYYY-MM-DDTHH:MM 形式で返す", () => {
+    expect(toDateTimeLocalInput("2026-04-11T09:05:00")).toBe("2026-04-11T09:05");
+  });
+
+  test("月 / 日 / 時 / 分は 2 桁ゼロ埋め", () => {
+    expect(toDateTimeLocalInput("2026-01-02T03:04:00")).toBe("2026-01-02T03:04");
+  });
+
+  test("秒は落とす (datetime-local は分単位)", () => {
+    expect(toDateTimeLocalInput("2026-04-11T10:00:45")).toBe("2026-04-11T10:00");
   });
 });

--- a/src/shared/lib/time.ts
+++ b/src/shared/lib/time.ts
@@ -22,6 +22,20 @@ export function formatClock(iso: string): string {
   return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
 }
 
+/**
+ * ISO 8601 文字列を `<input type="datetime-local">` の value 形式 (`YYYY-MM-DDTHH:MM`)
+ * にローカル時刻で整形する。タイムゾーン情報は落ちる (input は tz-naive)。
+ */
+export function toDateTimeLocalInput(iso: string): string {
+  const d = new Date(iso);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mi = String(d.getMinutes()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}T${hh}:${mi}`;
+}
+
 /** ローカル時刻の今日を "YYYY-MM-DD" で返す。 */
 export function todayIso(): string {
   const d = new Date();


### PR DESCRIPTION
## 概要 (What)

`EventDetailPanel` に manual イベントの編集フォーム（title / start_time / end_time / project_id / meet_url / description）と削除ボタンを追加。Phase 2 で片肺だった manual イベント CRUD を Phase 3 着手前に揃える。

## 関連 Issue

Closes #76

## 背景 (Why)

[ADR 0010](../blob/main/docs/adr/0010-google-calendar-event-edit-scope.md) で `google_calendar` イベントは Google 側属性 read-only / 削除不可と決め、`source` で責務を分けた。一方 manual 側は「Phase 1 から挙動を変えない（全フィールド編集可）」と書きつつ、`EventDetailPanel` に編集 / 削除 UI が無く、AddPanel から作った後は UI で触れない状態だった。Phase 3（行動データ学習）に進む前に Phase 2 の取りこぼしを潰す。

## Before → After (概念・フロー・メンタルモデル)

**Before:**

- mental model: 「manual イベントは作るだけ。間違えたら DB を直接触るしかない」
- detail panel は `<div>`（role なし）で e2e から scope できず、削除ボタン不在の検証は「画面全体の『削除』ボタン件数 === 0」で代替していた

**After:**

- `EventDetailPanel` が view モード ↔ edit モードを切り替える。manual のみ全フィールド編集 / 削除可、google_calendar は ADR 0010 通り read-only / 削除不可で固定（`canEdit = isManual && !!onUpdate` / `canDelete = isManual && !!onDelete` でガード、Supabase Gateway 側でも `source` を見て二重防衛）
- mental model: 「manual の編集は detail panel から。GCal は Google 側で直して同期で取り込む」
- パネルが `role="dialog"` + `aria-label="イベント詳細"` を持つようになり、e2e は dialog scope に閉じてリグレ検出できる（`kozutsumi-frontend-a11y` skill 準拠）

## 追加したテスト (How verified)

- [x] **EventDetailPanel.test.tsx**: 編集フォーム初期化 / バリデーション（タイトル必須・終了 > 開始）/ 保存 patch 整合 / キャンセル / `onUpdate` reject 時のエラー表示 / 削除 confirm 分岐 / GCal で edit / delete UI が出ない（+ 19 件）
- [x] **time.test.ts**: `toDateTimeLocalInput` ヘルパー（+ 3 件）
- [x] **e2e `project-event-crud.spec.ts`**: manual の create → 全フィールド edit → DB 反映 / 削除 → 行消滅 / 確認ダイアログ cancel → 行残留（+ 3 ケース）
- [x] **e2e `gcal-event-readonly.spec.ts`**: dialog scope に絞って「編集」「削除」ボタンが GCal では出ないことを確認するリグレ（既存ケースを scope 化 + 編集ボタン非表示の assert 追加）
- [x] ローカル: typecheck / lint / format / unit 245/245 pass。e2e は Docker / 本ホストの local Supabase 不在のため CI で検証

## このPRの範囲外 (Out of scope)

- 繰り返しイベント / 複数日イベントの分割表示
- イベントの依存関係編集（タスク → イベントは別 UI で実装済み、本 issue の非スコープ）
- 削除時の `action_log` 記録: issue body の「要確認」項目について、イベントは行動データ対象外（vision.md の差別化はタスク行動の蓄積）と判断し記録しない

https://claude.ai/code/session_01RFMABGasHdnSF2MgUGdBbG