### PR TITLE
test(e2e): AddPanel イベントタブ → DayTimeline 表示を semantic locator で踏む

### DIFF
--- a/e2e/event-day-timeline-render.spec.ts
+++ b/e2e/event-day-timeline-render.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "./fixtures";
+
+/**
+ * Issue #77:
+ *   AddPanel「イベント」タブから作った manual イベントが DayTimeline に
+ *   描画されることを semantic locator で踏む。
+ *
+ * `project-event-crud.spec.ts` は DB (events 行) への insert 整合を見る spec で、
+ * UI 表示までは検証していない。ここでは UI 表示の責務だけに絞る (DB assert は
+ * 重複させない)。
+ *
+ * DayTimeline は「今日」のローカル日付のイベントしか描画しないので、開始日付は
+ * 実行日に揃える必要がある。
+ *
+ * semantic 構造 (kozutsumi-frontend-a11y skill):
+ *   - DayTimeline 全体: <section aria-label="本日のタイムライン"> → role="region"
+ *   - EventCard 群:     <ul role="list" aria-label="本日のイベント"> / <li>
+ */
+test.describe("AddPanel イベントタブ → DayTimeline 表示 (Issue #77)", () => {
+  test("manual event を作ると DayTimeline の listitem として表示される", async ({
+    signedInPageWithProject: page,
+    projectName,
+  }) => {
+    const eventTitle = "E2E DayTimeline 表示確認 MTG";
+    const todayLocal = todayDateStr();
+    const startLocal = `${todayLocal}T13:00`;
+    const endLocal = `${todayLocal}T14:30`;
+
+    // --- AddPanel イベントタブから 1 件作る --------------------------------
+    await page.getByRole("button", { name: "新規追加" }).click();
+    const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+    await addDialog.getByRole("tab", { name: "イベント" }).click();
+    await addDialog.getByLabel("タイトル").fill(eventTitle);
+    await addDialog.getByLabel("開始").fill(startLocal);
+    await addDialog.getByLabel("終了").fill(endLocal);
+    await addDialog.getByLabel("プロジェクト (任意)").selectOption({ label: projectName });
+    await addDialog.getByRole("button", { name: "追加" }).click();
+    await expect(addDialog).toHaveCount(0);
+
+    // --- DayTimeline 配下で listitem として描画されている --------------------
+    // region scope で他の list (TreeView の凡例 / 履歴) と衝突しないように絞る。
+    const timeline = page.getByRole("region", { name: "本日のタイムライン" });
+    await expect(timeline).toBeVisible();
+
+    const eventItem = timeline.getByRole("listitem").filter({ hasText: eventTitle });
+    await expect(eventItem).toHaveCount(1);
+    await expect(eventItem).toBeVisible();
+
+    // --- EventCard 内の時刻レンジが描画される -------------------------------
+    // EventCard.tsx は formatClock で "13:00–14:30" の形で表示する (en dash)。
+    // 開始時刻 / 終了時刻が正しく時間帯ラベルに反映されることを listitem スコープで
+    // 確認する (locator が取りやすいので DB assert に委ねず UI 側で踏む)。
+    await expect(eventItem).toContainText("13:00");
+    await expect(eventItem).toContainText("14:30");
+  });
+});
+
+/**
+ * DayTimeline は「今日」のローカル日付のイベントしか描画しないので、開始日付を
+ * 実行日に揃える。`project-event-crud.spec.ts` の `todayDateStr` と同じ実装。
+ */
+function todayDateStr(): string {
+  const d = new Date();
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}

