### PR TITLE
feat(ci): DB migration を手動 trigger の GitHub Actions で本番適用 (#101)

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -1,0 +1,125 @@
+name: DB migrate (production)
+
+# 本番 Supabase に migration を適用する。手動 trigger のみ。
+# 設計判断は ADR-0019 / ADR-0020 を参照。
+#
+# 手順:
+# 1. GitHub UI から `Run workflow` で起動
+# 2. `production` Environment の approval を承認
+# 3. 適用前バックアップ → migration 適用 → 結果確認の順に流れる
+# 4. backup は artifact として 14 日保持される
+#
+# secret は `SUPABASE_DB_URL` のみ。step env で個別に渡す
+# (job env / workflow env には置かない: ADR-0020 の hardening 方針)。
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run: take backup and show pending migrations, but do not apply"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: db-migrate-production
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    name: Apply migrations to production
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      # supabase/config.toml の major_version = 15 と揃える。
+      # pg_dump はサーバーと同じメジャーバージョン以上が必要。
+      - name: Install PostgreSQL 15 client tools
+        run: |
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+            -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+          sudo sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client-15
+
+      # 適用前のロールバック用 dump。public schema はデータ込み、それ以外は構造のみ。
+      # 重い時間がかかるほどデータが大きくなったら別 issue で再設計する。
+      - name: Take pre-migration backup
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          ts=$(date -u +%Y%m%dT%H%M%SZ)
+          mkdir -p backups
+          pg_dump --no-owner --no-privileges --schema=public \
+            --file="backups/pre-migrate-${ts}-public.sql" \
+            "$SUPABASE_DB_URL"
+          pg_dump --no-owner --no-privileges --schema-only \
+            --file="backups/pre-migrate-${ts}-schema.sql" \
+            "$SUPABASE_DB_URL"
+          echo "BACKUP_TS=${ts}" >> "$GITHUB_ENV"
+          ls -la backups/
+
+      - name: Upload backup artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: db-backup-${{ env.BACKUP_TS }}
+          path: backups/
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Show migration state (local files vs applied)
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          echo "::group::Local migration files (supabase/migrations/)"
+          ls -1 supabase/migrations/ || true
+          echo "::endgroup::"
+          echo "::group::Applied migrations on remote (supabase_migrations.schema_migrations)"
+          psql "$SUPABASE_DB_URL" -c \
+            "SELECT version FROM supabase_migrations.schema_migrations ORDER BY version DESC LIMIT 30;" \
+            || echo "Could not read schema_migrations (table might not exist on first run)"
+          echo "::endgroup::"
+
+      - name: Apply migrations
+        if: ${{ inputs.dry_run != true }}
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          supabase db push --db-url "$SUPABASE_DB_URL"
+
+      - name: Verify post-migrate state
+        if: ${{ inputs.dry_run != true }}
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          echo "::group::Applied migrations after push"
+          psql "$SUPABASE_DB_URL" -c \
+            "SELECT version FROM supabase_migrations.schema_migrations ORDER BY version DESC LIMIT 10;"
+          echo "::endgroup::"
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "### DB migrate (production)"
+            echo ""
+            if [ "${{ inputs.dry_run }}" = "true" ]; then
+              echo "- Mode: **DRY RUN** (no apply)"
+            else
+              echo "- Mode: **APPLY**"
+            fi
+            echo "- Backup artifact: \`db-backup-${BACKUP_TS:-unknown}\` (retention 14 days)"
+            echo ""
+            echo "ADR: [0019](../blob/main/docs/adr/0019-db-migration-via-manual-github-actions.md) / [0020](../blob/main/docs/adr/0020-db-migration-credential-as-db-connection-string.md)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -31,7 +31,7 @@ jobs:
   migrate:
     name: Apply migrations to production
     runs-on: ubuntu-latest
-    environment: production
+    environment: Production
     timeout-minutes: 15
 
     steps:

--- a/README.md
+++ b/README.md
@@ -88,7 +88,35 @@ supabase db reset
 supabase gen types typescript --local > src/shared/types/database.ts
 ```
 
-リモートにプッシュするときは `supabase db push`。
+#### 本番 Supabase への適用
+
+本番への migration 適用は **GitHub Actions の手動 trigger workflow** で行う（ADR-0019 / ADR-0020）。
+PC からの `supabase db push` 直接実行はしない。
+
+1. 該当の migration を含む PR を main に merge する
+2. GitHub の `Actions` タブ →「DB migrate (production)」→「Run workflow」
+3. `production` Environment の approval を承認する（reviewer = repo owner）
+4. workflow が走り、適用前 backup → migration 適用 → 結果確認の順に実行される
+5. backup は artifact として 14 日保持される（事故時のロールバック用）
+
+スマホからは GitHub アプリで上記 2〜3 を 2 タップで完結できる。
+
+**事前設定（一度だけ）:**
+
+- GitHub Repository → Settings → Environments で `production` Environment を作成
+  - `Required reviewers` に repo owner を追加（approval gate）
+- 同 Environment の Secrets に `SUPABASE_DB_URL` を登録
+  - 形式: `postgresql://postgres.<PROJECT_REF>:<DB_PASSWORD>@<host>:5432/postgres`
+  - **必ず Session pooler (port 5432)** を使う。Transaction pooler (6543) では `pg_dump` が動かない
+  - 値は Supabase Dashboard → Project Settings → Database → Connection string から取得
+
+**dry run:**
+
+「Run workflow」起動時に `dry_run` を ON にすると、backup と pending migration の表示までで止まる（適用しない）。本番に流す前の事前確認用。
+
+**漏洩時 / 定期 rotate:**
+
+Supabase Dashboard → Database → Reset database password で再生成 → GitHub Environment Secret の `SUPABASE_DB_URL` を上書き。半年〜1 年に 1 回が目安。
 
 ## ドキュメント
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ PC からの `supabase db push` 直接実行はしない。
 
 1. 該当の migration を含む PR を main に merge する
 2. GitHub の `Actions` タブ →「DB migrate (production)」→「Run workflow」
-3. `production` Environment の approval を承認する（reviewer = repo owner）
+3. `Production` Environment の approval を承認する（reviewer = repo owner）
 4. workflow が走り、適用前 backup → migration 適用 → 結果確認の順に実行される
 5. backup は artifact として 14 日保持される（事故時のロールバック用）
 
@@ -103,7 +103,7 @@ PC からの `supabase db push` 直接実行はしない。
 
 **事前設定（一度だけ）:**
 
-- GitHub Repository → Settings → Environments で `production` Environment を作成
+- GitHub Repository → Settings → Environments で `Production` Environment を作成
   - `Required reviewers` に repo owner を追加（approval gate）
 - 同 Environment の Secrets に `SUPABASE_DB_URL` を登録
   - 形式: `postgresql://postgres.<PROJECT_REF>:<DB_PASSWORD>@<host>:5432/postgres`

--- a/docs/adr/0019-db-migration-via-manual-github-actions.md
+++ b/docs/adr/0019-db-migration-via-manual-github-actions.md
@@ -1,0 +1,74 @@
+# ADR 0019: DB migration は手動 trigger の GitHub Actions で適用する
+
+- **Status**: Accepted
+- **Date**: 2026-04-28
+- **Related**: -
+
+## Context
+
+kozutsumi は個人開発で、開発の主戦場が**スマホ**である。
+このため、本番 Supabase への migration 適用 (`supabase db push`) を PC からの手動コマンド実行に依存させると、
+スキーマ変更を出すたびに PC を開かないと進められず、開発フロー全体のボトルネックになる。
+
+一方、main merge をトリガーにした完全自動 CD は、破壊的 migration（DROP TABLE / NOT NULL 追加 / 型変更など）が
+即本番に流れる。kozutsumi は無料 Supabase で運用していて point-in-time recovery が効かないため、
+事故の recovery が高コストになる。
+
+「PC 手動」と「完全自動」の中間で、スマホからでも実行できて、かつ破壊的変更を一段止められる仕組みが必要。
+
+## Decision
+
+DB migration の本番適用は、**手動 trigger 専用の GitHub Actions workflow** で行う。
+
+- Trigger は `workflow_dispatch` のみ。`push` / `pull_request` 等の自動 trigger は使わない
+- `production` environment を作り、**approval required** に設定する。reviewer は repo owner（自分）
+- スマホからは GitHub アプリで「Run workflow」→ approval を承認、の 2 タップで適用できる
+- workflow からの呼び出し方法は ADR-0020 で別途決める
+
+## Consequences
+
+### 肯定的影響
+
+- **スマホ運用が成立する**。PC を開かずに migration を流せる
+- **破壊的変更の事故防止が一段挟まる**。approval ステップで「diff 見てから承認」できる
+- **GitHub の権限モデルで保護される**。`workflow_dispatch` は repo の write 権限保有者しか実行できないため、
+  fork PR や外部からの誘発はない（`pull_request_target` のような落とし穴も避けられる）
+- **secret は GitHub Secrets に閉じる**。PC の `.env.local` に置きっぱなしにするより、
+  漏洩経路（laptop 紛失 / 誤コミット / shell history）が減る
+
+### 否定的影響・トレードオフ
+
+- **GitHub Actions の supply chain 攻撃を受け得る**。依存 action が乗っ取られた場合、
+  step 内の secret が抜かれる可能性は残る。kozutsumi の脅威モデル（個人プロダクト・アルファ期・
+  自分のデータが主・migration workflow は週0〜数回しか動かない）では許容範囲と判断
+- **approval ステップの分だけ実行に時間がかかる**。即時性は落ちる（が migration はそもそも
+  即時性が必要な操作ではない）
+- **workflow のメンテ対象が増える**。CI 既存 workflow に加えて migration workflow を維持する必要がある
+
+### Approval gate の意味の限定
+
+approval gate の目的は **「破壊的 migration の事故防止」** であり、
+**supply chain 防御ではない**。approve した瞬間に runner が起動して secret が注入されるため、
+compromised action からの secret 抽出は approve のタイミングと無関係に起きうる。
+ここを混同しない。
+
+## Alternatives considered
+
+- **PC からの手動 `supabase db push`**: 現状維持案。スマホ運用要件と相反するため不採用
+- **main merge 起点の完全自動 CD**: 破壊的変更が即本番に流れるリスクが許容できないため不採用。
+  PR 時点で `supabase db diff` を bot コメントに出す + lint で破壊的変更を検出する、
+  といった補強でも、ヒトのレビューが間に挟まらないと事故率が下がりきらないため
+- **PR コメント `/migrate` での trigger**: 仕組みとしては可能だが、
+  `workflow_dispatch` + Environment approval と blast radius が変わらない上、
+  実装が複雑になるため不採用
+
+## Notes
+
+- supply chain hardening（action の SHA pin / step env / minimal permissions など）は
+  リポジトリ全体に対する横断的方針として別途扱う（pinact 等の自動化ツールでまとめて適用）。
+  本 ADR では migration workflow 個別の話としては扱わない
+- 漏洩時の対応（DB password rotate）と認証情報の選択は ADR-0020 を参照
+- 将来 supersede される条件:
+  - スマホ運用要件が変わって PC 手動運用が現実的に戻った場合
+  - Supabase Edge Function 等、別の実行基盤に migration 実行を移す場合
+  - 自動化要件が高まって approval gate が運用負荷になった場合（破壊的変更を別経路で検知できる仕組みとセットで再検討）

--- a/docs/adr/0020-db-migration-credential-as-db-connection-string.md
+++ b/docs/adr/0020-db-migration-credential-as-db-connection-string.md
@@ -1,0 +1,83 @@
+# ADR 0020: DB migration の認証情報は project-scoped な DB connection string を使う
+
+- **Status**: Accepted
+- **Date**: 2026-04-28
+- **Related**: [ADR 0019](./0019-db-migration-via-manual-github-actions.md)
+
+## Context
+
+ADR-0019 で migration 適用を GitHub Actions に持たせたため、CI 側に Supabase へアクセスするための
+認証情報を置く必要がある。Supabase が提供する認証情報は scope が異なる:
+
+| 認証情報 | スコープ | DB に対してできること |
+|---|---|---|
+| Personal Access Token (PAT) | アカウント全体 | 全 project の管理、billing、project 作成・削除、DB アクセスも可能 |
+| DB password (connection string に含まれる) | 1 DB | その project の Postgres に full アクセス（DDL/DML） |
+| Service role key | 1 project の API 経由 | RLS bypass で全 row に DML。SQL 直接の DDL には不向き |
+| Anon key | 1 project の RLS 越し | RLS 通過範囲のみ |
+
+漏洩時の blast radius を最小化したい。Supabase は **「migration だけ実行できる」scoped token は提供していない**
+（2026-04 時点）。
+
+## Decision
+
+CI に置く認証情報は **`SUPABASE_DB_URL`（DB connection string）1 本のみ**とする。
+
+- `postgresql://postgres.<PROJECT_REF>:<DB_PASSWORD>@<host>:6543/postgres` 形式
+- workflow 内では `supabase db push --db-url "$SUPABASE_DB_URL"` または `psql` で直接実行する
+- PAT は使わず、`supabase link` のような project 紐付けも行わない
+
+## Consequences
+
+### 肯定的影響
+
+- **scope が 1 DB に閉じる**。漏洩しても他 project / billing / アカウント設定は守られる
+- **PAT より blast radius が狭い**。直感とは逆だが、PAT はアカウント全体スコープなので DB password より広い
+- **workflow がシンプルになる**。`supabase login` / `supabase link` 等の前段が不要で、
+  接続文字列を渡すだけで完結する
+- **secret が 1 本に集約される**。複数の認証情報を CI に置く必要がない
+
+### 否定的影響・トレードオフ
+
+- **接続文字列に DB password が埋まっている**。漏洩した場合、その DB に対してフルアクセスを許す。
+  ただしこの blast radius は PAT より狭く、`auth.users` テーブルや user データへの直接アクセスは可能
+- **kozutsumi は無料 Supabase で運用しているため point-in-time recovery がない**。
+  漏洩時の最悪ケースでは手動バックアップに依存する → migration workflow 内で適用前に
+  `pg_dump` を取って artifact 化する補強で対応する（実装側の話）
+
+### 漏洩時の対応
+
+1. Supabase Project Settings → Database → **Reset database password** で再生成
+2. 新しい connection string をコピーして GitHub Repository Secrets の `SUPABASE_DB_URL` を上書き
+3. 必要に応じて DB の audit log を確認（Supabase Dashboard）
+
+定期 rotate は半年〜1年程度を目安にする。
+
+## Alternatives considered
+
+- **PAT (`SUPABASE_ACCESS_TOKEN`) + `supabase link`**:
+  account 全体スコープになり blast radius が大きい。複数 project や billing まで巻き込まれる。不採用
+- **Custom Postgres role (`migrator` 等) で grant を絞る**:
+  `migrator` role を作って public schema の DDL/DML だけ許可する案。scope はさらに絞れるが、
+  - `auth` schema を触る migration（trigger 追加など）が出ると詰む
+  - extension を追加する migration では superuser が必要
+  - role 自体の管理（password rotate / grant 追加）が手作業で発生
+  - Supabase の DB リセット時に role が消える可能性
+  
+  運用コストが見合わないため不採用。将来 migration 量が増えて benefit が cost を上回るタイミングで再検討
+- **Service role key**:
+  PostgREST 経由のアクセスで、SQL 直接実行による migration には向いていない。不採用
+- **migration 専用の Supabase アカウントを別途作る**:
+  Supabase の利用規約上「machine user / 別アカウント」が許容されるか不明。
+  かつ PAT を CI に置くこと自体が DB password より広い scope なので、得られる benefit が薄い。不採用
+
+## Notes
+
+- 接続文字列は GitHub Repository Secrets に置き、workflow では **step env** で渡す
+  （job env / workflow env には置かない。compromised action からの secret 抽出を step 単位に閉じる）
+- 漏洩リスクの最終判断は ADR-0019 の脅威モデル（個人プロダクト・アルファ期・自分のデータが主）と
+  セットで成立している
+- 将来 supersede される条件:
+  - Supabase が migration-only な scoped token を提供した場合
+  - migration の量・複雑度が増えて custom Postgres role の運用コストが見合うようになった場合
+  - kozutsumi がアルファを抜けて他人のデータを預かるフェーズに入った場合（脅威モデルが変わるので再評価）


### PR DESCRIPTION
## 概要

ADR-0019 / ADR-0020 で確定した方針を実装。本番 Supabase への migration 適用を、PC からの `supabase db push` 直接実行から **`workflow_dispatch` のみで起動する GitHub Actions** に切り替える。スマホ中心の開発フローでも適用が完結し、`Production` Environment の approval gate で破壊的 migration の事故を一段防ぐ。

## 関連 Issue

Closes #101

## 背景

- スマホ中心の開発フローのため PC 手動 push がボトルネック
- main merge での完全自動 CD は破壊的 migration の事故が即本番に出るので不可
- 中間運用として「手動 trigger + approval gate + 最小スコープ secret 1 本」を採用

詳細は ADR を参照:

- [ADR-0019: DB migration は手動 trigger の GitHub Actions で適用する](docs/adr/0019-db-migration-via-manual-github-actions.md)
- [ADR-0020: DB migration の認証情報は project-scoped な DB connection string を使う](docs/adr/0020-db-migration-credential-as-db-connection-string.md)

## Before → After

**Before:**

- 開発者が PC を開いて `supabase db push` を手で実行
- DB password / connection string が開発者ローカル (`.env.local`) に居座る
- スマホからは migration が流せない

**After:**

- GitHub Actions の `DB migrate (production)` を手動 trigger
- `Production` Environment の approval を承認すると適用が走る
- secret は GitHub Environment Secret に集約 (`SUPABASE_DB_URL` 1 本、Session pooler の URL に DB password が埋まる形)
- 適用前に `pg_dump` でバックアップを artifact 化（14 日保持、ロールバック用）
- `dry_run` input で「適用なしで pending を見るだけ」も可能

## 追加したテスト

- [x] workflow ファイルの構文 / 式 / step 構成を手動レビュー
- [ ] **動作確認は merge 後に実施**: `workflow_dispatch` workflow は default branch に乗らないと Actions UI に出ないため、merge 後に dry_run → 本番適用の順で実機確認する

## リリース前チェックリスト

- [x] ドキュメント (README / ADR) を更新した
- [x] 環境変数 / シークレットを追加・更新した
  - GitHub `Production` Environment + Environment Secret `SUPABASE_DB_URL` 登録済み
  - `Required reviewers` = repo owner、`Deployment branches and tags` = `main` only に設定済み
- [x] 既存ユーザーへの影響なし（新規 workflow 追加 + ドキュメント変更のみ、アプリのランタイム挙動には影響なし）

## このPRの範囲外

- **GitHub Actions の SHA pin / supply chain hardening 横断対応**: `pinact` 等のツールで repo 全体に一括適用する別作業
- **custom Postgres role (`migrator`) 化**: ADR-0020 で将来検討項目として明記
- **既存 CI (`.github/workflows/ci.yml` の supabase job) への変更**: 既存 CI は migration 検証用ローカル適用で目的が別、今回は触らない


---
_Generated by [Claude Code](https://claude.ai/code/session_018Qu6FU6s2JjaTNpLSchcNC)_