### PR TITLE
fix(ci): pg_dump / local Postgres を本番に合わせて 17 に更新

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -42,16 +42,18 @@ jobs:
         with:
           version: latest
 
-      # supabase/config.toml の major_version = 15 と揃える。
       # pg_dump はサーバーと同じメジャーバージョン以上が必要。
-      - name: Install PostgreSQL 15 client tools
+      # Supabase 本番は PostgreSQL 17 にアップグレード済みなので 17 を入れる。
+      # Ubuntu runner には client 16 が既に入っているため、pg_wrapper が 16 を
+      # 選ばないよう必ず最新メジャーを追加 install すること。
+      - name: Install PostgreSQL 17 client tools
         run: |
           sudo install -d /usr/share/postgresql-common/pgdg
           sudo curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
             -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
           sudo sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           sudo apt-get update -qq
-          sudo apt-get install -y -qq postgresql-client-15
+          sudo apt-get install -y -qq postgresql-client-17
 
       # 適用前のロールバック用 dump。public schema はデータ込み、それ以外は構造のみ。
       # 重い時間がかかるほどデータが大きくなったら別 issue で再設計する。

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -14,7 +14,7 @@ schemas = ["public"]
 [db]
 port = 54322
 shadow_port = 54320
-major_version = 15
+major_version = 17
 
 [studio]
 enabled = true


### PR DESCRIPTION
## 概要 (What)

DB migrate (production) ワークフローが `server version mismatch` で失敗していたのを修正し、ローカル Supabase の major_version も本番に揃える。

## 背景 (Why)

Supabase 本番が PostgreSQL 17.6 にアップグレードされたが、

- `db-migrate.yml` は `postgresql-client-15` を install していた
- Ubuntu 24.04 runner にはデフォルトで client 16 が入っており、`pg_wrapper` は最大バージョンを選ぶため pg_dump 16.13 が呼ばれていた
- pg_dump はサーバーのメジャーバージョン以上が必要なので、16 < 17 でバックアップ取得が失敗

`supabase/config.toml` の `major_version = 15` も同じく本番と乖離していたので合わせて更新する（ADR-0019 の前提だった「ローカル＝本番のバージョン整合」を維持するため）。

## Before → After (概念・フロー・メンタルモデル)

**Before:** ローカル / GHA / 本番 でメジャーバージョンが 15 / 16 / 17 と三者三様。pg_dump は runner デフォルトの 16 が拾われ、本番 17 に対して mismatch で fail。

**After:** ローカル = GHA = 本番 = 17 で揃う。GHA は明示的に client 17 を install して `pg_wrapper` が 17 を選ぶ。

## 追加したテスト (How verified)

- [x] ワークフロー本体は次回の手動 trigger で実機検証
- [x] grep で他に PG 15 への参照が残っていないことを確認
- [ ] ユニットテストの追加対象なし（CI 設定 / 設定ファイルのみの変更）

## リリース前チェックリスト (When / Before merge)

- [x] マイグレーションの適用順を確認した（migration 自体には変更なし）
- [x] ドキュメント (README / ADR / docs/) を更新した（不要、ADR-0019 のバージョン記載は元々無し）
- [ ] **ローカル開発者向け注意**: `supabase/config.toml` のメジャーバージョン変更で既存ボリュームと非互換になる。`supabase stop --no-backup && supabase start` でローカル DB を作り直す必要あり

## このPRの範囲外 (Out of scope)

- pg client バージョンを Renovate / Dependabot 等で追跡する仕組みは入れない（Supabase 本番のメジャー昇格は頻度が低く、起きたら都度手動で揃える方針）

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqvNRPwHrHP5gLMWJx3BHP)_