### PR TITLE
feat(ai): /api/ai/decompose + 非同期タスク分解 (P3-6, #91)

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -24,6 +24,7 @@ import { useLazyCalendarSync } from "@/features/sync/useLazyCalendarSync";
 import { TaskDetailPanel } from "@/features/task-detail/TaskDetailPanel";
 import { PauseReasonModal } from "@/features/task-stack/PauseReasonModal";
 import { TaskStack, type TopTimerBinding } from "@/features/task-stack/TaskStack";
+import { triggerDecompose } from "@/features/task-stack/triggerDecompose";
 import { useTaskTimer } from "@/features/task-stack/useTaskTimer";
 import { TreeView } from "@/features/tree-view/TreeView";
 import { UserMenu } from "@/features/user-menu/UserMenu";
@@ -626,7 +627,24 @@ export function AppShell({ initialView, user }: AppShellProps) {
             onCreateTask={async (input) => {
               // stackOrder は末尾に割り当て (pending 件数)
               const stackOrder = pendingTasks.length;
-              await createTaskMutation.mutateAsync({ ...input, stackOrder });
+              const created = await createTaskMutation.mutateAsync({ ...input, stackOrder });
+              // P3-6 / ADR 0017: タスク作成成功後に AI 分解を fire-and-forget で投げる。
+              // server 側でも `decompose_status='decomposing'` に倒すが、UI に分解中 pill を
+              // 即時出すため optimistic に cache を書き換える。AI_ENABLED=false / 失敗時は
+              // server が `none` に戻す (decompose-server の guard 経路)。
+              // 既に invalidateQueries で refetch 中の cache に対しては map で上書き、
+              // refetch 前で entry が無ければ末尾に append する。
+              queryClient.setQueryData<Task[]>(keys.tasks, (prev) => {
+                const list = prev ?? [];
+                const found = list.some((t) => t.id === created.id);
+                const updated = { ...created, decomposeStatus: "decomposing" as const };
+                return found
+                  ? list.map((t) =>
+                      t.id === created.id ? { ...t, decomposeStatus: "decomposing" } : t,
+                    )
+                  : [...list, updated];
+              });
+              triggerDecompose(created.id);
             }}
             onCreateEvent={async (input) => {
               await createEventMutation.mutateAsync(input);

--- a/src/app/api/ai/decompose/route.test.ts
+++ b/src/app/api/ai/decompose/route.test.ts
@@ -1,0 +1,165 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+// withAiRoute の中で require する supabase server client を mock
+vi.mock("@/shared/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+// Gemini SDK を mock (テストでは API key 不要・実通信なし)
+const generateContentMock = vi.fn();
+vi.mock("@google/generative-ai", () => ({
+  GoogleGenerativeAI: function MockGoogleGenerativeAI() {
+    return {
+      getGenerativeModel: () => ({
+        generateContent: generateContentMock,
+      }),
+    };
+  },
+}));
+
+// decomposeTask 本体は別 test で踏むので、ここでは call 検証だけ行う
+const decomposeTaskMock = vi.fn();
+vi.mock("@/entities/task/decompose-server", () => ({
+  decomposeTask: (...args: unknown[]) => decomposeTaskMock(...args),
+}));
+
+import { createClient } from "@/shared/supabase/server";
+
+import { POST } from "./route";
+
+function makeSupabase(session: { user: { id: string } } | null): SupabaseClient {
+  return {
+    auth: {
+      getSession: vi.fn(async () => ({ data: { session }, error: null })),
+    },
+  } as unknown as SupabaseClient;
+}
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/ai/decompose", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+describe("POST /api/ai/decompose", () => {
+  const original = {
+    aiEnabled: process.env.AI_ENABLED,
+    geminiApiKey: process.env.GEMINI_API_KEY,
+  };
+
+  beforeEach(() => {
+    delete process.env.AI_ENABLED;
+    delete process.env.GEMINI_API_KEY;
+    vi.mocked(createClient).mockReset();
+    decomposeTaskMock.mockReset();
+    generateContentMock.mockReset();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (original.aiEnabled === undefined) delete process.env.AI_ENABLED;
+    else process.env.AI_ENABLED = original.aiEnabled;
+    if (original.geminiApiKey === undefined) delete process.env.GEMINI_API_KEY;
+    else process.env.GEMINI_API_KEY = original.geminiApiKey;
+    vi.restoreAllMocks();
+  });
+
+  test("AI_ENABLED=false → 200 skipped, decomposeTask は呼ばれない (e2e バイパス、ADR 0014)", async () => {
+    const response = await POST(makeRequest({ task_id: "t1" }));
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { skipped: boolean; reason: string };
+    expect(body).toEqual({ skipped: true, reason: "ai_disabled" });
+    expect(decomposeTaskMock).not.toHaveBeenCalled();
+  });
+
+  test("未ログイン → 401 unauthorized", async () => {
+    process.env.AI_ENABLED = "true";
+    process.env.GEMINI_API_KEY = "k";
+    vi.mocked(createClient).mockResolvedValue(makeSupabase(null));
+
+    const response = await POST(makeRequest({ task_id: "t1" }));
+
+    expect(response.status).toBe(401);
+    expect(decomposeTaskMock).not.toHaveBeenCalled();
+  });
+
+  test("body に task_id が無い → ok:false で error を返す (200 で握る、fire-and-forget client は無視)", async () => {
+    process.env.AI_ENABLED = "true";
+    process.env.GEMINI_API_KEY = "k";
+    vi.mocked(createClient).mockResolvedValue(makeSupabase({ user: { id: "u1" } }));
+
+    const response = await POST(makeRequest({ wrong_field: "x" }));
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { ok: boolean; error: string };
+    expect(body).toEqual({ ok: false, error: "missing task_id" });
+    expect(decomposeTaskMock).not.toHaveBeenCalled();
+  });
+
+  test("body が JSON でない → ok:false で error を返す (parse エラーで 500 にしない)", async () => {
+    process.env.AI_ENABLED = "true";
+    process.env.GEMINI_API_KEY = "k";
+    vi.mocked(createClient).mockResolvedValue(makeSupabase({ user: { id: "u1" } }));
+
+    const response = await POST(makeRequest("not json"));
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(decomposeTaskMock).not.toHaveBeenCalled();
+  });
+
+  test("正常系: decomposeTask を userId / taskId / generate 付きで呼び出す", async () => {
+    process.env.AI_ENABLED = "true";
+    process.env.GEMINI_API_KEY = "k";
+    const supabase = makeSupabase({ user: { id: "u1" } });
+    vi.mocked(createClient).mockResolvedValue(supabase);
+    decomposeTaskMock.mockResolvedValue({
+      kind: "decomposed",
+      childIds: ["c1", "c2"],
+    });
+    generateContentMock.mockResolvedValue({ response: { text: () => "[]" } });
+
+    const response = await POST(makeRequest({ task_id: "parent-1" }));
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { ok: boolean; outcome: unknown };
+    expect(body).toEqual({
+      ok: true,
+      outcome: { kind: "decomposed", childIds: ["c1", "c2"] },
+    });
+
+    expect(decomposeTaskMock).toHaveBeenCalledOnce();
+    const callArg = decomposeTaskMock.mock.calls[0][0] as {
+      userId: string;
+      taskId: string;
+      generate: (p: string) => Promise<string>;
+    };
+    expect(callArg.userId).toBe("u1");
+    expect(callArg.taskId).toBe("parent-1");
+    expect(typeof callArg.generate).toBe("function");
+
+    // generate を実行すると Gemini が呼ばれることを確認
+    const text = await callArg.generate("dummy prompt");
+    expect(generateContentMock).toHaveBeenCalledWith("dummy prompt");
+    expect(text).toBe("[]");
+  });
+
+  test("decomposeTask が throw → 500 ai_failed (fail-soft、client は握り潰す)", async () => {
+    process.env.AI_ENABLED = "true";
+    process.env.GEMINI_API_KEY = "k";
+    vi.mocked(createClient).mockResolvedValue(makeSupabase({ user: { id: "u1" } }));
+    decomposeTaskMock.mockRejectedValue(new Error("gemini quota exceeded"));
+
+    const response = await POST(makeRequest({ task_id: "p1" }));
+
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("ai_failed");
+  });
+});

--- a/src/app/api/ai/decompose/route.ts
+++ b/src/app/api/ai/decompose/route.ts
@@ -1,0 +1,54 @@
+import { createGeminiClient } from "@/shared/ai/client";
+import { withAiRoute } from "@/shared/ai/route";
+import { decomposeTask } from "@/entities/task/decompose-server";
+
+/**
+ * AI タスク分解 endpoint (P3-6, ADR 0017 / 0018 / 0016)。
+ *
+ * 期待フロー:
+ * - client がタスク作成成功後に fire-and-forget で POST する (`{ task_id }`)
+ * - `withAiRoute` が AI_ENABLED / 認証を吸収する。AI_ENABLED=false なら 200 skipped で終わり
+ * - 本体は `decomposeTask` (ADR 0017 race guard / parser / bulk insert / action_log) を呼ぶ
+ * - 失敗 / parse 不能のときは親が `decompose_status='none'` のまま残り、core はそのまま動く
+ *   (ADR 0013 augmentation only)
+ *
+ * クライアント側はレスポンスを使わない (fire-and-forget)。それでも outcome を返すのは
+ * dev / curl / 将来の retry で観測できるようにするため。
+ */
+
+const MODEL_ID = "gemini-2.5-flash";
+
+export async function POST(request: Request) {
+  return withAiRoute(request, async ({ supabase, userId, request: req }) => {
+    const body = await safeJsonBody(req);
+    const taskId = typeof body?.task_id === "string" ? body.task_id : null;
+    if (!taskId) {
+      return { ok: false, error: "missing task_id" };
+    }
+
+    const client = createGeminiClient();
+    const model = client.getGenerativeModel({ model: MODEL_ID });
+
+    const outcome = await decomposeTask({
+      supabase,
+      userId,
+      taskId,
+      generate: async (prompt) => {
+        const result = await model.generateContent(prompt);
+        return result.response.text();
+      },
+    });
+
+    return { ok: true, outcome };
+  });
+}
+
+async function safeJsonBody(req: Request): Promise<Record<string, unknown> | null> {
+  try {
+    const data = (await req.json()) as unknown;
+    if (typeof data !== "object" || data === null) return null;
+    return data as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}

--- a/src/entities/action-log/server.ts
+++ b/src/entities/action-log/server.ts
@@ -1,0 +1,44 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { Database, Json } from "@/shared/types/database";
+
+import type { ActionMetadataMap, ActionType } from "./types";
+
+/**
+ * Server 側 (Route Handler 内) からの action_logs 書き込み helper。
+ *
+ * client 側 logger (`./logger.ts`) は `typeof window === "undefined"` を返却条件にしており
+ * server からの呼び出しでは no-op になる (browser session 前提の supabase client を使う)。
+ * Route Handler では server supabase client (`@/shared/supabase/server`) と認証済み userId を
+ * 持っているので、ここでは props で受け取って直接 INSERT する。
+ *
+ * 設計原則は client 側と同じ:
+ * - INSERT 失敗は `console.error` に留め、呼び出し元のロジックは止めない (ADR 0001)
+ * - `task_deleted` / `decomposition_modified` は FK 違反を避けるため column の task_id を
+ *   null にする。metadata.task_id は一次の真実として残す
+ */
+
+function extractTaskId(actionType: ActionType, metadata: Record<string, unknown>): string | null {
+  if (actionType === "task_deleted" || actionType === "decomposition_modified") {
+    return null;
+  }
+  const v = metadata["task_id"];
+  return typeof v === "string" ? v : null;
+}
+
+export async function logServerSide<T extends ActionType>(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  actionType: T,
+  metadata: ActionMetadataMap[T],
+): Promise<void> {
+  const { error } = await supabase.from("action_logs").insert({
+    user_id: userId,
+    action_type: actionType,
+    task_id: extractTaskId(actionType, metadata as unknown as Record<string, unknown>),
+    metadata: metadata as unknown as Json,
+  });
+  if (error) {
+    console.error("[action-log/server] insert failed", error);
+  }
+}

--- a/src/entities/task/decompose-server.test.ts
+++ b/src/entities/task/decompose-server.test.ts
@@ -1,0 +1,338 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { Database, Tables } from "@/shared/types/database";
+
+import { decomposeTask, type DecomposeTaskDeps, type GenerateFn } from "./decompose-server";
+
+type Plan = {
+  fetch: { data: Partial<Tables<"tasks">> | null; error: { message: string } | null };
+  update: { error: { message: string } | null };
+  // bulk insert tasks → returns id rows
+  insertTasks: { data: { id: string }[] | null; error: { message: string } | null };
+  insertActionLogs: { error: { message: string } | null };
+};
+
+function makeSupabase(plan: Plan): {
+  client: SupabaseClient<Database>;
+  calls: {
+    insertedTasks: unknown[];
+    statusUpdates: Array<{ id: unknown; decompose_status: unknown }>;
+    actionLogs: unknown[];
+  };
+} {
+  const calls = {
+    insertedTasks: [] as unknown[],
+    statusUpdates: [] as Array<{ id: unknown; decompose_status: unknown }>,
+    actionLogs: [] as unknown[],
+  };
+
+  const from = vi.fn((table: string) => {
+    if (table === "action_logs") {
+      return {
+        insert: (payload: unknown) => {
+          calls.actionLogs.push(payload);
+          return Promise.resolve({ error: plan.insertActionLogs.error });
+        },
+      };
+    }
+
+    // table === "tasks"
+    return {
+      // fetchParent: select(...).eq(...).eq(...).maybeSingle()
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn(() =>
+              Promise.resolve({
+                data: plan.fetch.data ?? null,
+                error: plan.fetch.error,
+              }),
+            ),
+          })),
+        })),
+      })),
+      // setDecomposeStatus: update({...}).eq("id", taskId) — eq is awaited (PostgrestFilterBuilder is thenable)
+      // bulk insert: insert(payloads).select("id") — chain returns data/error
+      update: (patch: { decompose_status?: unknown }) => ({
+        eq: (_col: string, val: unknown) => {
+          calls.statusUpdates.push({ id: val, decompose_status: patch.decompose_status });
+          return Promise.resolve({ error: plan.update.error });
+        },
+      }),
+      insert: (payloads: unknown) => {
+        // bulk insert tasks: chain ends with .select("id")
+        calls.insertedTasks.push(payloads);
+        return {
+          select: vi.fn(() =>
+            Promise.resolve({
+              data: plan.insertTasks.data,
+              error: plan.insertTasks.error,
+            }),
+          ),
+        };
+      },
+    };
+  });
+
+  const client = {
+    from,
+  } as unknown as SupabaseClient<Database>;
+
+  return { client, calls };
+}
+
+function makeParentRow(overrides: Partial<Tables<"tasks">> = {}): Partial<Tables<"tasks">> {
+  return {
+    id: "parent-1",
+    status: "idle",
+    decompose_status: "none",
+    title: "親タスク",
+    body: "本文",
+    estimated_minutes: 60,
+    project_id: "proj-1",
+    depends_on_event_id: "evt-1",
+    stack_order: 5,
+    ...overrides,
+  };
+}
+
+function defaultPlan(parent: Partial<Tables<"tasks">> | null): Plan {
+  return {
+    fetch: { data: parent, error: null },
+    update: { error: null },
+    insertTasks: { data: [{ id: "child-1" }, { id: "child-2" }], error: null },
+    insertActionLogs: { error: null },
+  };
+}
+
+function makeDeps(opts: {
+  client: SupabaseClient<Database>;
+  generate: GenerateFn;
+  taskId?: string;
+  userId?: string;
+}): DecomposeTaskDeps {
+  return {
+    supabase: opts.client,
+    userId: opts.userId ?? "user-1",
+    taskId: opts.taskId ?? "parent-1",
+    generate: opts.generate,
+  };
+}
+
+describe("decomposeTask", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  test("happy path: AI が 2 件返す → 子 insert + 親 decomposed + action_log 記録", async () => {
+    const { client, calls } = makeSupabase(defaultPlan(makeParentRow()));
+    const generate = vi.fn(async () =>
+      JSON.stringify([
+        { title: "子A", estimated_minutes: 30 },
+        { title: "子B", estimated_minutes: 15 },
+      ]),
+    );
+
+    const result = await decomposeTask(makeDeps({ client, generate }));
+
+    expect(result).toEqual({ kind: "decomposed", childIds: ["child-1", "child-2"] });
+
+    // bulk insert payload を検証
+    expect(calls.insertedTasks).toHaveLength(1);
+    const inserted = calls.insertedTasks[0] as Array<Record<string, unknown>>;
+    expect(inserted).toHaveLength(2);
+    expect(inserted[0]).toMatchObject({
+      user_id: "user-1",
+      project_id: "proj-1", // 親から継承
+      depends_on_event_id: "evt-1", // 親から継承
+      parent_task_id: "parent-1",
+      title: "子A",
+      estimated_minutes: 30,
+      stack_order: 5, // baseStackOrder = parent.stack_order
+      decompose_status: "none",
+    });
+    expect(inserted[1]).toMatchObject({
+      title: "子B",
+      stack_order: 6, // baseStackOrder + 1
+    });
+
+    // 状態遷移: decomposing → decomposed
+    expect(calls.statusUpdates).toEqual([
+      { id: "parent-1", decompose_status: "decomposing" },
+      { id: "parent-1", decompose_status: "decomposed" },
+    ]);
+
+    // action_log: task_decomposed
+    expect(calls.actionLogs).toHaveLength(1);
+    expect(calls.actionLogs[0]).toMatchObject({
+      user_id: "user-1",
+      action_type: "task_decomposed",
+      task_id: "parent-1",
+      metadata: { task_id: "parent-1", child_ids: ["child-1", "child-2"] },
+    });
+
+    // prompt が組まれている
+    expect(generate).toHaveBeenCalledOnce();
+    expect(generate).toHaveBeenCalledWith(expect.stringContaining("親タスク"));
+  });
+
+  test("親が存在しない (RLS or 既に削除) → no-op で skipped", async () => {
+    const { client, calls } = makeSupabase(defaultPlan(null));
+    const generate = vi.fn();
+
+    const result = await decomposeTask(makeDeps({ client, generate }));
+
+    expect(result).toEqual({ kind: "skipped", reason: "task_not_found" });
+    expect(generate).not.toHaveBeenCalled();
+    expect(calls.insertedTasks).toHaveLength(0);
+    expect(calls.statusUpdates).toHaveLength(0);
+    expect(calls.actionLogs).toHaveLength(0);
+  });
+
+  test("race condition: 親が active 化 → 分解せず skipped (ADR 0017 Notes)", async () => {
+    const { client, calls } = makeSupabase(defaultPlan(makeParentRow({ status: "active" })));
+    const generate = vi.fn();
+
+    const result = await decomposeTask(makeDeps({ client, generate }));
+
+    expect(result).toEqual({ kind: "skipped", reason: "parent_active_or_locked" });
+    expect(generate).not.toHaveBeenCalled();
+    expect(calls.insertedTasks).toHaveLength(0);
+    expect(calls.statusUpdates).toHaveLength(0); // decomposing にすら倒さない
+  });
+
+  test("paused / done でも同じく skipped", async () => {
+    for (const status of ["paused", "done"] as const) {
+      const { client } = makeSupabase(defaultPlan(makeParentRow({ status })));
+      const generate = vi.fn();
+
+      const result = await decomposeTask(makeDeps({ client, generate }));
+
+      expect(result).toEqual({ kind: "skipped", reason: "parent_active_or_locked" });
+      expect(generate).not.toHaveBeenCalled();
+    }
+  });
+
+  test("既に decomposed → 二重分解しない (重複 fire-and-forget 耐性)", async () => {
+    const { client, calls } = makeSupabase(
+      defaultPlan(makeParentRow({ decompose_status: "decomposed" })),
+    );
+    const generate = vi.fn();
+
+    const result = await decomposeTask(makeDeps({ client, generate }));
+
+    expect(result).toEqual({ kind: "skipped", reason: "already_resolved" });
+    expect(generate).not.toHaveBeenCalled();
+    expect(calls.insertedTasks).toHaveLength(0);
+  });
+
+  test("既に skipped → 再分解しない", async () => {
+    const { client } = makeSupabase(defaultPlan(makeParentRow({ decompose_status: "skipped" })));
+    const generate = vi.fn();
+
+    const result = await decomposeTask(makeDeps({ client, generate }));
+
+    expect(result).toEqual({ kind: "skipped", reason: "already_resolved" });
+    expect(generate).not.toHaveBeenCalled();
+  });
+
+  test("AI が parse 不能なテキストを返す → none に戻して failed (core を止めない)", async () => {
+    const { client, calls } = makeSupabase(defaultPlan(makeParentRow()));
+    const generate = vi.fn(async () => "I can't help you decompose this");
+
+    const result = await decomposeTask(makeDeps({ client, generate }));
+
+    expect(result).toEqual({ kind: "failed", reason: "ai_response_unparseable" });
+    expect(calls.insertedTasks).toHaveLength(0);
+    // 状態: decomposing → none (戻す)
+    expect(calls.statusUpdates).toEqual([
+      { id: "parent-1", decompose_status: "decomposing" },
+      { id: "parent-1", decompose_status: "none" },
+    ]);
+    expect(calls.actionLogs).toHaveLength(0);
+  });
+
+  test("AI が空配列 → 親を skipped に倒す (= 分解不要と判断)", async () => {
+    const { client, calls } = makeSupabase(defaultPlan(makeParentRow()));
+    const generate = vi.fn(async () => "[]");
+
+    const result = await decomposeTask(makeDeps({ client, generate }));
+
+    expect(result).toEqual({ kind: "skipped", reason: "ai_decided_not_to_split" });
+    expect(calls.insertedTasks).toHaveLength(0);
+    expect(calls.statusUpdates).toEqual([
+      { id: "parent-1", decompose_status: "decomposing" },
+      { id: "parent-1", decompose_status: "skipped" },
+    ]);
+    expect(calls.actionLogs).toHaveLength(0);
+  });
+
+  test("AI が 1 件しか返さない (実質分解されてない) → skipped に倒す (parser 仕様)", async () => {
+    const { client, calls } = makeSupabase(defaultPlan(makeParentRow()));
+    const generate = vi.fn(async () =>
+      JSON.stringify([{ title: "ひとつだけ", estimated_minutes: 10 }]),
+    );
+
+    const result = await decomposeTask(makeDeps({ client, generate }));
+
+    expect(result).toEqual({ kind: "skipped", reason: "ai_decided_not_to_split" });
+    expect(calls.insertedTasks).toHaveLength(0);
+  });
+
+  test("子 insert が DB 失敗 → none に戻して failed", async () => {
+    const plan = defaultPlan(makeParentRow());
+    plan.insertTasks = { data: null, error: { message: "FK violation" } };
+    const { client, calls } = makeSupabase(plan);
+    const generate = vi.fn(async () =>
+      JSON.stringify([
+        { title: "a", estimated_minutes: 15 },
+        { title: "b", estimated_minutes: 15 },
+      ]),
+    );
+
+    const result = await decomposeTask(makeDeps({ client, generate }));
+
+    expect(result).toEqual({ kind: "failed", reason: "insert_failed" });
+    expect(calls.statusUpdates).toEqual([
+      { id: "parent-1", decompose_status: "decomposing" },
+      { id: "parent-1", decompose_status: "none" },
+    ]);
+    expect(calls.actionLogs).toHaveLength(0);
+  });
+
+  test("親の stack_order が null でも子は 0 始まりで割り当てられる", async () => {
+    const { client, calls } = makeSupabase(defaultPlan(makeParentRow({ stack_order: null })));
+    const generate = vi.fn(async () =>
+      JSON.stringify([
+        { title: "a", estimated_minutes: 15 },
+        { title: "b", estimated_minutes: 15 },
+      ]),
+    );
+
+    await decomposeTask(makeDeps({ client, generate }));
+
+    const inserted = calls.insertedTasks[0] as Array<Record<string, unknown>>;
+    expect(inserted[0]).toMatchObject({ stack_order: 0 });
+    expect(inserted[1]).toMatchObject({ stack_order: 1 });
+  });
+
+  test("親の depends_on_event_id が null なら子も null", async () => {
+    const { client, calls } = makeSupabase(
+      defaultPlan(makeParentRow({ depends_on_event_id: null })),
+    );
+    const generate = vi.fn(async () =>
+      JSON.stringify([
+        { title: "a", estimated_minutes: 15 },
+        { title: "b", estimated_minutes: 15 },
+      ]),
+    );
+
+    await decomposeTask(makeDeps({ client, generate }));
+
+    const inserted = calls.insertedTasks[0] as Array<Record<string, unknown>>;
+    expect(inserted[0].depends_on_event_id).toBeNull();
+    expect(inserted[1].depends_on_event_id).toBeNull();
+  });
+});

