### PR TITLE
feat(task): task_category 列 + task_category_changed ACTION_TYPE (P3-2, #87)

### DIFF
--- a/src/entities/action-log/logger.test.ts
+++ b/src/entities/action-log/logger.test.ts
@@ -165,6 +165,7 @@ describe("ACTION_TYPES", () => {
       TASK_REORDERED: "task_reordered",
       TASK_DELETED: "task_deleted",
       TASK_TITLE_CHANGED: "task_title_changed",
+      TASK_CATEGORY_CHANGED: "task_category_changed",
       TASK_DEPENDENCY_SET: "task_dependency_set",
       TASK_DEPENDENCY_CLEARED: "task_dependency_cleared",
       INTERRUPTION_PUSHED: "interruption_pushed",
@@ -172,6 +173,51 @@ describe("ACTION_TYPES", () => {
       STACK_PROPOSED: "stack_proposed",
       STACK_PROPOSAL_ACCEPTED: "stack_proposal_accepted",
       CALENDAR_SYNCED: "calendar_synced",
+    });
+  });
+});
+
+describe("log(task_category_changed)", () => {
+  beforeEach(() => {
+    clearLog();
+    __resetLoggerClientForTest();
+    insertMock.mockClear();
+    fromMock.mockClear();
+    getUserMock.mockClear();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("AI 初期ラベル無し (from=null) → user 選択 (to) を insert する", async () => {
+    log(ACTION_TYPES.TASK_CATEGORY_CHANGED, {
+      task_id: "t1",
+      from: null,
+      to: "coding",
+    });
+    await flushMicrotasks();
+    expect(insertMock).toHaveBeenCalledWith({
+      user_id: "user-1",
+      action_type: "task_category_changed",
+      task_id: "t1",
+      metadata: { task_id: "t1", from: null, to: "coding" },
+    });
+  });
+
+  test("AI ラベル → user override (from / to あり) を insert する", async () => {
+    log(ACTION_TYPES.TASK_CATEGORY_CHANGED, {
+      task_id: "t1",
+      from: "doc",
+      to: "research",
+    });
+    await flushMicrotasks();
+    expect(insertMock).toHaveBeenCalledWith({
+      user_id: "user-1",
+      action_type: "task_category_changed",
+      task_id: "t1",
+      metadata: { task_id: "t1", from: "doc", to: "research" },
     });
   });
 });

--- a/src/entities/action-log/logger.ts
+++ b/src/entities/action-log/logger.ts
@@ -24,6 +24,7 @@ export const ACTION_TYPES = Object.freeze({
   TASK_REORDERED: "task_reordered",
   TASK_DELETED: "task_deleted",
   TASK_TITLE_CHANGED: "task_title_changed",
+  TASK_CATEGORY_CHANGED: "task_category_changed",
   TASK_DEPENDENCY_SET: "task_dependency_set",
   TASK_DEPENDENCY_CLEARED: "task_dependency_cleared",
   INTERRUPTION_PUSHED: "interruption_pushed",

--- a/src/entities/action-log/types.ts
+++ b/src/entities/action-log/types.ts
@@ -6,6 +6,7 @@ export type ActionType =
   | "task_reordered"
   | "task_deleted"
   | "task_title_changed"
+  | "task_category_changed"
   | "task_dependency_set"
   | "task_dependency_cleared"
   | "interruption_pushed"
@@ -38,6 +39,14 @@ export type ActionMetadataMap = {
     task_id: string;
     old_title: string;
     new_title: string;
+  };
+  // Phase 3 #87 / ADR 0015: 人間が AI 初期ラベル / 既存値を override した時に記録。
+  // Phase 4 のラベリング精度改善ループの暗黙フィードバック源。
+  // from は AI ラベリング失敗 / 既存タスクで null になり得る。to は user 選択値で必ず存在する。
+  task_category_changed: {
+    task_id: string;
+    from: string | null;
+    to: string;
   };
   // Phase 2 #53: 依存イベントの設定 / 解除。Phase 4 で「依存設定が着手順に効いたか」の分析データに使う。
   task_dependency_set: {

--- a/src/entities/task/gateway.ts
+++ b/src/entities/task/gateway.ts
@@ -1,4 +1,4 @@
-import type { Task } from "./types";
+import type { Task, TaskCategory } from "./types";
 
 export type CreateTaskInput = {
   projectId: string;
@@ -9,6 +9,7 @@ export type CreateTaskInput = {
   dependsOnEventId?: string | null;
   isInterruption?: boolean;
   parentTaskId?: string | null;
+  taskCategory?: TaskCategory | null;
 };
 
 export type UpdateTaskInput = {
@@ -20,6 +21,7 @@ export type UpdateTaskInput = {
   stackOrder?: number | null;
   dependsOnEventId?: string | null;
   isInterruption?: boolean;
+  taskCategory?: TaskCategory | null;
   completedAt?: string | null;
 };
 

--- a/src/entities/task/supabase-gateway.test.ts
+++ b/src/entities/task/supabase-gateway.test.ts
@@ -1,0 +1,153 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { Database, Tables } from "@/shared/types/database";
+
+import { SupabaseTaskGateway } from "./supabase-gateway";
+
+/**
+ * Gateway 経由で task_category が読み書きできることを保証する (#87 完了条件)。
+ *
+ * SupabaseTaskGateway はクエリビルダ薄ラッパーなので、
+ * - fromRow が `task_category` を Task.taskCategory に写す
+ * - create が `task_category` を payload に乗せる
+ * - update が patch.taskCategory を `task_category` に乗せる
+ * の 3 点だけを mock で踏んで担保する。
+ *
+ * RLS / CHECK 制約の検証は migration 側 (raw SQL) の責務。ここでは型 / mapping のみ。
+ */
+
+function makeRow(overrides: Partial<Tables<"tasks">> = {}): Tables<"tasks"> {
+  return {
+    id: "t1",
+    user_id: "u1",
+    project_id: "p1",
+    title: "x",
+    body: "",
+    estimated_minutes: null,
+    status: "idle",
+    stack_order: null,
+    depends_on_event_id: null,
+    is_interruption: false,
+    parent_task_id: null,
+    task_category: null,
+    created_at: "2026-04-27T00:00:00.000Z",
+    completed_at: null,
+    ...overrides,
+  };
+}
+
+type MockChain = {
+  insert: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  select: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  single: ReturnType<typeof vi.fn>;
+  from: ReturnType<typeof vi.fn>;
+};
+
+function makeSupabase(returnedRow: Tables<"tasks">): {
+  client: SupabaseClient<Database>;
+  chain: MockChain;
+} {
+  const single = vi.fn(async () => ({ data: returnedRow, error: null }));
+  const eq = vi.fn(() => ({ select, single }));
+  const select = vi.fn(() => ({ single, eq }));
+  const insert = vi.fn(() => ({ select }));
+  const update = vi.fn(() => ({ eq }));
+  const from = vi.fn(() => ({ insert, update, select }));
+  const chain: MockChain = { insert, update, select, eq, single, from };
+
+  const client = {
+    auth: {
+      getUser: vi.fn(async () => ({
+        data: { user: { id: "u1" } },
+        error: null,
+      })),
+    },
+    from,
+  } as unknown as SupabaseClient<Database>;
+
+  return { client, chain };
+}
+
+describe("SupabaseTaskGateway: task_category mapping", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  test("create: taskCategory 指定値が payload.task_category に乗る", async () => {
+    const { client, chain } = makeSupabase(makeRow({ task_category: "coding" }));
+    const gateway = new SupabaseTaskGateway(client);
+
+    const task = await gateway.create({
+      projectId: "p1",
+      title: "x",
+      taskCategory: "coding",
+    });
+
+    expect(chain.insert).toHaveBeenCalledWith(expect.objectContaining({ task_category: "coding" }));
+    expect(task.taskCategory).toBe("coding");
+  });
+
+  test("create: taskCategory 未指定なら null で insert される (AI ラベリング失敗を許容、ADR 0015)", async () => {
+    const { client, chain } = makeSupabase(makeRow({ task_category: null }));
+    const gateway = new SupabaseTaskGateway(client);
+
+    const task = await gateway.create({ projectId: "p1", title: "x" });
+
+    expect(chain.insert).toHaveBeenCalledWith(expect.objectContaining({ task_category: null }));
+    expect(task.taskCategory).toBeNull();
+  });
+
+  test("update: taskCategory 明示なら update.task_category に乗る (override)", async () => {
+    const { client, chain } = makeSupabase(makeRow({ task_category: "research" }));
+    const gateway = new SupabaseTaskGateway(client);
+
+    const task = await gateway.update("t1", { taskCategory: "research" });
+
+    expect(chain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ task_category: "research" }),
+    );
+    expect(task.taskCategory).toBe("research");
+  });
+
+  test("update: taskCategory=null も明示的に書ける (override で外す)", async () => {
+    const { client, chain } = makeSupabase(makeRow({ task_category: null }));
+    const gateway = new SupabaseTaskGateway(client);
+
+    await gateway.update("t1", { taskCategory: null });
+
+    expect(chain.update).toHaveBeenCalledWith(expect.objectContaining({ task_category: null }));
+  });
+
+  test("update: taskCategory を patch に含めなければ update に乗らない", async () => {
+    const { client, chain } = makeSupabase(makeRow({ task_category: "doc" }));
+    const gateway = new SupabaseTaskGateway(client);
+
+    await gateway.update("t1", { title: "y" });
+
+    const call = chain.update.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(call).not.toHaveProperty("task_category");
+    expect(call).toHaveProperty("title", "y");
+  });
+
+  test("list: row.task_category が Task.taskCategory に写る", async () => {
+    const { client } = makeSupabase(makeRow({ task_category: "admin" }));
+    // list は order chain を使うので個別に組む
+    const orderInner = vi.fn(async () => ({
+      data: [makeRow({ task_category: "admin" })],
+      error: null,
+    }));
+    const orderOuter = vi.fn(() => ({ order: orderInner }));
+    const select = vi.fn(() => ({ order: orderOuter }));
+    (client.from as ReturnType<typeof vi.fn>).mockReturnValueOnce({ select });
+
+    const gateway = new SupabaseTaskGateway(client);
+    const tasks = await gateway.list();
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]!.taskCategory).toBe("admin");
+  });
+});

--- a/src/entities/task/supabase-gateway.ts
+++ b/src/entities/task/supabase-gateway.ts
@@ -20,6 +20,7 @@ function fromRow(row: Tables<"tasks">): Task {
     dependsOnEventId: row.depends_on_event_id,
     isInterruption: row.is_interruption,
     parentTaskId: row.parent_task_id,
+    taskCategory: row.task_category,
     createdAt: row.created_at,
     completedAt: row.completed_at,
   };
@@ -58,6 +59,7 @@ export class SupabaseTaskGateway implements TaskGateway {
       depends_on_event_id: input.dependsOnEventId ?? null,
       is_interruption: input.isInterruption ?? false,
       parent_task_id: input.parentTaskId ?? null,
+      task_category: input.taskCategory ?? null,
     };
     const { data, error } = await this.supabase.from("tasks").insert(payload).select("*").single();
     if (error) throw error;
@@ -74,6 +76,7 @@ export class SupabaseTaskGateway implements TaskGateway {
     if (patch.stackOrder !== undefined) update.stack_order = patch.stackOrder;
     if (patch.dependsOnEventId !== undefined) update.depends_on_event_id = patch.dependsOnEventId;
     if (patch.isInterruption !== undefined) update.is_interruption = patch.isInterruption;
+    if (patch.taskCategory !== undefined) update.task_category = patch.taskCategory;
     if (patch.completedAt !== undefined) update.completed_at = patch.completedAt;
     const { data, error } = await this.supabase
       .from("tasks")

--- a/src/entities/task/types.ts
+++ b/src/entities/task/types.ts
@@ -1,4 +1,13 @@
+import type { TaskCategoryValue } from "@/shared/types/database";
+
 export type TaskStatus = "idle" | "active" | "paused" | "done";
+
+/**
+ * タスク種別 (ADR 0015 / #87)。
+ * AI が初期ラベル、人間は override で暗黙的フィードバックを残す。
+ * AI ラベリング失敗時 / 既存タスクは null。
+ */
+export type TaskCategory = TaskCategoryValue;
 
 /**
  * DB スキーマ (supabase/migrations/..._initial_schema.sql の tasks) と 1:1 対応。
@@ -16,6 +25,7 @@ export type Task = {
   dependsOnEventId: string | null;
   isInterruption: boolean;
   parentTaskId: string | null;
+  taskCategory: TaskCategory | null;
   createdAt: string;
   completedAt: string | null;
 };

--- a/src/features/task-detail/TaskDetailPanel.test.tsx
+++ b/src/features/task-detail/TaskDetailPanel.test.tsx
@@ -33,6 +33,7 @@ const baseTask: Task = {
   dependsOnEventId: null,
   isInterruption: false,
   parentTaskId: null,
+  taskCategory: null,
   createdAt: "2026-04-11T00:00:00",
   completedAt: null,
 };

--- a/src/features/task-stack/TaskStack.test.tsx
+++ b/src/features/task-stack/TaskStack.test.tsx
@@ -36,6 +36,7 @@ const baseTask: Task = {
   dependsOnEventId: null,
   isInterruption: false,
   parentTaskId: null,
+  taskCategory: null,
   createdAt: "2026-04-11T00:00:00",
   completedAt: null,
 };

--- a/src/features/task-stack/useTaskTimer.test.tsx
+++ b/src/features/task-stack/useTaskTimer.test.tsx
@@ -45,6 +45,7 @@ const baseTask: Task = {
   dependsOnEventId: null,
   isInterruption: false,
   parentTaskId: null,
+  taskCategory: null,
   createdAt: "2026-04-19T09:00:00.000Z",
   completedAt: null,
 };

--- a/src/mocks/tasks.ts
+++ b/src/mocks/tasks.ts
@@ -11,6 +11,7 @@ export function buildInitialTasks(): Task[] {
     status: "idle" as const,
     isInterruption: false,
     parentTaskId: null,
+    taskCategory: null,
     createdAt: now,
     completedAt: null,
   };

--- a/src/shared/types/database.ts
+++ b/src/shared/types/database.ts
@@ -11,6 +11,13 @@
  */
 export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
 
+/**
+ * tasks.task_category の値域 (#87, ADR 0015)。
+ * DB 側は text + CHECK 制約 (supabase/migrations/20260427000000_task_category.sql)。
+ * 値の追加・名称変更は ADR の supersede ではなく migration + ここの更新で行う。
+ */
+export type TaskCategoryValue = "coding" | "doc" | "research" | "admin" | "other";
+
 export type Database = {
   public: {
     Tables: {
@@ -54,6 +61,7 @@ export type Database = {
           depends_on_event_id: string | null;
           is_interruption: boolean;
           parent_task_id: string | null;
+          task_category: TaskCategoryValue | null;
           created_at: string;
           completed_at: string | null;
         };
@@ -69,6 +77,7 @@ export type Database = {
           depends_on_event_id?: string | null;
           is_interruption?: boolean;
           parent_task_id?: string | null;
+          task_category?: TaskCategoryValue | null;
           created_at?: string;
           completed_at?: string | null;
         };
@@ -84,6 +93,7 @@ export type Database = {
           depends_on_event_id?: string | null;
           is_interruption?: boolean;
           parent_task_id?: string | null;
+          task_category?: TaskCategoryValue | null;
           created_at?: string;
           completed_at?: string | null;
         };

--- a/supabase/migrations/20260427000000_task_category.sql
+++ b/supabase/migrations/20260427000000_task_category.sql
@@ -1,0 +1,27 @@
+-- kozutsumi Phase 3 (P3-2, #87): tasks.task_category + task_category_changed ACTION_TYPE
+--
+-- References:
+-- * docs/adr/0015-task-category-ai-first-labeling.md (AI が初期ラベル / 人間は override)
+-- * docs/adr/0001-action-logs-from-phase1.md (action_type は text のまま JSONB で揺らぎ吸収)
+--
+-- 設計判断:
+-- * tasks.task_category は text + CHECK (nullable, default なし)。
+--   - default を置かないのは「AI ラベリング失敗時は null のまま」(ADR 0015 §6) を
+--     成立させるため。Gateway / migration で 0 が紛れ込まない。
+-- * 値域 (`coding` / `doc` / `research` / `admin` / `other`) は ADR 0015 Notes の通り
+--   パラメータ扱い。今後の追加 / 名称変更は本 migration の supersede ではなく、
+--   別 migration で CHECK を貼り直す運用。
+-- * 既存タスクは null で残す (backfill しない)。CHECK は nullable を許容するので問題なし。
+-- * action_logs.action_type には CHECK / enum を貼らない (ADR 0001)。
+--   `task_category_changed` は code 側 (logger.ts ACTION_TYPES) に登録するだけで
+--   raw SQL レベルでは即書ける。ここでは何もしない。
+
+alter table public.tasks
+  add column task_category text;
+
+alter table public.tasks
+  add constraint tasks_task_category_values
+  check (
+    task_category is null
+    or task_category in ('coding', 'doc', 'research', 'admin', 'other')
+  );


### PR DESCRIPTION
## 概要 (What)

`tasks.task_category` 列 (text + CHECK、nullable) と `task_category_changed` ACTION_TYPE を整え、Phase 3 / 4 の見積もり補正・行動パターン分析の入力軸 (タスク種類別) になるデータ層を仕込む。AI 初期ラベル / 人間 override / override は action_log に残す、を成立させる器だけを置く PR (実際の AI ラベリング・override UI・補正エンジンは別 issue)。

## 関連 Issue

Closes #87

## 背景 (Why)

- [ADR 0015](docs/adr/0015-task-category-ai-first-labeling.md) で「AI が初期ラベル / 人間は override / override は `action_log` に残す」を決めた
- `architecture.md` §1.5 の見積もり補正エンジンも §1.6 の行動パターン分析も「タスク種類別の集計」を入力にしている。Phase 3 / 4 のコア機能はタスクに **種類分類軸** が要る
- vision / `architecture.md` §1.7 の暗黙的フィードバック原則 (「承認ステップは挟まない、ユーザーの操作が暗黙的にフィードバックされて精度が上がる」) と整合させるため、override は `action_log` に残して再学習データにする ([ADR 0001](docs/adr/0001-action-logs-from-phase1.md) の延長)

## Before → After (概念・フロー・メンタルモデル)

**Before:**

`tasks` には種類分類軸が無い。Phase 3 / 4 の補正エンジン・行動パターン分析が「タスク種類別」を計算する入力が存在しない状態。

**After:**

```
tasks
  └─ task_category text? (nullable, CHECK in [coding, doc, research, admin, other])
        ├─ AI が create 時に初期ラベル (P3-4 で実装)
        ├─ 人間が override (P3-5 で UI)
        └─ override → action_log に task_category_changed: { task_id, from, to } を記録
              ↑ 暗黙フィードバックの一次データ。Phase 4 のラベリング再学習が読む
```

設計上の固定点:

- **default を置かない**: AI ラベリング失敗時 / 既存タスクは `null` のまま。`null` は補正エンジンが「グループ化対象から外す」で扱える ([ADR 0015](docs/adr/0015-task-category-ai-first-labeling.md) §6 / [ADR 0013](docs/adr/0013-ai-as-augmentation-only.md) augmentation only)
- **値域 (`coding` / `doc` / `research` / `admin` / `other`) は ADR の supersede ではなくパラメータ**: 改訂は別 migration で CHECK を貼り直す運用
- **`action_logs.action_type` には CHECK / enum を貼らない** ([ADR 0001](docs/adr/0001-action-logs-from-phase1.md)): Phase 1 から「text + JSONB metadata で揺らぎ吸収」と決めている。`task_category_changed` は code 側 `ACTION_TYPES` に登録するだけで raw SQL でも即書ける
- **`from` は `null` 許容**: AI ラベル無し / 既存タスクへの初回 override (`from=null → to=coding`) を踏める

## 追加したテスト (How verified)

- [x] `src/entities/task/supabase-gateway.test.ts` — Gateway の `task_category` mapping 6 ケース (create 指定 / create 未指定 → null / update override / update で null に戻す / patch 未指定なら update に乗らない / list で row → Task に写る)
- [x] `src/entities/action-log/logger.test.ts` — `task_category_changed` の metadata 形 2 ケース (`from=null → to`、`from → to`)
- [x] `src/entities/action-log/logger.test.ts` の `ACTION_TYPES` 期待値に `TASK_CATEGORY_CHANGED` を追加
- [x] 既存 mock / fixture (`src/mocks/tasks.ts`、`TaskDetailPanel.test.tsx`、`TaskStack.test.tsx`、`useTaskTimer.test.tsx`) に `taskCategory: null` を補完して型を合わせる
- [x] `npm run typecheck` / `npm run lint` / `npm test` (253 passed) / `npm run format:check` 成功
- [ ] migration の up / down は手元に supabase CLI が無く未実機検証 (SQL は `ALTER TABLE ADD COLUMN` + `ADD CONSTRAINT` の単純構成。merge 前にローカルで `supabase db reset` を 1 度踏む想定)
- [ ] e2e は未実行 (本 PR は UI 変更を含まないので no-op だが CI で踏める)

## リリース前チェックリスト (When / Before merge)

- [x] マイグレーションの適用順を確認した (`20260427000000_task_category.sql`、既存 migration の最後尾に追加)
- [ ] ローカルで `supabase db reset` を踏んで migration が clean に上下することを確認
- [ ] 既存ユーザー (Vercel production) への影響: `tasks.task_category` は nullable + default 無しなので既存行は `null` で残る。破壊的変更なし

## このPRの範囲外 (Out of scope)

- AI による初期ラベリング (P3-4、別 issue)
- override UI (P3-5、別 issue)
- 既存タスクの AI backfill ([ADR 0015](docs/adr/0015-task-category-ai-first-labeling.md) Notes、別 issue)
- 値域の追加 / 名称変更 (運用で別 migration を切る)
- 補正エンジン本体 (P3-9、別 issue)
- `task_category_changed` を踏む Gateway フック (override UI の P3-5 で同時に書く想定)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBxwTqfv4hLQAGBRXVftk4)_