--- a/e2e/gcal-event-readonly.spec.ts
+++ b/e2e/gcal-event-readonly.spec.ts
@@ -50,8 +50,12 @@ test.describe("google_calendar イベントの編集制約 (ADR 0010)", () => {
     await page.reload();
 
     // --- DayTimeline の EventCard をクリックして詳細を開く -------------------
-    // EventCard は role を持たない div だが、表示テキストに event.title が含まれる。
-    await page.getByText(eventTitle).first().click();
+    // Issue #77 で立てた a11y 構造 (region 配下の listitem) で scope する。
+    // 上部の "<title>中" インジケータ (`isNow` 時の <span>) と衝突しないよう
+    // listitem に絞る (`getByText(...).first()` だと CI 実行時刻が event 範囲に
+    // 被ったとき indicator span を拾って flake する)。
+    const timeline = page.getByRole("region", { name: "本日のタイムライン" });
+    await timeline.getByRole("listitem").filter({ hasText: eventTitle }).click();
 
     // EventDetailPanel が開く (Issue #76 で role="dialog" + aria-label="イベント詳細"
     // を付与済み)。GCal 由来であることを示すバッジ + 由来説明文の存在を踏む。
@@ -126,7 +130,9 @@ test.describe("google_calendar イベントの編集制約 (ADR 0010)", () => {
     await page.reload();
 
     // --- DayTimeline → 詳細を開く -------------------------------------------
-    await page.getByText(eventTitle).first().click();
+    // listitem scope で indicator span (`isNow` 時の `<title>中`) との衝突を回避。
+    const timeline = page.getByRole("region", { name: "本日のタイムライン" });
+    await timeline.getByRole("listitem").filter({ hasText: eventTitle }).click();
     await expect(page.getByTestId("google-calendar-badge").first()).toBeVisible();
 
     // --- 「未設定 を変更」 → select 表示 → プロジェクトを選ぶ ----------------

--- a/e2e/project-event-crud.spec.ts
+++ b/e2e/project-event-crud.spec.ts
@@ -149,7 +149,12 @@ test.describe("manual イベント編集 (events 行整合, Issue #76)", () => {
     expect(created.description).toBe("");
 
     // --- open EventDetailPanel: DayTimeline 上の event card をクリック ---
-    await page.getByText(initialTitle).first().click();
+    // region scope の listitem で取る (Issue #77 で立てた a11y 構造)。
+    // 上部の "<title>中" インジケータ (`isNow` 時の <span>) と衝突しないように
+    // listitem に絞って取る (`getByText(...).first()` だと CI 実行時刻が
+    // event 範囲に被ったとき indicator span を拾って flake する)。
+    const timeline = page.getByRole("region", { name: "本日のタイムライン" });
+    await timeline.getByRole("listitem").filter({ hasText: initialTitle }).click();
     const detailDialog = page.getByRole("dialog", { name: "イベント詳細" });
     await expect(detailDialog).toBeVisible();
 
@@ -210,7 +215,9 @@ test.describe("manual イベント削除 (events 行消滅, Issue #76)", () => {
     const created = await getEventByTitle(admin, userId, eventTitle);
 
     // --- open detail → 削除 (confirm を accept) ---
-    await page.getByText(eventTitle).first().click();
+    // listitem scope で indicator span (`isNow` 時の `<title>中`) との衝突を回避。
+    const timeline = page.getByRole("region", { name: "本日のタイムライン" });
+    await timeline.getByRole("listitem").filter({ hasText: eventTitle }).click();
     const detailDialog = page.getByRole("dialog", { name: "イベント詳細" });
     await expect(detailDialog).toBeVisible();
 
@@ -252,7 +259,9 @@ test.describe("manual イベント削除 (events 行消滅, Issue #76)", () => {
 
     const created = await getEventByTitle(admin, userId, eventTitle);
 
-    await page.getByText(eventTitle).first().click();
+    // listitem scope で indicator span (`isNow` 時の `<title>中`) との衝突を回避。
+    const timeline = page.getByRole("region", { name: "本日のタイムライン" });
+    await timeline.getByRole("listitem").filter({ hasText: eventTitle }).click();
     const detailDialog = page.getByRole("dialog", { name: "イベント詳細" });
     await expect(detailDialog).toBeVisible();
 

--- a/src/features/day-timeline/DayTimeline.tsx
+++ b/src/features/day-timeline/DayTimeline.tsx
@@ -26,9 +26,12 @@ export function DayTimeline({ events, nowMin, today, onOpenEvent }: DayTimelineP
   const firstFutureIdx = sortedEvents.findIndex((e) => minutesOfDay(e.startTime) > nowMin);
 
   return (
-    <div className="px-4 pb-1 pt-3.5">
+    <section aria-label="本日のタイムライン" className="px-4 pb-1 pt-3.5">
       <div className="mb-2.5 flex items-baseline gap-2">
-        <div className="h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-accent-green" />
+        <div
+          aria-hidden="true"
+          className="h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-accent-green"
+        />
         <span className="font-jp text-[11px] text-fg-subtle">{formatDate(today)}</span>
         <span className="text-[11px] tabular-nums text-fg-emphasized">{fmtMin(nowMin)}</span>
         {currentSlot?.type === "free" && (
@@ -43,17 +46,22 @@ export function DayTimeline({ events, nowMin, today, onOpenEvent }: DayTimelineP
 
       <TimelineBar slots={slots} nowMin={nowMin} dayStart={dayStart} dayEnd={dayEnd} />
 
-      <div className="mt-2 flex flex-col gap-1">
+      <ul
+        role="list"
+        aria-label="本日のイベント"
+        className="m-0 mt-2 flex list-none flex-col gap-1 p-0"
+      >
         {sortedEvents.map((ev, i) => (
-          <EventCard
-            key={ev.id}
-            event={ev}
-            nowMin={nowMin}
-            isNextCandidate={i === firstFutureIdx}
-            onClick={() => onOpenEvent(ev.id)}
-          />
+          <li key={ev.id}>
+            <EventCard
+              event={ev}
+              nowMin={nowMin}
+              isNextCandidate={i === firstFutureIdx}
+              onClick={() => onOpenEvent(ev.id)}
+            />
+          </li>
         ))}
-      </div>
-    </div>
+      </ul>
+    </section>
   );
 }


### PR DESCRIPTION
## 概要 (What)

AddPanel「イベント」タブから作成した manual イベントが DayTimeline に描画されることを e2e で保証する。
DayTimeline 側に role / aria が立っていなかったので a11y skill のとおり構造を立てた上で、新規 spec で UI 表示の責務を踏む。

## 関連 Issue

Closes #77

## 背景 (Why)

既存の `project-event-crud.spec.ts` は `events` 行の DB integrity だけを見ており、UI 表示までは未検証だった。
DayTimeline は `<div>` の入れ子で role / aria が無く、`getByRole` で scope できないため semantic locator で書けなかった。
locator が書けない = 構造不足のシグナル（`kozutsumi-frontend-a11y` skill）として扱い、構造側を立て直す。

## Before → After (概念・フロー・メンタルモデル)

**Before:**

- DayTimeline 全体: `<div>`（role なし）
- EventCard 群: `<div>` の縦並び（list 構造なし）
- e2e: `page.getByText(title).first()` のような text-base locator しか取れず、他 UI のテキストと衝突する余地があった

**After:**

- DayTimeline 全体: `<section aria-label="本日のタイムライン">`（= `role=region`）
- EventCard 群: `<ul role="list" aria-label="本日のイベント">` / `<li>`
- 装飾 dot は `aria-hidden`
- e2e: `getByRole("region", { name: "本日のタイムライン" })` 配下で `getByRole("listitem").filter({ hasText })` で scope できる

## 追加したテスト (How verified)

- [x] `e2e/event-day-timeline-render.spec.ts`: AddPanel イベントタブで manual event を作成 → DayTimeline 配下の listitem として描画 + 開始 / 終了時刻ラベル (`13:00` / `14:30`) が EventCard に載ることを確認
- [x] `npm run typecheck` / `npm run test` (unit 245 件) / `npm run lint` / `npm run format:check` 全て pass
- DB 整合は既存 `project-event-crud.spec.ts` 側に任せて重複させない（UI 表示の責務に絞る）

## このPRの範囲外 (Out of scope)

- イベント編集 UI の e2e（Phase 2.2 の別 issue）
- 複数日イベントの分割表示
- 本物の Google Calendar イベントの DayTimeline 表示（`gcal-event-readonly.spec.ts` 側で踏み済み）
- EventCard 自体の `role="button"` 化（クリック動線は `project-event-crud.spec.ts` 側で踏めているので今回は据え置き）


---
_Generated by [Claude Code](https://claude.ai/code/session_015TpFdBPUC4Aev48uDhBNN9)_