--- a/src/entities/task/decompose-server.ts
+++ b/src/entities/task/decompose-server.ts
@@ -1,0 +1,178 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { logServerSide } from "@/entities/action-log/server";
+import {
+  buildDecomposePrompt,
+  parseDecomposeResponse,
+  type DecomposeInput,
+} from "@/shared/ai/prompts/decompose";
+import type { Database, Tables, TablesInsert } from "@/shared/types/database";
+
+/**
+ * AI タスク分解 (P3-6) の server 側 orchestrator。
+ *
+ * 流れ (ADR 0017 / 0018 / 0016):
+ * 1. 親タスクを userId スコープで取得 (RLS 前提だが defense in depth)。見つからなければ no-op
+ * 2. race condition guard: 親が active/paused/done か、既に decomposed/skipped なら no-op
+ *    (ADR 0017 Notes: 親 active 化済みは分解対象から外す。冪等性のため重複時もスキップ)
+ * 3. 親の decompose_status を `decomposing` に倒す (client が optimistic に既に倒している
+ *    可能性もあるが、server で再確定して fire-and-forget の重複呼びでも壊れないようにする)
+ * 4. Gemini に prompt を投げて応答を取る (caller injected `generate` で境界を切る → ユニット可能)
+ * 5. parser が null → `none` に戻す (失敗 = 親をそのまま残す)。空配列 → `skipped`
+ * 6. children を bulk insert (parent_task_id = parent.id)。project_id / depends_on_event_id を
+ *    親から継承、stack_order = parent.stack_order + i で割り当てる (P3-7 の UI が描画分岐する)
+ * 7. 親を `decomposed` に倒し、`task_decomposed` action_log を書く
+ *
+ * 純粋ではないが、Gemini 呼び出しを props で受け取ることでユニットテスト可能にしている。
+ * Supabase 周辺は薄ラッパーなのでクエリチェーンを mock することで検証する。
+ */
+
+export type DecomposeTaskOutcome =
+  | { kind: "decomposed"; childIds: string[] }
+  | { kind: "skipped"; reason: SkipReason }
+  | { kind: "failed"; reason: FailReason };
+
+type SkipReason =
+  | "task_not_found"
+  | "parent_active_or_locked" // status=active/paused/done
+  | "already_resolved" // decompose_status=decomposed/skipped
+  | "ai_decided_not_to_split"; // 空配列 / 1 件
+
+type FailReason = "ai_response_unparseable" | "insert_failed";
+
+export type GenerateFn = (prompt: string) => Promise<string>;
+
+export type DecomposeTaskDeps = {
+  supabase: SupabaseClient<Database>;
+  userId: string;
+  taskId: string;
+  generate: GenerateFn;
+};
+
+const SKIP_STATUSES = new Set(["active", "paused", "done"]);
+const ALREADY_RESOLVED = new Set(["decomposed", "skipped"]);
+
+export async function decomposeTask(deps: DecomposeTaskDeps): Promise<DecomposeTaskOutcome> {
+  const { supabase, userId, taskId, generate } = deps;
+
+  const parent = await fetchParent(supabase, userId, taskId);
+  if (!parent) {
+    return { kind: "skipped", reason: "task_not_found" };
+  }
+
+  if (SKIP_STATUSES.has(parent.status)) {
+    return { kind: "skipped", reason: "parent_active_or_locked" };
+  }
+  if (ALREADY_RESOLVED.has(parent.decompose_status)) {
+    return { kind: "skipped", reason: "already_resolved" };
+  }
+
+  // 重複 fire-and-forget や client 側 optimistic ズレに耐えるよう、ここで decomposing に確定させる。
+  await setDecomposeStatus(supabase, parent.id, "decomposing");
+
+  const prompt = buildDecomposePrompt(toPromptInput(parent));
+  const responseText = await generate(prompt);
+  const parsed = parseDecomposeResponse(responseText);
+
+  if (parsed === null) {
+    // ADR 0013 augmentation only: AI 失敗で core を止めない。none に戻して終わり
+    // (再試行は将来 issue。本実装ではユーザーが override で操作する)
+    await setDecomposeStatus(supabase, parent.id, "none");
+    return { kind: "failed", reason: "ai_response_unparseable" };
+  }
+
+  if (parsed.length === 0) {
+    await setDecomposeStatus(supabase, parent.id, "skipped");
+    return { kind: "skipped", reason: "ai_decided_not_to_split" };
+  }
+
+  const baseStackOrder = parent.stack_order ?? 0;
+  const childPayloads: TablesInsert<"tasks">[] = parsed.map((child, idx) => ({
+    user_id: userId,
+    project_id: parent.project_id,
+    title: child.title,
+    body: "",
+    estimated_minutes: child.estimatedMinutes,
+    parent_task_id: parent.id,
+    depends_on_event_id: parent.depends_on_event_id,
+    stack_order: baseStackOrder + idx,
+    decompose_status: "none",
+  }));
+
+  const { data: insertedRows, error: insertErr } = await supabase
+    .from("tasks")
+    .insert(childPayloads)
+    .select("id");
+
+  if (insertErr || !insertedRows) {
+    console.error("[ai/decompose] child insert failed", insertErr);
+    await setDecomposeStatus(supabase, parent.id, "none");
+    return { kind: "failed", reason: "insert_failed" };
+  }
+
+  const childIds = insertedRows.map((r) => r.id);
+
+  await setDecomposeStatus(supabase, parent.id, "decomposed");
+  await logServerSide(supabase, userId, "task_decomposed", {
+    task_id: parent.id,
+    child_ids: childIds,
+  });
+
+  return { kind: "decomposed", childIds };
+}
+
+type ParentRow = Pick<
+  Tables<"tasks">,
+  | "id"
+  | "status"
+  | "decompose_status"
+  | "title"
+  | "body"
+  | "estimated_minutes"
+  | "project_id"
+  | "depends_on_event_id"
+  | "stack_order"
+>;
+
+async function fetchParent(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  taskId: string,
+): Promise<ParentRow | null> {
+  const { data, error } = await supabase
+    .from("tasks")
+    .select(
+      "id, status, decompose_status, title, body, estimated_minutes, project_id, depends_on_event_id, stack_order",
+    )
+    .eq("id", taskId)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (error) {
+    console.error("[ai/decompose] parent fetch failed", error);
+    return null;
+  }
+  return (data as ParentRow | null) ?? null;
+}
+
+async function setDecomposeStatus(
+  supabase: SupabaseClient<Database>,
+  taskId: string,
+  status: Tables<"tasks">["decompose_status"],
+): Promise<void> {
+  const { error } = await supabase
+    .from("tasks")
+    .update({ decompose_status: status })
+    .eq("id", taskId);
+  if (error) {
+    console.error("[ai/decompose] decompose_status update failed", error);
+  }
+}
+
+function toPromptInput(row: ParentRow): DecomposeInput {
+  return {
+    title: row.title,
+    body: row.body,
+    estimatedMinutes: row.estimated_minutes,
+  };
+}

