### PR TITLE
feat(task-stack): Variant E 本実装移植 (P3-7, #92)

### DIFF
--- a/src/features/task-stack/DoneList.tsx
+++ b/src/features/task-stack/DoneList.tsx
@@ -1,13 +1,38 @@
-import type { Task } from "../../entities/task/types";
+import { getProject } from "@/entities/project/projects";
+import { useProjects } from "@/entities/project/ProjectsContext";
+import type { Task } from "@/entities/task/types";
+import { fmtDuration } from "@/shared/lib/time";
+import { ParallelogramProgress } from "@/shared/ui/ParallelogramProgress";
 
+import { buildStackItems, computeDoneProgress } from "./stackItems";
+
+/**
+ * Stack View の Done セクション (ADR 0016 §8)。
+ *
+ * - 行カードと同じ 2 行レイアウト + `opacity-50` で薄表示。
+ * - 子の done は ⤷ 親 + 進捗バー (currentIndex=0) を出す。
+ * - 親の done (decompose されなかった親 = leaf-parent) は ⤷ 親なしで title のみ。
+ * - 「戻す」ボタンで Stack 末尾に復元 (上から消化の原則を崩さない)。
+ *
+ * Stack 側の current 強調と被らないよう `currentIndex=0` で固定する。
+ */
 type DoneListProps = {
   doneTasks: Task[];
+  /** parent 解決のため pending+done 全件を渡す。 */
+  allTasks: readonly Task[];
   onOpenDetail: (id: string) => void;
   onToggleDone: (id: string) => void;
 };
 
-export function DoneList({ doneTasks, onOpenDetail, onToggleDone }: DoneListProps) {
+export function DoneList({ doneTasks, allTasks, onOpenDetail, onToggleDone }: DoneListProps) {
+  const { projectsById } = useProjects();
   if (doneTasks.length === 0) return null;
+
+  // done タスクを Item に変換 (child は親解決込み)。
+  // 親が done に落ちるケースは稀 (子が完了しても親は idle のまま) なので、
+  // buildStackItems の decomposed 除外をそのまま流用する。
+  const { items } = buildStackItems(doneTasks, allTasks);
+
   return (
     <>
       <div className="flex items-center gap-2 px-5 pb-2 pt-5">
@@ -17,34 +42,69 @@ export function DoneList({ doneTasks, onOpenDetail, onToggleDone }: DoneListProp
         <div className="h-px flex-1 bg-bg-border" />
         <span className="text-[9px] text-fg-faint">{doneTasks.length}</span>
       </div>
-      {doneTasks.map((task) => (
-        <div
-          key={task.id}
-          onClick={() => onOpenDetail(task.id)}
-          className="mx-4 flex cursor-pointer items-center gap-2.5 px-3.5 py-1.5 opacity-30"
-        >
-          <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
-            <polyline
-              points="3,8 7,12 13,4"
-              stroke="#22c55e"
-              strokeWidth="2.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-          <span className="font-jp text-[11px] text-fg-weak line-through">{task.title}</span>
-          <div className="flex-1" />
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onToggleDone(task.id);
-            }}
-            className="cursor-pointer rounded-[3px] border border-bg-divider bg-transparent px-1.5 py-0.5 font-jp text-[9px] text-fg-faint"
-          >
-            戻す
-          </button>
-        </div>
-      ))}
+      <ul role="list" aria-label="完了済みタスク" className="m-0 list-none p-0 opacity-50">
+        {items.map((item) => {
+          const task = item.task;
+          const proj = getProject(projectsById, task.projectId);
+          const parent = item.kind === "leaf-child" ? item.parent : undefined;
+          const parentColor = parent ? getProject(projectsById, parent.projectId).color : null;
+          const progress = parent ? computeDoneProgress(parent, allTasks) : null;
+          return (
+            <li key={item.id}>
+              <div
+                onClick={() => onOpenDetail(task.id)}
+                className="mx-4 cursor-pointer border-b border-bg-elevated px-2.5 py-2"
+              >
+                {/* Row 1: ProjectDot + title (line-through) + estimate + 戻す */}
+                <div className="flex items-center gap-2">
+                  <div
+                    className="h-1.5 w-1.5 shrink-0 rounded-full opacity-70"
+                    style={{ background: proj.color }}
+                  />
+                  <span className="flex-1 truncate font-jp text-[12px] text-fg-weak line-through">
+                    {task.title}
+                  </span>
+                  {task.estimatedMinutes !== null && (
+                    <span className="text-[9px] tabular-nums text-fg-faint">
+                      {fmtDuration(task.estimatedMinutes)}
+                    </span>
+                  )}
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onToggleDone(task.id);
+                    }}
+                    aria-label={`${task.title} を未完了に戻す`}
+                    className="cursor-pointer rounded-[3px] border border-bg-divider bg-transparent px-1.5 py-0.5 font-jp text-[9px] text-fg-faint"
+                  >
+                    戻す
+                  </button>
+                </div>
+                {/* Row 2: ⤷ 親 + progress (currentIndex=0) — 子のみ */}
+                {parent && progress && parentColor && (
+                  <div className="ml-[14px] mt-1 flex items-center gap-2">
+                    <span
+                      className="min-w-0 flex-1 truncate font-jp text-[9px]"
+                      style={{ color: `${parentColor}99` }}
+                      title={`親: ${parent.title}`}
+                    >
+                      ⤷ {parent.title}
+                    </span>
+                    <ParallelogramProgress
+                      total={progress.total}
+                      doneCount={progress.doneCount}
+                      currentIndex={progress.currentIndex}
+                      color={parentColor}
+                      size="sm"
+                    />
+                  </div>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
     </>
   );
 }

--- a/src/features/task-stack/StatusPill.tsx
+++ b/src/features/task-stack/StatusPill.tsx
@@ -1,0 +1,45 @@
+import type { DecomposeStatus } from "@/entities/task/types";
+
+/**
+ * 親の AI 分解状態を示す pill (ADR 0016 §4)。
+ * Stack 行 / Top カード下ゾーン Row 3 右詰の「分解状態スロット」で
+ * `ParallelogramProgress` と同じ位置に配置される。
+ *
+ * - `decomposing`: AI 分解中。`role=status` + `aria-live=polite` で読み上げる。
+ * - `skipped`: AI が分解不要と判断。
+ * - `none`: 分解未試行 (`AI_ENABLED=false` 等)。
+ * - `decomposed`: pill は出さない (進捗バーが代わりに出る)。
+ */
+type StatusPillProps = {
+  status: DecomposeStatus;
+};
+
+export function StatusPill({ status }: StatusPillProps) {
+  if (status === "decomposing") {
+    return (
+      <span
+        role="status"
+        aria-live="polite"
+        className="inline-flex items-center gap-1 rounded-[3px] bg-accent-blue/15 px-1.5 py-px font-jp text-[8px] text-accent-blue"
+      >
+        <span className="h-1 w-1 animate-pulse rounded-full bg-accent-blue" aria-hidden="true" />
+        AI 分解中
+      </span>
+    );
+  }
+  if (status === "skipped") {
+    return (
+      <span className="rounded-[3px] bg-fg-weak/15 px-1.5 py-px font-jp text-[8px] text-fg-weak">
+        分解不要
+      </span>
+    );
+  }
+  if (status === "none") {
+    return (
+      <span className="rounded-[3px] bg-fg-weak/10 px-1.5 py-px font-jp text-[8px] text-fg-faint">
+        未分解
+      </span>
+    );
+  }
+  return null;
+}

--- a/src/features/task-stack/TaskRow.tsx
+++ b/src/features/task-stack/TaskRow.tsx
@@ -1,20 +1,39 @@
-import type { Task } from "../../entities/task/types";
-import type { Event } from "../../entities/event/types";
 import type { PointerEvent as ReactPointerEvent } from "react";
-import { getProject } from "../../entities/project/projects";
-import { useProjects } from "../../entities/project/ProjectsContext";
-import { IMMINENT_THRESHOLD_MS, fmtDuration, formatRelativeTime } from "../../shared/lib/time";
-import { Grip } from "./Grip";
 
+import { getProject } from "@/entities/project/projects";
+import { useProjects } from "@/entities/project/ProjectsContext";
+import type { Event } from "@/entities/event/types";
+import type { Task } from "@/entities/task/types";
+import { ParallelogramProgress } from "@/shared/ui/ParallelogramProgress";
+import { IMMINENT_THRESHOLD_MS, fmtDuration, formatRelativeTime } from "@/shared/lib/time";
+
+import { Grip } from "./Grip";
+import type { Progress } from "./stackItems";
+import { StatusPill } from "./StatusPill";
+
+/**
+ * Stack View の行カード (Top 以外) (ADR 0016 §3)。
+ *
+ * 3 行構成:
+ * - Row 1: Grip + ProjectDot + title (左) + estimate (右)
+ * - Row 2: dep event (右詰) ※子は親の dep に fallback (§6)
+ * - Row 3: ⤷ 親タスク名 (左) + 進捗バー | 分解状態 pill (右)
+ *
+ * 完了 checkbox は出さない (Top-only complete; ADR 0016 §7)。
+ * leaf-parent (親自身が Stack 行) は「⤷ 親」を出さず、status pill のみ。
+ */
 type TaskRowProps = {
   task: Task;
   events: readonly Event[];
   /** 現在時刻 (ms)。依存イベントの相対時刻 / 直近判定で使う。0 は SSR placeholder。 */
   now: number;
   isBeingDragged: boolean;
+  /** 子タスクなら親 Task。leaf-parent では undefined。 */
+  parent?: Task;
+  /** 子タスクなら親に紐付く進捗。leaf-parent では undefined。 */
+  progress?: Progress;
   onPointerDown: (e: ReactPointerEvent<HTMLElement>) => void;
   onClick: () => void;
-  onToggleDone: () => void;
 };
 
 export function TaskRow({
@@ -22,72 +41,97 @@ export function TaskRow({
   events,
   now,
   isBeingDragged,
+  parent,
+  progress,
   onPointerDown,
   onClick,
-  onToggleDone,
 }: TaskRowProps) {
   const { projectsById } = useProjects();
   const proj = getProject(projectsById, task.projectId);
-  const dep = task.dependsOnEventId ? events.find((e) => e.id === task.dependsOnEventId) : null;
+
+  // ADR 0016 §6: 子は親の dependsOnEventId を継承 (子自身の値がなければ親に fallback)。
+  const effectiveDepId = task.dependsOnEventId ?? parent?.dependsOnEventId ?? null;
+  const dep = effectiveDepId ? events.find((e) => e.id === effectiveDepId) : null;
   const depImminent =
     dep !== null &&
     dep !== undefined &&
     now > 0 &&
     new Date(dep.startTime).getTime() - now <= IMMINENT_THRESHOLD_MS;
 
+  const showProgress = parent !== undefined && progress !== undefined;
+  // leaf-parent (= 親自身が Stack 行) のときは status pill。decomposing/skipped/none を表示。
+  const showStatusPill = parent === undefined && task.decomposeStatus !== "decomposed";
+
   return (
     <div
       onClick={onClick}
-      className={`mx-4 flex cursor-pointer items-center gap-2 border-b border-bg-elevated px-2.5 py-2 transition-opacity duration-150 ${
+      className={`mx-4 cursor-pointer border-b border-bg-elevated px-2.5 py-2 transition-opacity duration-150 ${
         isBeingDragged ? "opacity-30" : "opacity-100"
       }`}
     >
-      <div
-        onPointerDown={(e) => {
-          e.stopPropagation();
-          onPointerDown(e);
-        }}
-        className="shrink-0 cursor-grab touch-none p-0.5"
-      >
-        <Grip />
-      </div>
-      <div
-        className="h-1.5 w-1.5 shrink-0 rounded-full opacity-70"
-        style={{ background: proj.color }}
-      />
-      <span className="flex-1 truncate font-jp text-[12px] text-fg-muted">{task.title}</span>
-      {dep && (
-        <span
-          className={`max-w-[140px] shrink-0 truncate rounded-[3px] px-1 py-px font-jp text-[8px] text-accent-amber ${
-            depImminent ? "bg-[#E85D0440] font-semibold" : "bg-[#E85D0415]"
-          }`}
-          title={`${dep.title} (${formatRelativeTime(dep.startTime, new Date(now))})`}
+      {/* Row 1: Grip + ProjectDot + title + estimate */}
+      <div className="flex items-center gap-2">
+        <div
+          onPointerDown={(e) => {
+            e.stopPropagation();
+            onPointerDown(e);
+          }}
+          aria-label="並び替えハンドル"
+          className="shrink-0 cursor-grab touch-none p-0.5"
         >
-          ← {formatRelativeTime(dep.startTime, new Date(now))} {dep.title}
-        </span>
+          <Grip />
+        </div>
+        <div
+          className="h-1.5 w-1.5 shrink-0 rounded-full opacity-70"
+          style={{ background: proj.color }}
+        />
+        <span className="flex-1 truncate font-jp text-[12px] text-fg-muted">{task.title}</span>
+        {task.estimatedMinutes !== null && (
+          <span className="text-[9px] tabular-nums text-fg-faint">
+            {fmtDuration(task.estimatedMinutes)}
+          </span>
+        )}
+      </div>
+      {/* Row 2: dep event (右詰) */}
+      {dep && (
+        <div className="ml-[26px] mt-1 flex items-center justify-end">
+          <span
+            className={`max-w-[180px] truncate rounded-[3px] px-1.5 py-px font-jp text-[8px] text-accent-amber ${
+              depImminent ? "bg-[#E85D0440] font-semibold" : "bg-[#E85D0415]"
+            }`}
+            title={`${dep.title} (${formatRelativeTime(dep.startTime, new Date(now))})`}
+          >
+            ← {formatRelativeTime(dep.startTime, new Date(now))} {dep.title}
+          </span>
+        </div>
       )}
-      {task.estimatedMinutes !== null && (
-        <span className="text-[9px] tabular-nums text-fg-faint">
-          {fmtDuration(task.estimatedMinutes)}
-        </span>
+      {/* Row 3: ⤷ 親 (左) + progress | status pill (右) */}
+      {(showProgress || showStatusPill) && (
+        <div className="ml-[26px] mt-1 flex items-center gap-2">
+          {showProgress && parent ? (
+            <span
+              className="min-w-0 flex-1 truncate font-jp text-[9px]"
+              style={{ color: `${getProject(projectsById, parent.projectId).color}cc` }}
+              title={`親: ${parent.title}`}
+            >
+              ⤷ {parent.title}
+            </span>
+          ) : (
+            <span className="min-w-0 flex-1" />
+          )}
+          {showProgress && progress && parent ? (
+            <ParallelogramProgress
+              total={progress.total}
+              doneCount={progress.doneCount}
+              currentIndex={progress.currentIndex}
+              color={getProject(projectsById, parent.projectId).color}
+              size="sm"
+            />
+          ) : showStatusPill ? (
+            <StatusPill status={task.decomposeStatus} />
+          ) : null}
+        </div>
       )}
-      <button
-        onClick={(e) => {
-          e.stopPropagation();
-          onToggleDone();
-        }}
-        className="flex h-[22px] w-[22px] shrink-0 cursor-pointer items-center justify-center rounded-[5px] border border-bg-divider bg-transparent text-fg-weak"
-      >
-        <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
-          <polyline
-            points="3,8 7,12 13,4"
-            stroke="currentColor"
-            strokeWidth="2.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-      </button>
     </div>
   );
 }

--- a/src/features/task-stack/TaskStack.test.tsx
+++ b/src/features/task-stack/TaskStack.test.tsx
@@ -1,13 +1,15 @@
 import { fireEvent, render as rtlRender } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { Event } from "@/entities/event/types";
+import { ProjectsProvider } from "@/entities/project/ProjectsContext";
+import type { Project } from "@/entities/project/types";
+import type { Task } from "@/entities/task/types";
+
 import { DoneList } from "./DoneList";
 import { TaskRow } from "./TaskRow";
 import { TaskStack, type TopTimerBinding } from "./TaskStack";
 import { TopTaskCard } from "./TopTaskCard";
-import type { Task } from "../../entities/task/types";
-import type { Event } from "../../entities/event/types";
-import type { Project } from "../../entities/project/types";
-import { ProjectsProvider } from "../../entities/project/ProjectsContext";
 
 // 依存イベントの相対時刻表現は「現在時刻」依存。テストは固定時刻 2026-04-11T09:00 で評価する。
 const FIXED_NOW = new Date("2026-04-11T09:00:00");
@@ -21,6 +23,7 @@ afterEach(() => {
 
 const projects: Project[] = [
   { id: "slo", name: "SLO推進", color: "#2D9F45", isPrimary: true, createdAt: "" },
+  { id: "career", name: "転職活動", color: "#E85D04", isPrimary: false, createdAt: "" },
 ];
 const render = (ui: React.ReactElement) =>
   rtlRender(<ProjectsProvider projects={projects}>{ui}</ProjectsProvider>);
@@ -90,8 +93,7 @@ describe("TopTaskCard", () => {
     expect(getByText("SLO推進")).toBeTruthy();
   });
 
-  test("dependsOnEventId の依存イベントを解決してバッジ表示 (相対時刻 + タイトル)", () => {
-    // FIXED_NOW=09:00, event=14:00 → 5時間後 → 「今日 14:00 MTG」
+  test("dependsOnEventId の依存イベントを解決してバッジ表示", () => {
     const { getByText } = render(
       <TopTaskCard
         {...topProps}
@@ -107,15 +109,16 @@ describe("TopTaskCard", () => {
     expect(getByText("要件整理")).toBeTruthy();
   });
 
-  test("idle タスクは『開始』ボタンを表示し onStart を呼ぶ", () => {
+  test("idle タスクでも『開始』+『完了』ボタンを表示する (Top-only complete; ADR 0016 §7)", () => {
     const onStart = vi.fn();
-    const onClick = vi.fn();
+    const onComplete = vi.fn();
     const { getByLabelText } = render(
-      <TopTaskCard {...topProps} task={baseTask} onStart={onStart} onClick={onClick} />,
+      <TopTaskCard {...topProps} task={baseTask} onStart={onStart} onComplete={onComplete} />,
     );
     fireEvent.click(getByLabelText("開始"));
     expect(onStart).toHaveBeenCalledTimes(1);
-    expect(onClick).not.toHaveBeenCalled();
+    fireEvent.click(getByLabelText("完了"));
+    expect(onComplete).toHaveBeenCalledTimes(1);
   });
 
   test("active タスクは中断/完了ボタンと経過時間を表示する", () => {
@@ -137,19 +140,75 @@ describe("TopTaskCard", () => {
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
 
-  test("paused タスクは『再開』ボタンと中断理由バッジを表示する", () => {
+  test("paused タスクは『再開』+『完了』を表示する", () => {
     const onResume = vi.fn();
+    const onComplete = vi.fn();
     const { getByLabelText, getByText } = render(
       <TopTaskCard
         {...topProps}
         task={{ ...baseTask, status: "paused" }}
         pauseReason="meeting"
         onResume={onResume}
+        onComplete={onComplete}
       />,
     );
     expect(getByText("中断: MTG")).toBeTruthy();
     fireEvent.click(getByLabelText("再開"));
     expect(onResume).toHaveBeenCalledTimes(1);
+    fireEvent.click(getByLabelText("完了"));
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  test("leaf-child の Top は ⤷ 親 + 進捗バーを下ゾーンに出す", () => {
+    const parent: Task = {
+      ...baseTask,
+      id: "p1",
+      title: "面接対策",
+      decomposeStatus: "decomposed",
+    };
+    const child: Task = { ...baseTask, id: "c1", title: "志望動機A", parentTaskId: "p1" };
+    const { getByText, getByRole } = render(
+      <TopTaskCard
+        {...topProps}
+        task={child}
+        parent={parent}
+        progress={{ total: 3, doneCount: 1, currentIndex: 2, totalMinutes: 90 }}
+      />,
+    );
+    expect(getByText(/⤷ 面接対策/)).toBeTruthy();
+    const bar = getByRole("progressbar");
+    expect(bar.getAttribute("aria-valuenow")).toBe("1");
+    expect(bar.getAttribute("aria-valuemax")).toBe("3");
+    expect(bar.getAttribute("aria-label")).toMatch(/進捗 1\/3、現在 2\/3/);
+  });
+
+  test("leaf-parent (decomposing) の Top は status pill を下ゾーンに出す", () => {
+    const { getByRole, queryByText } = render(
+      <TopTaskCard {...topProps} task={{ ...baseTask, decomposeStatus: "decomposing" }} />,
+    );
+    expect(getByRole("status").textContent).toContain("AI 分解中");
+    expect(queryByText(/⤷ /)).toBeNull();
+  });
+
+  test("子の dependsOnEventId が null なら親の dep を継承する (ADR 0016 §6)", () => {
+    const parent: Task = {
+      ...baseTask,
+      id: "p1",
+      title: "面接対策",
+      decomposeStatus: "decomposed",
+      dependsOnEventId: "e1",
+    };
+    const child: Task = { ...baseTask, id: "c1", title: "志望動機A", parentTaskId: "p1" };
+    const { getByText } = render(
+      <TopTaskCard
+        {...topProps}
+        task={child}
+        parent={parent}
+        events={[baseEvent]}
+        progress={{ total: 1, doneCount: 0, currentIndex: 1, totalMinutes: 30 }}
+      />,
+    );
+    expect(getByText(/今日 14:00 MTG/)).toBeTruthy();
   });
 });
 
@@ -163,12 +222,26 @@ describe("TaskRow", () => {
         isBeingDragged={false}
         onPointerDown={noop}
         onClick={noop}
-        onToggleDone={noop}
       />,
     );
     expect(getByText("SLI 定義更新")).toBeTruthy();
     // estimatedMinutes=45 → fmtDuration → "45m"
     expect(getByText("45m")).toBeTruthy();
+  });
+
+  test("完了 checkbox は表示しない (Top-only complete; ADR 0016 §7)", () => {
+    const { queryByLabelText } = render(
+      <TaskRow
+        task={baseTask}
+        events={[]}
+        now={NOW_MS}
+        isBeingDragged={false}
+        onPointerDown={noop}
+        onClick={noop}
+      />,
+    );
+    expect(queryByLabelText("完了")).toBeNull();
+    expect(queryByLabelText("SLI 定義更新 を完了")).toBeNull();
   });
 
   test("dependsOnEventId があれば「相対時刻 + タイトル」のバッジを表示", () => {
@@ -180,7 +253,6 @@ describe("TaskRow", () => {
         isBeingDragged={false}
         onPointerDown={noop}
         onClick={noop}
-        onToggleDone={noop}
       />,
     );
     expect(getByText(/今日 14:00 MTG/)).toBeTruthy();
@@ -195,43 +267,131 @@ describe("TaskRow", () => {
         isBeingDragged={false}
         onPointerDown={noop}
         onClick={noop}
-        onToggleDone={noop}
       />,
     );
     expect(queryByText(/MTG/)).toBeNull();
     expect(queryByText(/今日/)).toBeNull();
+  });
+
+  test("leaf-child の行カードは ⤷ 親 + 進捗バーを Row 3 に出す", () => {
+    const parent: Task = {
+      ...baseTask,
+      id: "p1",
+      title: "面接対策",
+      decomposeStatus: "decomposed",
+    };
+    const child: Task = { ...baseTask, id: "c1", title: "志望動機A", parentTaskId: "p1" };
+    const { getByText, getByRole } = render(
+      <TaskRow
+        task={child}
+        events={[]}
+        now={NOW_MS}
+        isBeingDragged={false}
+        parent={parent}
+        progress={{ total: 3, doneCount: 1, currentIndex: 2, totalMinutes: 90 }}
+        onPointerDown={noop}
+        onClick={noop}
+      />,
+    );
+    expect(getByText(/⤷ 面接対策/)).toBeTruthy();
+    expect(getByRole("progressbar").getAttribute("aria-label")).toMatch(/進捗 1\/3、現在 2\/3/);
+  });
+
+  test("leaf-parent (decomposing) の行カードは status pill を出す", () => {
+    const { getByRole } = render(
+      <TaskRow
+        task={{ ...baseTask, decomposeStatus: "decomposing" }}
+        events={[]}
+        now={NOW_MS}
+        isBeingDragged={false}
+        onPointerDown={noop}
+        onClick={noop}
+      />,
+    );
+    expect(getByRole("status").textContent).toContain("AI 分解中");
+  });
+
+  test("leaf-parent (none) の行カードは『未分解』pill を出す", () => {
+    const { getByText } = render(
+      <TaskRow
+        task={baseTask}
+        events={[]}
+        now={NOW_MS}
+        isBeingDragged={false}
+        onPointerDown={noop}
+        onClick={noop}
+      />,
+    );
+    expect(getByText("未分解")).toBeTruthy();
   });
 });
 
 describe("DoneList", () => {
   test("空なら何も描画しない", () => {
     const { container } = render(
-      <DoneList doneTasks={[]} onOpenDetail={noop} onToggleDone={noop} />,
+      <DoneList doneTasks={[]} allTasks={[]} onOpenDetail={noop} onToggleDone={noop} />,
     );
     expect(container.firstChild).toBeNull();
   });
 
   test("done タスクのタイトルと「戻す」ボタンを表示", () => {
     const doneTasks: Task[] = [{ ...baseTask, status: "done" }];
-    const { getByText } = render(
-      <DoneList doneTasks={doneTasks} onOpenDetail={noop} onToggleDone={noop} />,
+    const { getByText, getByLabelText } = render(
+      <DoneList
+        doneTasks={doneTasks}
+        allTasks={doneTasks}
+        onOpenDetail={noop}
+        onToggleDone={noop}
+      />,
     );
     expect(getByText("SLI 定義更新")).toBeTruthy();
-    expect(getByText("戻す")).toBeTruthy();
-    expect(getByText(/^\d+$/)).toBeTruthy(); // count バッジ
+    expect(getByLabelText("SLI 定義更新 を未完了に戻す")).toBeTruthy();
   });
 
   test("「戻す」ボタンで onToggleDone(taskId) が呼ばれる", () => {
     const onToggleDone = vi.fn();
-    const { getByText } = render(
+    const doneTasks: Task[] = [{ ...baseTask, status: "done" }];
+    const { getByLabelText } = render(
       <DoneList
-        doneTasks={[{ ...baseTask, status: "done" }]}
+        doneTasks={doneTasks}
+        allTasks={doneTasks}
         onOpenDetail={noop}
         onToggleDone={onToggleDone}
       />,
     );
-    fireEvent.click(getByText("戻す"));
+    fireEvent.click(getByLabelText("SLI 定義更新 を未完了に戻す"));
     expect(onToggleDone).toHaveBeenCalledWith("t1");
+  });
+
+  test("子の done は ⤷ 親 + 進捗バー (currentIndex=0) を出す", () => {
+    const parent: Task = {
+      ...baseTask,
+      id: "p1",
+      title: "面接対策",
+      decomposeStatus: "decomposed",
+    };
+    const doneChild: Task = {
+      ...baseTask,
+      id: "c1",
+      title: "志望動機A",
+      parentTaskId: "p1",
+      status: "done",
+    };
+    const pendingChild: Task = { ...baseTask, id: "c2", title: "志望動機B", parentTaskId: "p1" };
+    const { getByRole, getByText } = render(
+      <DoneList
+        doneTasks={[doneChild]}
+        allTasks={[parent, doneChild, pendingChild]}
+        onOpenDetail={noop}
+        onToggleDone={noop}
+      />,
+    );
+    expect(getByText(/⤷ 面接対策/)).toBeTruthy();
+    const bar = getByRole("progressbar");
+    expect(bar.getAttribute("aria-valuenow")).toBe("1");
+    expect(bar.getAttribute("aria-valuemax")).toBe("2");
+    // currentIndex=0 → aria-label に「現在 X/Y」を含まない
+    expect(bar.getAttribute("aria-label")).toBe("進捗 1/2");
   });
 });
 
@@ -259,6 +419,47 @@ describe("TaskStack", () => {
     expect(getByText("Second task")).toBeTruthy();
     expect(getByText("Third task")).toBeTruthy();
     expect(getAllByText("3")).toBeTruthy();
+  });
+
+  test("decomposed 親は Stack 行から消え、子だけがフラットに並ぶ (ADR 0016 §1)", () => {
+    const parent: Task = {
+      ...baseTask,
+      id: "p1",
+      title: "面接対策",
+      projectId: "career",
+      decomposeStatus: "decomposed",
+    };
+    const c1: Task = {
+      ...baseTask,
+      id: "c1",
+      title: "志望動機A",
+      projectId: "career",
+      parentTaskId: "p1",
+      stackOrder: 1,
+    };
+    const c2: Task = {
+      ...baseTask,
+      id: "c2",
+      title: "志望動機B",
+      projectId: "career",
+      parentTaskId: "p1",
+      stackOrder: 2,
+    };
+    const { queryByText, getByText } = render(
+      <TaskStack
+        events={[]}
+        now={NOW_MS}
+        pendingTasks={[parent, c1, c2]}
+        doneTasks={[]}
+        topTimer={idleTimer}
+        onReorder={noop}
+        onToggleDone={noop}
+        onOpenDetail={noop}
+      />,
+    );
+    expect(queryByText("面接対策")).toBeNull(); // 親は Stack 行に出ない
+    expect(getByText("志望動機A")).toBeTruthy();
+    expect(getByText("志望動機B")).toBeTruthy();
   });
 
   test("done が混在すると DoneList も表示される", () => {

--- a/src/features/task-stack/TaskStack.tsx
+++ b/src/features/task-stack/TaskStack.tsx
@@ -1,7 +1,11 @@
-import type { Event } from "../../entities/event/types";
-import type { PauseReason } from "../../entities/task/time-entries";
-import type { Task } from "../../entities/task/types";
+import { useMemo } from "react";
+
+import type { Event } from "@/entities/event/types";
+import type { PauseReason } from "@/entities/task/time-entries";
+import type { Task } from "@/entities/task/types";
+
 import { DoneList } from "./DoneList";
+import { buildStackItems, computeChildProgress } from "./stackItems";
 import { TaskRow } from "./TaskRow";
 import { TopTaskCard } from "./TopTaskCard";
 import { useStackDnD } from "./useStackDnD";
@@ -53,25 +57,35 @@ export function TaskStack({
   onToggleDone,
   onOpenDetail,
 }: TaskStackProps) {
+  // ADR 0016 §1: decomposed 親を Stack 行から除外し、子をフラット化。
+  const allTasks = useMemo(() => [...pendingTasks, ...doneTasks], [pendingTasks, doneTasks]);
+  const { items } = useMemo(
+    () => buildStackItems(pendingTasks, allTasks),
+    [pendingTasks, allTasks],
+  );
+
   const { dragIdx, overIdx, rowRefs, handlePointerDown } = useStackDnD(onReorder);
 
   return (
     <>
-      <StackHeader count={pendingTasks.length} />
+      <StackHeader count={items.length} />
 
       {/*
         並び順が意味を持つリスト。role=list / listitem を立てておくと
         スクリーンリーダーが項目数を読み上げ、e2e も semantic に取れる。
       */}
       <ul role="list" aria-label="タスクスタック" className="m-0 list-none p-0">
-        {pendingTasks.map((task, idx) => {
+        {items.map((item, idx) => {
           const isFirst = idx === 0;
           const isBeingDragged = dragIdx === idx;
           const isDropTarget = overIdx === idx && dragIdx !== null && dragIdx !== idx;
+          const task = item.task;
+          const parent = item.kind === "leaf-child" ? item.parent : undefined;
+          const progress = parent ? computeChildProgress(task, parent, allTasks, items) : undefined;
 
           return (
             <li
-              key={task.id}
+              key={item.id}
               ref={(el: HTMLLIElement | null) => {
                 rowRefs.current[idx] = el;
               }}
@@ -85,6 +99,8 @@ export function TaskStack({
                   isBeingDragged={isBeingDragged}
                   elapsedSeconds={topTimer.elapsedSeconds}
                   pauseReason={topTimer.pauseReason}
+                  parent={parent}
+                  progress={progress}
                   onPointerDown={(e) => handlePointerDown(idx, e)}
                   onClick={() => onOpenDetail(task.id)}
                   onStart={topTimer.onStart}
@@ -98,9 +114,10 @@ export function TaskStack({
                   events={events}
                   now={now}
                   isBeingDragged={isBeingDragged}
+                  parent={parent}
+                  progress={progress}
                   onPointerDown={(e) => handlePointerDown(idx, e)}
                   onClick={() => onOpenDetail(task.id)}
-                  onToggleDone={() => onToggleDone(task.id)}
                 />
               )}
             </li>
@@ -108,7 +125,12 @@ export function TaskStack({
         })}
       </ul>
 
-      <DoneList doneTasks={doneTasks} onOpenDetail={onOpenDetail} onToggleDone={onToggleDone} />
+      <DoneList
+        doneTasks={doneTasks}
+        allTasks={allTasks}
+        onOpenDetail={onOpenDetail}
+        onToggleDone={onToggleDone}
+      />
     </>
   );
 }

--- a/src/features/task-stack/TopTaskCard.tsx
+++ b/src/features/task-stack/TopTaskCard.tsx
@@ -1,28 +1,44 @@
 import type { PointerEvent as ReactPointerEvent } from "react";
 
-import type { Event } from "../../entities/event/types";
-import { getProject } from "../../entities/project/projects";
-import { useProjects } from "../../entities/project/ProjectsContext";
-import type { PauseReason } from "../../entities/task/time-entries";
-import type { Task } from "../../entities/task/types";
-import { IMMINENT_THRESHOLD_MS, formatRelativeTime } from "../../shared/lib/time";
+import type { Event } from "@/entities/event/types";
+import { getProject } from "@/entities/project/projects";
+import { useProjects } from "@/entities/project/ProjectsContext";
+import type { PauseReason } from "@/entities/task/time-entries";
+import type { Task } from "@/entities/task/types";
+import { bodyPreview } from "@/shared/lib/body-preview";
+import { IMMINENT_THRESHOLD_MS, fmtDuration, formatRelativeTime } from "@/shared/lib/time";
+import { ParallelogramProgress } from "@/shared/ui/ParallelogramProgress";
+
 import { Grip } from "./Grip";
 import { pauseReasonLabel } from "./PauseReasonModal";
+import type { Progress } from "./stackItems";
+import { StatusPill } from "./StatusPill";
 import { formatElapsed } from "./useTaskTimer";
 
-function bodyPreview(body: string): string {
-  if (!body) return "";
-  return body.split("\n").find((l) => l.trim() && !l.startsWith("#")) || "";
-}
-
+/**
+ * Stack View の Top カード (ADR 0016 §2)。
+ *
+ * 上下 2 ゾーン構造:
+ * - 上ゾーン (Top 専用 / 着手集中): project header + 状態 badge + 大タイトル
+ *   + Timer Controls + body preview + 自タスク見積もり
+ * - 下ゾーン (行カードと共通参照): dep (右詰) → ⤷ 親 + 合計 + progress | status pill
+ *
+ * leaf-parent (親自身が Top) のときは下ゾーンの「⤷ 親」を省き、status pill のみ。
+ *
+ * 完了は idle / active / paused いずれの状態でも常時表示 (Top-only complete; §7)。
+ */
 type TopTaskCardProps = {
   task: Task;
-  events: Event[];
-  /** 現在時刻 (ms)。依存イベントの相対時刻 / 直近判定で使う。0 は SSR placeholder で計算をスキップ。 */
+  events: readonly Event[];
+  /** 現在時刻 (ms)。依存イベントの相対時刻 / 直近判定で使う。0 は SSR placeholder。 */
   now: number;
   isBeingDragged: boolean;
   elapsedSeconds: number;
   pauseReason: PauseReason | null;
+  /** 子タスクなら親 Task。leaf-parent では undefined。 */
+  parent?: Task;
+  /** 子タスクなら親に紐付く進捗。leaf-parent では undefined。 */
+  progress?: Progress;
   onPointerDown: (e: ReactPointerEvent<HTMLElement>) => void;
   onClick: () => void;
   onStart: () => void;
@@ -38,6 +54,8 @@ export function TopTaskCard({
   isBeingDragged,
   elapsedSeconds,
   pauseReason,
+  parent,
+  progress,
   onPointerDown,
   onClick,
   onStart,
@@ -47,14 +65,16 @@ export function TopTaskCard({
 }: TopTaskCardProps) {
   const { projectsById } = useProjects();
   const proj = getProject(projectsById, task.projectId);
-  const dep = task.dependsOnEventId ? events.find((e) => e.id === task.dependsOnEventId) : null;
-  // 24h 以内に迫っている依存はハイライト (背景濃度 + 太字) して着手判断のシグナルを強める。
-  // now=0 (SSR placeholder) のときは判定スキップ。
+
+  // ADR 0016 §6: 子は親の dependsOnEventId を継承 (子自身の値がなければ親に fallback)。
+  const effectiveDepId = task.dependsOnEventId ?? parent?.dependsOnEventId ?? null;
+  const dep = effectiveDepId ? events.find((e) => e.id === effectiveDepId) : null;
   const depImminent =
     dep !== null &&
     dep !== undefined &&
     now > 0 &&
     new Date(dep.startTime).getTime() - now <= IMMINENT_THRESHOLD_MS;
+
   const preview = bodyPreview(task.body);
   const isActive = task.status === "active";
   const isPaused = task.status === "paused";
@@ -62,42 +82,36 @@ export function TopTaskCard({
   return (
     <div
       onClick={onClick}
-      className={`relative mx-4 mb-1 cursor-pointer overflow-hidden rounded-[10px] bg-bg-elevated py-3.5 pl-[18px] pr-3.5 transition-opacity duration-150 ${
+      className={`relative mx-4 mb-1 cursor-pointer overflow-hidden rounded-[10px] bg-bg-elevated py-3.5 pl-[14px] pr-3.5 transition-opacity duration-150 ${
         isBeingDragged ? "opacity-40" : "opacity-100"
       }`}
-      style={{
-        border: `1px solid ${proj.color}40`,
-      }}
+      style={{ border: `1px solid ${proj.color}40` }}
     >
-      <div className="absolute bottom-0 left-0 top-0 w-[3px]" style={{ background: proj.color }} />
-      <div className="flex items-start gap-2.5">
+      <div
+        aria-hidden="true"
+        className="absolute bottom-0 left-0 top-0 w-[3px]"
+        style={{ background: proj.color }}
+      />
+      <div className="flex items-start gap-2">
         <div
           onPointerDown={(e) => {
             e.stopPropagation();
             onPointerDown(e);
           }}
+          aria-label="並び替えハンドル"
           className="mt-1.5 shrink-0 cursor-grab touch-none px-0.5 py-1"
         >
           <Grip />
         </div>
-        <div className="flex-1">
-          <div className="mb-1 flex items-center gap-2">
+        <div className="min-w-0 flex-1">
+          {/* ----------- 上ゾーン: project + state badge + title + Timer + preview ----------- */}
+          <div className="flex flex-wrap items-center gap-2">
             <div className="h-2 w-2 rounded-full" style={{ background: proj.color }} />
             <span className="font-jp text-[9px] text-fg-subtle">{proj.name}</span>
-            {dep && (
-              <span
-                className={`max-w-[180px] truncate rounded-[3px] px-1.5 py-px font-jp text-[8px] text-accent-amber ${
-                  depImminent ? "bg-[#E85D0440] font-semibold" : "bg-[#E85D0415]"
-                }`}
-                title={`${dep.title} (${formatRelativeTime(dep.startTime, new Date(now))})`}
-              >
-                ← {formatRelativeTime(dep.startTime, new Date(now))} {dep.title}
-              </span>
-            )}
             {isActive && (
               <span
-                className="rounded-[3px] bg-accent-blue/15 px-1.5 py-px font-jp text-[9px] font-semibold tabular-nums text-accent-blue"
                 aria-label="経過時間"
+                className="rounded-[3px] bg-accent-blue/15 px-1.5 py-px font-jp text-[9px] font-semibold tabular-nums text-accent-blue"
               >
                 ● {formatElapsed(elapsedSeconds)}
               </span>
@@ -107,29 +121,107 @@ export function TopTaskCard({
                 中断: {pauseReasonLabel(pauseReason)}
               </span>
             )}
+            {task.estimatedMinutes !== null && (
+              <span className="ml-auto text-[10px] tabular-nums text-fg-faint">
+                {fmtDuration(task.estimatedMinutes)}
+              </span>
+            )}
           </div>
-          <div className="font-jp text-[15px] font-semibold leading-[1.4] text-fg-strong">
-            {task.title}
+          <div className="mt-1 flex items-start gap-2">
+            <div className="flex-1 font-jp text-[15px] font-semibold leading-[1.4] text-fg-strong">
+              {task.title}
+            </div>
+            <TimerControls
+              status={task.status}
+              color={proj.color}
+              onStart={onStart}
+              onPauseRequest={onPauseRequest}
+              onResume={onResume}
+              onComplete={onComplete}
+            />
           </div>
           {preview && (
             <div className="mt-1 truncate font-jp text-[10px] text-fg-weak">{preview}</div>
           )}
+
+          {/* ----------- 下ゾーン: dep / ⤷ 親 + 合計 + progress | status pill ----------- */}
+          <div className="mt-3 border-t border-bg-border/60 pt-2">
+            {/* Row 2: dep (右詰)。slot は常時確保 (ADR 0016 §6) */}
+            <div className="flex min-h-[16px] items-center justify-end">
+              {dep && (
+                <span
+                  className={`max-w-[180px] truncate rounded-[3px] px-1.5 py-px font-jp text-[8px] text-accent-amber ${
+                    depImminent ? "bg-[#E85D0440] font-semibold" : "bg-[#E85D0415]"
+                  }`}
+                  title={`${dep.title} (${formatRelativeTime(dep.startTime, new Date(now))})`}
+                >
+                  ← {formatRelativeTime(dep.startTime, new Date(now))} {dep.title}
+                </span>
+              )}
+            </div>
+            {/* Row 3: ⤷ 親 (左) + 合計 (中) + progress | status pill (右) */}
+            <BottomRow task={task} parent={parent} progress={progress} />
+          </div>
         </div>
-        <TimerControls
-          task={task}
-          color={proj.color}
-          onStart={onStart}
-          onPauseRequest={onPauseRequest}
-          onResume={onResume}
-          onComplete={onComplete}
-        />
       </div>
     </div>
   );
 }
 
-type TimerControlsProps = {
+function BottomRow({
+  task,
+  parent,
+  progress,
+}: {
   task: Task;
+  parent: Task | undefined;
+  progress: Progress | undefined;
+}) {
+  const { projectsById } = useProjects();
+  const showProgress = parent !== undefined && progress !== undefined;
+  const showStatusPill = parent === undefined && task.decomposeStatus !== "decomposed";
+
+  if (!showProgress && !showStatusPill) return null;
+
+  if (!showProgress) {
+    // leaf-parent: ⤷ 親 を出さず、status pill のみ右詰
+    return (
+      <div className="mt-1 flex items-center justify-end">
+        <StatusPill status={task.decomposeStatus} />
+      </div>
+    );
+  }
+
+  // leaf-child: ⤷ 親 + 合計 + progress
+  if (!parent || !progress) return null;
+  const parentColor = getProject(projectsById, parent.projectId).color;
+  return (
+    <div className="mt-1 flex items-center gap-2">
+      <span
+        className="min-w-0 flex-1 truncate font-jp text-[10px]"
+        style={{ color: `${parentColor}cc` }}
+        title={`親: ${parent.title}`}
+      >
+        ⤷ {parent.title}
+      </span>
+      {progress.totalMinutes !== null && (
+        <span className="font-jp text-[10px] tabular-nums text-fg-muted">
+          合計 {fmtDuration(progress.totalMinutes)}
+        </span>
+      )}
+      <ParallelogramProgress
+        total={progress.total}
+        doneCount={progress.doneCount}
+        currentIndex={progress.currentIndex}
+        color={parentColor}
+        size="md"
+      />
+    </div>
+  );
+}
+
+type TimerControlsProps = {
+  status: Task["status"];
   color: string;
   onStart: () => void;
   onPauseRequest: () => void;
@@ -138,7 +230,7 @@ type TimerControlsProps = {
 };
 
 function TimerControls({
-  task,
+  status,
   color,
   onStart,
   onPauseRequest,
@@ -149,9 +241,21 @@ function TimerControls({
     e.stopPropagation();
     fn();
   };
-  if (task.status === "active") {
-    return (
-      <div className="flex shrink-0 items-center gap-1.5">
+  // Top-only complete (ADR 0016 §7): どの状態でも Complete を併置する。
+  return (
+    <div className="flex shrink-0 items-center gap-1.5">
+      {status === "idle" && (
+        <button
+          type="button"
+          onClick={stop(onStart)}
+          aria-label="開始"
+          className="flex h-9 cursor-pointer items-center gap-1 rounded-lg bg-transparent px-2.5 font-jp text-[11px] font-semibold"
+          style={{ border: `1.5px solid ${color}60`, color }}
+        >
+          <PlayIcon /> 開始
+        </button>
+      )}
+      {status === "active" && (
         <button
           type="button"
           onClick={stop(onPauseRequest)}
@@ -161,50 +265,34 @@ function TimerControls({
         >
           <PauseIcon />
         </button>
+      )}
+      {status === "paused" && (
         <button
           type="button"
-          onClick={stop(onComplete)}
-          aria-label="完了"
-          className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-lg bg-transparent"
+          onClick={stop(onResume)}
+          aria-label="再開"
+          className="flex h-9 cursor-pointer items-center gap-1 rounded-lg bg-transparent px-2.5 font-jp text-[11px] font-semibold"
           style={{ border: `1.5px solid ${color}60`, color }}
         >
-          <CheckIcon />
+          <PlayIcon /> 再開
         </button>
-      </div>
-    );
-  }
-  if (task.status === "paused") {
-    return (
+      )}
       <button
         type="button"
-        onClick={stop(onResume)}
-        aria-label="再開"
-        className="flex h-9 shrink-0 cursor-pointer items-center gap-1 rounded-lg bg-transparent px-2.5 font-jp text-[11px] font-semibold"
+        onClick={stop(onComplete)}
+        aria-label="完了"
+        className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-lg bg-transparent"
         style={{ border: `1.5px solid ${color}60`, color }}
       >
-        <PlayIcon />
-        再開
+        <CheckIcon />
       </button>
-    );
-  }
-  // idle / done は開始ボタン。done の場合は呼ばれない想定 (TaskStack 側で除外)
-  return (
-    <button
-      type="button"
-      onClick={stop(onStart)}
-      aria-label="開始"
-      className="flex h-9 shrink-0 cursor-pointer items-center gap-1 rounded-lg bg-transparent px-2.5 font-jp text-[11px] font-semibold"
-      style={{ border: `1.5px solid ${color}60`, color }}
-    >
-      <PlayIcon />
-      開始
-    </button>
+    </div>
   );
 }
 
 function PlayIcon() {
   return (
-    <svg width="10" height="12" viewBox="0 0 10 12" fill="currentColor">
+    <svg width="10" height="12" viewBox="0 0 10 12" fill="currentColor" aria-hidden="true">
       <polygon points="1,1 9,6 1,11" />
     </svg>
   );
@@ -212,7 +300,7 @@ function PlayIcon() {
 
 function PauseIcon() {
   return (
-    <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor">
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true">
       <rect x="2" y="2" width="3" height="8" rx="1" />
       <rect x="7" y="2" width="3" height="8" rx="1" />
     </svg>
@@ -221,7 +309,7 @@ function PauseIcon() {
 
 function CheckIcon() {
   return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
       <polyline
         points="3,8 7,12 13,4"
         stroke="currentColor"

--- a/src/features/task-stack/stackItems.test.ts
+++ b/src/features/task-stack/stackItems.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "vitest";
+
+import type { Task } from "@/entities/task/types";
+
+import {
+  buildStackItems,
+  computeChildProgress,
+  computeDoneProgress,
+  type StackItem,
+} from "./stackItems";
+
+const baseTask: Task = {
+  id: "t",
+  projectId: "p1",
+  title: "task",
+  body: "",
+  estimatedMinutes: 30,
+  status: "idle",
+  stackOrder: 0,
+  dependsOnEventId: null,
+  isInterruption: false,
+  parentTaskId: null,
+  decomposeStatus: "none",
+  taskCategory: null,
+  createdAt: "2026-04-27T00:00:00",
+  completedAt: null,
+};
+
+const t = (overrides: Partial<Task> & { id: string }): Task => ({ ...baseTask, ...overrides });
+
+describe("buildStackItems", () => {
+  test("decomposed 親は Stack 行から除外され、子だけがフラットに並ぶ", () => {
+    const parent = t({ id: "p", title: "親", decomposeStatus: "decomposed" });
+    const c1 = t({ id: "c1", title: "子1", parentTaskId: "p" });
+    const c2 = t({ id: "c2", title: "子2", parentTaskId: "p" });
+    const standalone = t({ id: "s", title: "単独タスク", decomposeStatus: "none" });
+
+    const { items } = buildStackItems([parent, c1, c2, standalone], [parent, c1, c2, standalone]);
+
+    expect(items.map((i) => i.id)).toEqual(["c1", "c2", "s"]);
+    expect(items[0].kind).toBe("leaf-child");
+    expect(items[2].kind).toBe("leaf-parent");
+  });
+
+  test("分解中 / 分解不要 / 未分解 の親は Stack 行に残る", () => {
+    const decomposing = t({ id: "a", decomposeStatus: "decomposing" });
+    const skipped = t({ id: "b", decomposeStatus: "skipped" });
+    const none = t({ id: "c", decomposeStatus: "none" });
+
+    const { items } = buildStackItems([decomposing, skipped, none], [decomposing, skipped, none]);
+
+    expect(items).toHaveLength(3);
+    expect(items.every((it) => it.kind === "leaf-parent")).toBe(true);
+  });
+
+  test("子の parent が見つからない場合は leaf-parent で fallback (落とさない)", () => {
+    const orphan = t({ id: "orphan", parentTaskId: "missing" });
+    const { items } = buildStackItems([orphan], [orphan]);
+    expect(items).toHaveLength(1);
+    expect(items[0].kind).toBe("leaf-parent");
+  });
+
+  test("tasksById に pending+done 全件が入る", () => {
+    const pending = t({ id: "p1" });
+    const done = t({ id: "d1", status: "done" });
+    const { tasksById } = buildStackItems([pending], [pending, done]);
+    expect(tasksById.get("p1")).toBe(pending);
+    expect(tasksById.get("d1")).toBe(done);
+  });
+});
+
+describe("computeChildProgress", () => {
+  test("currentIndex = doneCount + Stack 残中の自分の位置", () => {
+    // 親 p の子 5 つ。c1/c2 が done、c3/c4/c5 が pending (Stack 順 c3, c5, c4)
+    const parent = t({ id: "p", decomposeStatus: "decomposed" });
+    const c1 = t({ id: "c1", parentTaskId: "p", status: "done" });
+    const c2 = t({ id: "c2", parentTaskId: "p", status: "done" });
+    const c3 = t({ id: "c3", parentTaskId: "p" });
+    const c4 = t({ id: "c4", parentTaskId: "p" });
+    const c5 = t({ id: "c5", parentTaskId: "p" });
+    const all = [parent, c1, c2, c3, c4, c5];
+    const pending = [c3, c5, c4]; // Stack 順 (DnD 後)
+
+    const items: StackItem[] = pending.map((task) => ({
+      kind: "leaf-child" as const,
+      id: task.id,
+      task,
+      parent,
+    }));
+
+    // 全子の見積もりは baseTask.estimatedMinutes=30 → 5 子 × 30 = 150
+    // Stack 1 番目 = c3 → currentIndex = 2 (done) + 1 = 3
+    expect(computeChildProgress(c3, parent, all, items)).toEqual({
+      total: 5,
+      doneCount: 2,
+      currentIndex: 3,
+      totalMinutes: 150,
+    });
+    // Stack 2 番目 = c5 → currentIndex = 2 + 2 = 4
+    expect(computeChildProgress(c5, parent, all, items)).toEqual({
+      total: 5,
+      doneCount: 2,
+      currentIndex: 4,
+      totalMinutes: 150,
+    });
+    // Stack 3 番目 = c4 → currentIndex = 2 + 3 = 5
+    expect(computeChildProgress(c4, parent, all, items)).toEqual({
+      total: 5,
+      doneCount: 2,
+      currentIndex: 5,
+      totalMinutes: 150,
+    });
+  });
+
+  test("Stack 残に居ない子 (= done で pendingItems に居ない) は currentIndex=0", () => {
+    const parent = t({ id: "p", decomposeStatus: "decomposed" });
+    const c1 = t({ id: "c1", parentTaskId: "p", status: "done" });
+    const c2 = t({ id: "c2", parentTaskId: "p" });
+    const items: StackItem[] = [{ kind: "leaf-child", id: "c2", task: c2, parent }];
+
+    expect(computeChildProgress(c1, parent, [parent, c1, c2], items)).toEqual({
+      total: 2,
+      doneCount: 1,
+      currentIndex: 0,
+      totalMinutes: 60,
+    });
+  });
+
+  test("estimatedMinutes が混在 (一部 null) なら null は除外して合計", () => {
+    const parent = t({ id: "p", decomposeStatus: "decomposed" });
+    const c1 = t({ id: "c1", parentTaskId: "p", estimatedMinutes: 20 });
+    const c2 = t({ id: "c2", parentTaskId: "p", estimatedMinutes: null });
+    const c3 = t({ id: "c3", parentTaskId: "p", estimatedMinutes: 40 });
+    const items: StackItem[] = [{ kind: "leaf-child", id: "c1", task: c1, parent }];
+
+    expect(computeChildProgress(c1, parent, [parent, c1, c2, c3], items).totalMinutes).toBe(60);
+  });
+
+  test("全子の estimatedMinutes が null なら totalMinutes は null", () => {
+    const parent = t({ id: "p", decomposeStatus: "decomposed" });
+    const c1 = t({ id: "c1", parentTaskId: "p", estimatedMinutes: null });
+    const items: StackItem[] = [{ kind: "leaf-child", id: "c1", task: c1, parent }];
+
+    expect(computeChildProgress(c1, parent, [parent, c1], items).totalMinutes).toBeNull();
+  });
+});
+
+describe("computeDoneProgress", () => {
+  test("total / doneCount を出し、currentIndex は常に 0", () => {
+    const parent = t({ id: "p", decomposeStatus: "decomposed" });
+    const c1 = t({ id: "c1", parentTaskId: "p", status: "done" });
+    const c2 = t({ id: "c2", parentTaskId: "p", status: "done" });
+    const c3 = t({ id: "c3", parentTaskId: "p" });
+
+    expect(computeDoneProgress(parent, [parent, c1, c2, c3])).toEqual({
+      total: 3,
+      doneCount: 2,
+      currentIndex: 0,
+      totalMinutes: 90,
+    });
+  });
+});

--- a/src/features/task-stack/stackItems.ts
+++ b/src/features/task-stack/stackItems.ts
@@ -1,0 +1,114 @@
+import type { Task } from "@/entities/task/types";
+
+/**
+ * Stack View (ADR 0016 Variant E) の描画単位。
+ * 平坦な `Task[]` から「分解済み親を除外して子をフラット化」した結果を表す。
+ *
+ * - `leaf-child`: 子タスク (parent への参照付き)。下ゾーン Row 3 で「⤷ 親」と progress を出す。
+ * - `leaf-parent`: 親自身が Stack に並ぶケース (`decomposeStatus !== 'decomposed'`)。
+ *   = 未分解 / 分解中 / 分解不要 のいずれか。
+ */
+export type StackItem =
+  | { kind: "leaf-child"; id: string; task: Task; parent: Task }
+  | { kind: "leaf-parent"; id: string; task: Task };
+
+export type StackItemsResult = {
+  items: StackItem[];
+  /** 全タスク (pending + done) を id で引ける Map。Done セクションでも parent 参照に使う。 */
+  tasksById: ReadonlyMap<string, Task>;
+};
+
+/**
+ * `pendingTasks` を順序保ったまま Item に変換する。
+ *
+ * - 子タスク (`parentTaskId !== null`) は `leaf-child` に。
+ *   親が見つからないデータ不整合は `leaf-parent` で fallback (落とさない)。
+ * - 親タスク (`parentTaskId === null`):
+ *   - `decompose_status === 'decomposed'` → 子に置き換わるので Stack には出さない (除外)
+ *   - それ以外 (`none` / `decomposing` / `skipped`) → `leaf-parent` で出す
+ *
+ * @param pendingTasks Stack に並べたい順 (= stack_order 昇順)
+ * @param allTasks parent 解決のための全件 (pending + done を渡す)
+ */
+export function buildStackItems(
+  pendingTasks: readonly Task[],
+  allTasks: readonly Task[],
+): StackItemsResult {
+  const tasksById = new Map<string, Task>();
+  for (const t of allTasks) tasksById.set(t.id, t);
+
+  const items: StackItem[] = [];
+  for (const t of pendingTasks) {
+    if (t.parentTaskId !== null) {
+      const parent = tasksById.get(t.parentTaskId);
+      if (parent) {
+        items.push({ kind: "leaf-child", id: t.id, task: t, parent });
+        continue;
+      }
+      // 親が無いデータ不整合は落とさず leaf-parent として表示
+    }
+    if (t.decomposeStatus === "decomposed") {
+      // 子に置き換わるので Stack には出さない (ADR 0016 §1)
+      continue;
+    }
+    items.push({ kind: "leaf-parent", id: t.id, task: t });
+  }
+  return { items, tasksById };
+}
+
+export type Progress = {
+  total: number;
+  doneCount: number;
+  /** 1-based。0 を渡すと「現在なし」。Done セクション用。 */
+  currentIndex: number;
+  /** 子の見積もり合計 (分)。子全部が null なら null。Top カード下ゾーンの「合計」表示で使う。 */
+  totalMinutes: number | null;
+};
+
+/**
+ * 子タスクの進捗を計算する (ADR 0016 §5)。
+ *
+ * `currentIndex = doneCount + (Stack 残中の同親子における 1-based 位置)`。
+ * done が増えると自分のセグメントが右へオフセットする。
+ */
+export function computeChildProgress(
+  child: Task,
+  parent: Task,
+  allTasks: readonly Task[],
+  pendingItems: readonly StackItem[],
+): Progress {
+  const siblings = allTasks.filter((t) => t.parentTaskId === parent.id);
+  const total = siblings.length;
+  const doneCount = siblings.filter((t) => t.status === "done").length;
+  const totalMinutes = sumEstimatedMinutes(siblings);
+  let position = 0;
+  for (const it of pendingItems) {
+    if (it.kind === "leaf-child" && it.parent.id === parent.id) {
+      position++;
+      if (it.task.id === child.id) {
+        return { total, doneCount, currentIndex: doneCount + position, totalMinutes };
+      }
+    }
+  }
+  return { total, doneCount, currentIndex: 0, totalMinutes };
+}
+
+function sumEstimatedMinutes(tasks: readonly Task[]): number | null {
+  return tasks.reduce<number | null>((acc, t) => {
+    if (t.estimatedMinutes === null) return acc;
+    return (acc ?? 0) + t.estimatedMinutes;
+  }, null);
+}
+
+/**
+ * Done セクション用の進捗。current 強調なし (Stack 側の current と被らない)。
+ */
+export function computeDoneProgress(parent: Task, allTasks: readonly Task[]): Progress {
+  const siblings = allTasks.filter((t) => t.parentTaskId === parent.id);
+  return {
+    total: siblings.length,
+    doneCount: siblings.filter((t) => t.status === "done").length,
+    currentIndex: 0,
+    totalMinutes: sumEstimatedMinutes(siblings),
+  };
+}

--- a/src/shared/lib/body-preview.ts
+++ b/src/shared/lib/body-preview.ts
@@ -1,0 +1,10 @@
+/**
+ * markdown 本文の最初の非見出し行を抽出する。
+ * Stack View の Top カード上ゾーンや Variant E プロトで使う 1 行プレビュー。
+ *
+ * `#` で始まる行はスキップし、空行も除外する。1 行も無ければ空文字。
+ */
+export function bodyPreview(body: string | null | undefined): string {
+  if (!body) return "";
+  return body.split("\n").find((l) => l.trim() && !l.startsWith("#")) ?? "";
+}

--- a/src/shared/ui/ParallelogramProgress.tsx
+++ b/src/shared/ui/ParallelogramProgress.tsx
@@ -1,0 +1,83 @@
+/**
+ * AI 分解後の親の進捗を平行四辺形 (skewX) セグメントで可視化する。
+ * ADR 0016 §5: 数字併記の重複を避け、子の完了境界と「Stack 上の自分の番」を
+ * ひとつのバーで読み取れるようにする。
+ *
+ * - 完了: 親色で塗り
+ * - 現在 (= 自分の番、未完了): 親色の枠強調 + 中抜き
+ * - 未完了: 薄い親色の枠 + 中抜き
+ *
+ * a11y: `role="progressbar"` + `aria-valuenow/min/max` + `aria-label`。
+ *       セグメント自体は装飾なので `aria-hidden`。
+ */
+type Size = "md" | "sm";
+
+type ParallelogramProgressProps = {
+  total: number;
+  doneCount: number;
+  /**
+   * 1-based。0 を渡すと「現在なし」(全行カード未着手 / Done セクション内 等)。
+   * `currentIndex = doneCount + (Stack 残中の自分の位置)` を呼び出し側で算出する。
+   */
+  currentIndex: number;
+  color: string;
+  size?: Size;
+};
+
+function segmentSize(total: number, size: Size): { w: number; h: number } {
+  // 子数によって 3 段階で縮小 (~5 / ~9 / 10+)。10 子で 480px 幅に収まる目安。
+  if (size === "md") {
+    if (total <= 5) return { w: 16, h: 9 };
+    if (total <= 9) return { w: 12, h: 8 };
+    return { w: 9, h: 7 };
+  }
+  if (total <= 5) return { w: 10, h: 6 };
+  if (total <= 9) return { w: 8, h: 5 };
+  return { w: 6, h: 4 };
+}
+
+export function ParallelogramProgress({
+  total,
+  doneCount,
+  currentIndex,
+  color,
+  size = "md",
+}: ParallelogramProgressProps) {
+  const { w: segWidth, h: segHeight } = segmentSize(total, size);
+  return (
+    <div
+      role="progressbar"
+      aria-valuenow={doneCount}
+      aria-valuemin={0}
+      aria-valuemax={total}
+      aria-label={
+        currentIndex > 0
+          ? `進捗 ${doneCount}/${total}、現在 ${currentIndex}/${total}`
+          : `進捗 ${doneCount}/${total}`
+      }
+      className="flex shrink-0 items-center gap-[3px]"
+    >
+      {Array.from({ length: total }).map((_, i) => {
+        const idx = i + 1;
+        const isDone = idx <= doneCount;
+        const isCurrent = idx === currentIndex && !isDone;
+        const borderColor = isCurrent ? color : `${color}55`;
+        const borderWidth = isCurrent ? 1.5 : 1;
+        return (
+          <span
+            key={i}
+            aria-hidden="true"
+            style={{
+              width: segWidth,
+              height: segHeight,
+              transform: "skewX(-20deg)",
+              background: isDone ? color : "transparent",
+              border: `${borderWidth}px solid ${borderColor}`,
+              borderRadius: 1,
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要 (What)

Stack View の Variant E (Top カード上下 2 ゾーン + 行カード 3 行 + 平行四辺形プログレス) を `__experiments__/VariantE.tsx` のプロトから本実装 `src/features/task-stack/` に移植する。プロト自体の削除は #94 (P3-8) で別 PR。

## 関連 Issue

Closes #92

## 背景 (Why)

[ADR 0016](../blob/main/docs/adr/0016-stack-view-decomposition-children-only.md) で「分解後 Stack は子フラット + Top 上下 2 ゾーン + 行カード 3 行」を採用。プロトで決め切った構造を本実装に持ち込まないと、Phase 3 仮説「分解後 Stack で 1 つの子に集中できるか」を実機で検証できない。

P3-6 (AI 分解 API; #100) が先行マージ済みなので、UI 側がプロトのまま放置されると分解結果が出ても Stack 上で「decomposed 親 + 子」が両方並ぶ過渡期の見え方になる。本 PR でそれを正しい姿 (子のみフラット) に揃える。

## Before → After

**Before:**
- Stack 行 = 全 pending タスク (decomposed 親も子も並列に並ぶ)
- TaskRow は 1 行構成 + 完了 checkbox
- 分解状態 (decomposing / skipped / none) の可視化なし
- Top カードの完了は active 時のみ

**After:**
- Stack 行 = 子フラット。`decompose_status='decomposed'` の親は除外され、子だけが並ぶ (ADR 0016 §1)
- TaskRow は 3 行構成 (Grip+title / dep / ⤷親+progress) + Top-only complete (checkbox 削除)
- StatusPill (`role=status` + `aria-live=polite` for decomposing) と ParallelogramProgress (`role=progressbar`) が下ゾーン Row 3 の同じ「分解状態スロット」で切替 (ADR 0016 §4)
- Top カードは idle/active/paused 全状態で Complete ボタン常時表示 (ADR 0016 §7)
- 子の `dependsOnEventId` が null なら親に fallback (ADR 0016 §6)
- 合計時間は子の `estimatedMinutes` 合計から派生 (`Progress.totalMinutes`)

共通 component を shared レイヤへ昇格:
- `src/shared/ui/ParallelogramProgress.tsx`
- `src/shared/lib/body-preview.ts`

データ層ヘルパは feature 内に集約 (#95 で entities へ昇格予定):
- `src/features/task-stack/stackItems.ts` (`buildStackItems` / `computeChildProgress` / `computeDoneProgress`)
- `src/features/task-stack/StatusPill.tsx`

## 追加したテスト

- [x] `stackItems.test.ts`: decomposed 親除外 / 子フラット化 / orphan fallback / `currentIndex = doneCount + position` / `totalMinutes` の null 伝播
- [x] `TaskStack.test.tsx`: TopTaskCard / TaskRow / DoneList / TaskStack を semantic locator (`role=progressbar`, `role=status`, `aria-label`) で踏む。Top-only complete (TaskRow から checkbox 消失) も assert
- [x] dep 継承 (子 null → 親) を踏む test
- [x] typecheck / eslint / prettier / 315 unit tests 全 pass

カバーしていない領域:
- ブラウザでの実機確認 (sandbox 環境で dev server 起動できないため)。Variant E プロトと本実装が同じ見え方になるかは手動確認が必要。
- e2e は #96 (P3-11) で別途。

## リリース前チェックリスト

- [ ] dev で実機を踏み、プロト (`/experiments/adr-0016`) との同等性を確認 (decomposed 親除外 / 平行四辺形プログレス / Top-only complete / status pill)

## このPRの範囲外

- プロト削除 (`__experiments__/` + `/experiments/adr-0016`) → #94 P3-8 で別 PR (本 PR が落ち着いてから)
- AI 分解 API 自体は #100 (P3-6) で実装済み
- AI 提案メモ / 補正後見積もりの上ゾーン追加 → #93 P3-9
- e2e バイパス + Variant E core path 不変条件 → #96 P3-11
- 子の data-level dep 継承 / 統合・再分割 UI → ADR 0016 §9 の派生決定 (Phase 4 / 別 issue)


---
_Generated by [Claude Code](https://claude.ai/code/session_014jeDrYfMWLYFkaqvBH3S1f)_