### PR TITLE
fix(ci): pg_dump 17 を PATH 先頭に固定して pg_wrapper の解決ブレを防ぐ

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -44,8 +44,8 @@ jobs:
 
       # pg_dump はサーバーと同じメジャーバージョン以上が必要。
       # Supabase 本番は PostgreSQL 17 にアップグレード済みなので 17 を入れる。
-      # Ubuntu runner には client 16 が既に入っているため、pg_wrapper が 16 を
-      # 選ばないよう必ず最新メジャーを追加 install すること。
+      # Ubuntu runner の client 16 と pg_wrapper の優先順位に依存しないよう、
+      # 17 の bin を PATH 先頭に明示的に追加する。
       - name: Install PostgreSQL 17 client tools
         run: |
           sudo install -d /usr/share/postgresql-common/pgdg
@@ -54,6 +54,16 @@ jobs:
           sudo sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           sudo apt-get update -qq
           sudo apt-get install -y -qq postgresql-client-17
+          test -x /usr/lib/postgresql/17/bin/pg_dump
+          echo "/usr/lib/postgresql/17/bin" >> "$GITHUB_PATH"
+
+      - name: Verify pg_dump / psql resolves to 17
+        run: |
+          which pg_dump
+          pg_dump --version
+          which psql
+          psql --version
+          pg_dump --version | grep -q ' 17\.'
 
       # 適用前のロールバック用 dump。public schema はデータ込み、それ以外は構造のみ。
       # 重い時間がかかるほどデータが大きくなったら別 issue で再設計する。


### PR DESCRIPTION
## 概要 (What)

`db-migrate.yml` の PostgreSQL 17 client install ステップを強化し、`/usr/lib/postgresql/17/bin` を `GITHUB_PATH` の先頭に明示的に追加。直後に `pg_dump` / `psql` が 17 で解決されることを verify するステップを追加した。

## 背景 (Why)

PR #103 で `postgresql-client-17` を追加 install し、`supabase/config.toml` の `major_version` も 17 に揃えたが、本番 dispatch の再実行で以下の mismatch が再発した:

```
pg_dump: server version: 17.6; pg_dump version: 16.13 (Ubuntu 16.13-1.pgdg24.04+1)
```

Ubuntu runner には client 16 が default で入っており、`/usr/bin/pg_dump` を経由した pg_wrapper が 17 を選ばないケースがあったのが原因と推定。`apt` install だけでは経路が runner の状態に依存してしまうため、PATH 先頭で 17 のバイナリを直接指す形にハードニングする。

設計判断は ADR-0019 / ADR-0020 のまま変わらず、#103 で確定した方針の実装ハードニング。新規 ADR は不要。

## Before → After (概念・フロー・メンタルモデル)

**Before:** `postgresql-client-17` を install したうえで `/usr/bin/pg_dump`（pg_wrapper）の自動解決に任せる。runner に既存の client 16 が居るとどちらが選ばれるかが pg_wrapper の優先順位次第になる。

**After:** `/usr/lib/postgresql/17/bin` を `GITHUB_PATH` の先頭に追加し、pg_wrapper を経由せず 17 のバイナリを直接踏ませる。次のステップで `which pg_dump` / `pg_dump --version | grep ' 17\.'` を verify し、解決ブレが起きたら backup 取得前に fail させる。

## 追加したテスト (How verified)

- [x] workflow YAML の syntax を git diff レビューで確認
- [ ] 次回の `DB migrate (production)` 手動 dispatch で "Verify pg_dump / psql resolves to 17" ステップが通り、`pre-migration backup` が成功することで実証する（本 PR では runner 上での実行はしない）

## リリース前チェックリスト (When / Before merge)

該当なし（本番 DB スキーマの変更を伴わない CI 設定のみの修正）。

## このPRの範囲外 (Out of scope)

- `supabase/config.toml` の `major_version`（#103 で 17 に揃え済み）
- ローカル開発環境の Postgres バージョン（#103 で対応済み）
- Supabase CLI 自体のバージョン固定（別 issue で議論する余地あり）


---
_Generated by [Claude Code](https://claude.ai/code/session_018Zc12bkUzkgHt54qPKMeD4)_