--- a/src/features/task-stack/triggerDecompose.ts
+++ b/src/features/task-stack/triggerDecompose.ts
@@ -1,0 +1,24 @@
+/**
+ * AI タスク分解の fire-and-forget 起動 (P3-6, ADR 0017)。
+ *
+ * AppShell の onCreateTask 成功後にこれを呼ぶ。await しない:
+ * - レイテンシをタスク追加 UX に乗せない (ADR 0017 Decision 1-2)
+ * - AI 失敗 / `AI_ENABLED=false` で 200 skipped が返っても呼び出し元は知らない (ADR 0013)
+ *
+ * server 側 (`/api/ai/decompose`) が `decompose_status` を `decomposing` に倒すため、
+ * UI に分解中 pill を即時出したい場合は呼び出し元で optimistic update を別途行うこと
+ * (ADR 0017 Notes / Variant E status pill / P3-7)。
+ *
+ * 戻り値は無し。例外も握り潰す (fire-and-forget の契約)。
+ */
+export function triggerDecompose(taskId: string): void {
+  // void で結果を捨てる。catch で error も握り潰す
+  void fetch("/api/ai/decompose", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ task_id: taskId }),
+  }).catch((err) => {
+    // 失敗しても core は止まらない。dev では console に出して気付けるようにする
+    console.error("[ai/decompose] fire-and-forget failed", err);
+  });
+}

--- a/src/shared/ai/prompts/decompose.test.ts
+++ b/src/shared/ai/prompts/decompose.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "vitest";
+
+import { buildDecomposePrompt, parseDecomposeResponse } from "./decompose";
+
+describe("buildDecomposePrompt", () => {
+  test("親タスクの title / body / estimated_minutes を埋め込む", () => {
+    const prompt = buildDecomposePrompt({
+      title: "Dirbato 最終面接対策",
+      body: "志望動機 / 逆質問 / 自己 PR を準備する",
+      estimatedMinutes: 90,
+    });
+
+    expect(prompt).toContain("Dirbato 最終面接対策");
+    expect(prompt).toContain("志望動機 / 逆質問 / 自己 PR を準備する");
+    expect(prompt).toContain("90分");
+  });
+
+  test("body が空のときも壊れず (本文なし) として扱う", () => {
+    const prompt = buildDecomposePrompt({
+      title: "x",
+      body: "",
+      estimatedMinutes: null,
+    });
+
+    expect(prompt).toContain("(本文なし)");
+    expect(prompt).toContain("未設定");
+  });
+
+  test("出力形式の制約 (件数 / 自立タイトル / JSON のみ) が prompt に含まれる", () => {
+    const prompt = buildDecomposePrompt({
+      title: "x",
+      body: "",
+      estimatedMinutes: null,
+    });
+
+    expect(prompt).toContain("2〜7 件");
+    expect(prompt).toContain("空配列");
+    expect(prompt).toContain("JSON 配列のみ");
+    // ADR 0016 Notes「子タイトルの自立性」を担保する具体例
+    expect(prompt).toContain("親タスクの文脈なしで");
+  });
+});
+
+describe("parseDecomposeResponse", () => {
+  test("正常な JSON 配列をパースする (estimated_minutes は数値 / null どちらも許容)", () => {
+    const input = JSON.stringify([
+      { title: "下準備をする", estimated_minutes: 30 },
+      { title: "本作業を進める", estimated_minutes: null },
+      { title: "振り返り", estimated_minutes: 15 },
+    ]);
+
+    const result = parseDecomposeResponse(input);
+
+    expect(result).toEqual([
+      { title: "下準備をする", estimatedMinutes: 30 },
+      { title: "本作業を進める", estimatedMinutes: null },
+      { title: "振り返り", estimatedMinutes: 15 },
+    ]);
+  });
+
+  test("markdown fence (```json ... ```) を剥がす", () => {
+    const input =
+      '```json\n[{"title":"a","estimated_minutes":15},{"title":"b","estimated_minutes":15}]\n```';
+
+    const result = parseDecomposeResponse(input);
+
+    expect(result).toEqual([
+      { title: "a", estimatedMinutes: 15 },
+      { title: "b", estimatedMinutes: 15 },
+    ]);
+  });
+
+  test("空配列は [] を返し (= 親を skipped に倒す入力)、null とは区別する", () => {
+    const result = parseDecomposeResponse("[]");
+    expect(result).toEqual([]);
+  });
+
+  test("1 件のみは「実質分解されていない」ので [] (skipped 扱い) に倒す", () => {
+    const input = JSON.stringify([{ title: "ひとつだけ", estimated_minutes: 10 }]);
+
+    const result = parseDecomposeResponse(input);
+
+    expect(result).toEqual([]);
+  });
+
+  test("8 件以上は先頭 7 件で切る (AI 暴走時の安全弁)", () => {
+    const items = Array.from({ length: 12 }, (_, i) => ({
+      title: `子${i + 1}`,
+      estimated_minutes: 15,
+    }));
+
+    const result = parseDecomposeResponse(JSON.stringify(items));
+
+    expect(result).toHaveLength(7);
+    expect(result?.[0].title).toBe("子1");
+    expect(result?.[6].title).toBe("子7");
+  });
+
+  test("title が空 / 80 文字超過のエントリは捨て、残りを採用する", () => {
+    const longTitle = "あ".repeat(81);
+    const items = [
+      { title: "", estimated_minutes: 15 }, // 空 → 捨てる
+      { title: longTitle, estimated_minutes: 15 }, // 80 文字超過 → 捨てる
+      { title: "ok-1", estimated_minutes: 15 },
+      { title: "ok-2", estimated_minutes: 15 },
+    ];
+
+    const result = parseDecomposeResponse(JSON.stringify(items));
+
+    expect(result).toEqual([
+      { title: "ok-1", estimatedMinutes: 15 },
+      { title: "ok-2", estimatedMinutes: 15 },
+    ]);
+  });
+
+  test("estimated_minutes が許容バケット外 / 文字列 / 小数 → null に倒す (entry は採用)", () => {
+    const items = [
+      { title: "a", estimated_minutes: 7 }, // バケット外
+      { title: "b", estimated_minutes: "30" }, // 文字列
+      { title: "c", estimated_minutes: 15.5 }, // 小数
+      { title: "d", estimated_minutes: 30 }, // 許容
+    ];
+
+    const result = parseDecomposeResponse(JSON.stringify(items));
+
+    expect(result).toEqual([
+      { title: "a", estimatedMinutes: null },
+      { title: "b", estimatedMinutes: null },
+      { title: "c", estimatedMinutes: null },
+      { title: "d", estimatedMinutes: 30 },
+    ]);
+  });
+
+  test("JSON でない / 配列でない / 空文字列は null を返す (= AI 失敗扱い、none のまま残す)", () => {
+    expect(parseDecomposeResponse("")).toBeNull();
+    expect(parseDecomposeResponse("not json")).toBeNull();
+    expect(parseDecomposeResponse('{"title":"a"}')).toBeNull();
+    expect(parseDecomposeResponse("null")).toBeNull();
+  });
+});

--- a/src/shared/ai/prompts/decompose.ts
+++ b/src/shared/ai/prompts/decompose.ts
@@ -1,0 +1,135 @@
+/**
+ * AI タスク分解 (P3-6, ADR 0017 / 0018) の prompt 構築 + 応答パース。
+ *
+ * Gemini 呼び出し境界の外側に純粋関数として置くことで、prompt 文字列の組み立てと
+ * 応答 JSON の解釈をユニットテストで踏める形にしている (`/api/ai/decompose` 本体は
+ * これをデータパイプとしてつなぐだけ)。
+ *
+ * 出力契約 (ADR 0016 §1, 0017 Decision 3-5, 0018 Decision):
+ * - 「これ以上分解する必要なし」と判定された場合は空配列 → 親は `decompose_status='skipped'` に倒す
+ * - 子タイトルは親文脈なしで意味が読める独立した文言 (ADR 0016 Notes 「子タイトルの自立性」)
+ * - 子の estimated_minutes は AI が自信を持てない場合 null。親見積もりの機械的等分はしない
+ *   (補正後見積もりの責務は P3-9 / architecture.md §1.5)
+ */
+
+export type DecomposeInput = {
+  title: string;
+  body: string;
+  estimatedMinutes: number | null;
+};
+
+export type DecomposedChild = {
+  title: string;
+  estimatedMinutes: number | null;
+};
+
+const MIN_CHILDREN = 2;
+const MAX_CHILDREN = 7;
+const MAX_TITLE_LEN = 80;
+
+const ALLOWED_ESTIMATE_BUCKETS = [5, 10, 15, 20, 30, 45, 60, 90, 120] as const;
+
+/**
+ * Gemini に渡す prompt 文字列を構築する。
+ *
+ * - 出力数の上下限 (2〜7) を明示する。1 件しか出ないなら「分解不要」として空配列を返させる
+ *   (parser 側で 1 件は `skipped` 扱いに倒すフェイルセーフもあるが、prompt でも縛る)
+ * - 子タイトルは親文脈なしで読めること、本文に親タスク情報を埋め込んで誘導する
+ * - 出力は JSON 配列のみ。markdown fence や説明文が混じっても parser 側で剥がす前提
+ */
+export function buildDecomposePrompt(parent: DecomposeInput): string {
+  const bodyText = parent.body.trim().length > 0 ? parent.body.trim() : "(本文なし)";
+  const estimateText = parent.estimatedMinutes !== null ? `${parent.estimatedMinutes}分` : "未設定";
+
+  return [
+    "あなたは個人特化のタスク管理アシスタント。次の親タスクを、実行可能な粒度の子タスクに分解する。",
+    "",
+    "# 分解の方針",
+    `- 子タスクは ${MIN_CHILDREN}〜${MAX_CHILDREN} 件。`,
+    "- 親タスクが既に十分小さく分解の必要がないと判断したら、空配列 [] を返す。",
+    "- 各子タスクの title は、親タスクの文脈なしで読んで意味が取れる短い独立した文言にする。",
+    "  例 (悪): 「志望動機を書く」 / 例 (良): 「Dirbato 最終面接 志望動機 (パターン A) を書く」",
+    `- title は ${MAX_TITLE_LEN} 文字以内。装飾的なプレフィックス (Step 1: 等) は付けない。`,
+    `- estimated_minutes は ${ALLOWED_ESTIMATE_BUCKETS.join("/")} のいずれかの整数か、自信が無ければ null。`,
+    "",
+    "# 親タスク",
+    `title: ${parent.title}`,
+    `body: ${bodyText}`,
+    `estimated_minutes: ${estimateText}`,
+    "",
+    "# 出力形式",
+    "JSON 配列のみを返す。前後に説明文や markdown fence を付けない。",
+    '例: [{"title":"...","estimated_minutes":30},{"title":"...","estimated_minutes":null}]',
+  ].join("\n");
+}
+
+/**
+ * Gemini 応答テキストを `DecomposedChild[]` に解釈する。
+ *
+ * - markdown fence (```json ... ```) を剥がす
+ * - JSON 配列以外 / 解釈不能 → `null` (呼び出し側で「失敗」として親を `none` のまま残す)
+ * - 空配列 → `[]` (呼び出し側で「分解不要」として親を `skipped` に倒す)
+ * - 1 件のみ → `[]` 扱い (実質的な分解になっていないため)
+ * - 件数オーバー (>7) → 先頭 7 件で切る (AI が暴走した時の安全弁)
+ * - title が空 / 80 文字超過 → entry を捨てる (それ以外を採用)
+ * - estimated_minutes が許容バケット外 → null に倒す (整数 / null 以外も null)
+ *
+ * 戻り値:
+ *   `null`            : パース不能 (= AI 失敗扱い、`none` のまま残す)
+ *   `[]`              : 分解不要 (= `skipped`)
+ *   `DecomposedChild[]` (1+ 件): 採用する子配列
+ */
+export function parseDecomposeResponse(text: string): DecomposedChild[] | null {
+  const stripped = stripMarkdownFence(text).trim();
+  if (stripped.length === 0) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripped);
+  } catch {
+    return null;
+  }
+
+  if (!Array.isArray(parsed)) return null;
+
+  const children: DecomposedChild[] = [];
+  for (const entry of parsed) {
+    const child = normalizeChild(entry);
+    if (child) children.push(child);
+    if (children.length >= MAX_CHILDREN) break;
+  }
+
+  // 1 件しか取れなかった = 実質「分解されていない」ので skipped 扱いに倒す。
+  // ADR 0017 Decision 4 / vision「気づいたら細かくなってる」と整合させる
+  // (1 → 1 の置き換えはユーザーから見て分解が起きたように見えない)。
+  if (children.length < MIN_CHILDREN) return [];
+
+  return children;
+}
+
+function stripMarkdownFence(text: string): string {
+  const fenceRe = /^```(?:json)?\s*\n?([\s\S]*?)\n?```$/i;
+  const match = text.trim().match(fenceRe);
+  return match ? match[1] : text;
+}
+
+function normalizeChild(raw: unknown): DecomposedChild | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const obj = raw as Record<string, unknown>;
+
+  const title = typeof obj.title === "string" ? obj.title.trim() : "";
+  if (title.length === 0 || title.length > MAX_TITLE_LEN) return null;
+
+  const estimate = normalizeEstimate(obj.estimated_minutes);
+  return { title, estimatedMinutes: estimate };
+}
+
+function normalizeEstimate(raw: unknown): number | null {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw !== "number" || !Number.isFinite(raw)) return null;
+  if (!Number.isInteger(raw)) return null;
+  if (!ALLOWED_ESTIMATE_BUCKETS.includes(raw as (typeof ALLOWED_ESTIMATE_BUCKETS)[number])) {
+    return null;
+  }
+  return raw;
+}


### PR DESCRIPTION
## 概要 (What)

タスク追加 → AI 分解 → 子タスク差し込みの非同期パイプを実装する。タスク追加 UX は Gemini レイテンシに引きずられず、AI 失敗時は親が `decompose_status='none'` のまま Stack に残る (ADR 0013 augmentation only)。

## 関連 Issue

Closes #91

## 背景 (Why)

Phase 3 の核仮説「タスク追加時の自動分解で着手ハードルが下がるか」を検証する UI / データの土台。基盤系 (#86 P3-1 / #87 P3-2 / #88 P3-3) が揃ったので、その上に乗せる本機能。

判断は ADR で確定済み:

- [ADR 0017](../blob/main/docs/adr/0017-ai-task-decomposition-async.md) — 非同期分解 / fire-and-forget / 「分解中」status pill
- [ADR 0018](../blob/main/docs/adr/0018-keep-parent-task-id-for-ai-decomposition.md) — 親レコードを `parent_task_id` で保持
- [ADR 0016](../blob/main/docs/adr/0016-stack-view-decomposition-children-only.md) — 子のみフラット (Variant E、UI は P3-7)
- [ADR 0013](../blob/main/docs/adr/0013-ai-as-augmentation-only.md) — AI 失敗で core を止めない

ADR で未確定だった派生判断 (race condition 対応 / `project_id` / `dependsOnEventId` / 見積もり継承 / `stack_order` 配置) は本 PR で確定:

- race guard: parent.status が `active` / `paused` / `done` のいずれか、または parent.decompose_status が `decomposed` / `skipped` の場合は分解せず終了 (重複 fire-and-forget 耐性)
- 子の `project_id` / `depends_on_event_id` は親から継承
- 子の `estimated_minutes` は AI 出力 (null OK)。親見積もりの機械的等分はしない (補正は P3-9 の責務)
- 子数: AI に 2〜7 件指示。空配列または 1 件は `skipped` 扱い
- 子の `stack_order` = `parent.stack_order + i`。後続タスクの renumbering はしない (P3-7 の UI が描画分岐で吸収)

## Before → After (概念・フロー・メンタルモデル)

**Before:** タスク追加 = 1 行 INSERT して終わり。粒度の粗いタスクは粗いまま Stack の上から消化される。

**After:** タスク追加成功後に client が fire-and-forget で `/api/ai/decompose` を叩く。server は親をロード → race guard → Gemini に prompt → 子を bulk insert + 親を `decomposed` に倒す。AI 失敗 / quota / `AI_ENABLED=false` のときは親が `none` のまま残るだけで、core は普段通り動く。

```
[client] addTask → mutate (server INSERT)
                 → optimistic: 親.decompose_status = 'decomposing'
                 → fire-and-forget POST /api/ai/decompose

[server] withAiRoute (AI_ENABLED / auth)
       → fetch parent (RLS)
       → race guard (active/paused/done / already_resolved)
       → set decomposing
       → Gemini.generateContent(prompt)
       → parse response
         - null     → set 'none' + return failed
         - []       → set 'skipped' + return skipped
         - children → bulk insert + set 'decomposed' + log task_decomposed
```

## 追加したテスト (How verified)

- [x] **prompt 構築 / 応答パース のユニット (11 件)** — 件数制限・自立タイトル制約・` ```json ` フェンス剥がし・空配列 vs `null` の使い分け・8 件以上は先頭 7 件・estimated_minutes バケット外 → `null` 倒し・1 件のみ → `[]` 倒し
- [x] **`decomposeTask` orchestrator のユニット (12 件)** — happy path で payload 検証 (`project_id` / `depends_on_event_id` 継承・`stack_order = parent.stack_order + i`)、状態遷移 (`decomposing` → `decomposed`/`skipped`/`none`)、race guard (`active` / `paused` / `done` / `decomposed` / `skipped` 各々スキップ)、AI 失敗 → `none` 戻し、空配列 / 1 件 → `skipped`、子 insert DB エラー → `none` 戻し、`task_decomposed` action_log の metadata 検証
- [x] **Route Handler のユニット (6 件)** — `AI_ENABLED=false` で 200 skipped、未ログイン 401、`task_id` 欠落で `ok:false`、JSON 不正で `ok:false`、正常系で decomposeTask に `userId` / `taskId` / `generate` が渡る、handler throw → 500
- [x] full suite 297 件 / typecheck / lint / prettier 全て clean
- [ ] **手動確認 (Vercel preview / dev)** — 実 Gemini API 経由で「親追加 → 数秒後に子が並ぶ」と「`AI_ENABLED=false` で親が `none` のまま残る」を踏む。preview env 設定後にレビュー側で確認

## リリース前チェックリスト (When / Before merge)

- [ ] **Vercel production env**: `AI_ENABLED=true` と `GEMINI_API_KEY` を本番に設定 (preview は既定 `false` のまま)
- [ ] **Supabase production**: P3-2 (`task_category`) / P3-3 (`decompose_status`) migration が適用済みか確認 (`supabase db push`)
- [ ] **手動確認**: preview で 1 件「面接対策」級の粗いタスクを追加 → 数秒で子が並ぶ / Network タブで `/api/ai/decompose` が `outcome: { kind: "decomposed", ... }` / `action_logs` に `task_decomposed` 記録、を踏む
- [ ] **Gemini quota の様子見**: 個人利用ペースなら free tier で十分のはずだが、初日のリクエスト量を眺めておく

## このPRの範囲外 (Out of scope)

- **Stack View Variant E の本実装移植 (#92 P3-7)** — 「分解中」pill / 平行四辺形プログレス / 子フラット描画は別 issue。今回は client が `decompose_status='decomposing'` を optimistic に書くだけで、UI は読まない (DB / cache レベルのみ)
- **e2e 不変条件 (#96 P3-11)** — `AI_ENABLED=false` でも core path が semantic locator で踏める e2e 整備は別 issue。本 PR は ユニット / Route Handler テストまで
- **再試行 UI / 取消し UI** — ADR 0017 Notes で「実装後の運用で判断」となっているため未着手
- **子の統合 / 再分割 UI** — Phase 4 / 別 issue
- **既存タスクの backfill 分解** — 別 issue
- **集計ヘルパ整備 (#95 P3-10)** — 親除外集計など、Phase 4 の暗黙的フィードバック分析の入力整理は別 issue

https://claude.ai/code/session_01GrqpUW4ArXoNSHdSf1KMwn

---
_Generated by [Claude Code](https://claude.ai/code/session_01GrqpUW4ArXoNSHdSf1KMwn)_