### PR TITLE
feat(db): decompose_status enum に failed 値を追加 (P3-12, #110)

### DIFF
--- a/src/entities/task/types.ts
+++ b/src/entities/task/types.ts
@@ -3,15 +3,16 @@ import type { TaskCategoryValue } from "@/shared/types/database";
 export type TaskStatus = "idle" | "active" | "paused" | "done";
 
 /**
- * AI 分解 (ADR 0017 / 0018) における親タスクの状態。
+ * AI 分解 (ADR 0017 / 0018 / 0021) における親タスクの状態。
  * - none        : 分解未試行 (Phase 1〜2 由来の既存タスク含む)
  * - decomposing : AI 分解 fire-and-forget 中
  * - decomposed  : 子レコードが parent_task_id 経由で存在
  * - skipped     : AI が分解不要と判断 / AI_ENABLED=false 等
+ * - failed      : AI 分解失敗 (ADR 0021)。終端 status、再実行で decomposing に戻る
  *
  * Stack View (ADR 0016 Variant E) は decomposed の親を出さず、子だけを並べる。
  */
-export type DecomposeStatus = "none" | "decomposing" | "decomposed" | "skipped";
+export type DecomposeStatus = "none" | "decomposing" | "decomposed" | "skipped" | "failed";
 
 /**
  * タスク種別 (ADR 0015 / #87)。

--- a/src/shared/types/database.ts
+++ b/src/shared/types/database.ts
@@ -229,7 +229,7 @@ export type Database = {
       task_status: "idle" | "active" | "paused" | "done";
       event_source: "manual" | "google_calendar";
       pause_reason: "meeting" | "interruption" | "voluntary";
-      decompose_status: "none" | "decomposing" | "decomposed" | "skipped";
+      decompose_status: "none" | "decomposing" | "decomposed" | "skipped" | "failed";
     };
   };
 };

--- a/supabase/migrations/20260429000000_p3_12_decompose_status_failed.sql
+++ b/supabase/migrations/20260429000000_p3_12_decompose_status_failed.sql
@@ -1,0 +1,20 @@
+-- kozutsumi Phase 3 (P3-12, #110): decompose_status enum に failed を追加
+--
+-- References:
+-- * docs/adr/0021-ai-decomposition-failure-visibility.md
+--   (AI 分解失敗を終端 status `failed` で表現する。`decomposing` 固まりの構造的解消)
+-- * supabase/migrations/20260427100000_p3_3_decompose_status.sql
+--   (enum の初期定義 4 値: none / decomposing / decomposed / skipped)
+--
+-- 本 migration が決めること:
+--   decompose_status enum に `failed` 値を 1 つ追加する。既存値の意味は変えない。
+--
+-- 後続 issue で扱うもの (本 migration では触らない):
+--   * server 側の遷移ロジック (P3-13, #111): parse / quota / insert 失敗で `failed` に倒す
+--   * StatusPill の failed 分岐 (P3-14, #112)
+--   * 詳細パネルの AI 分解情報エリア (P3-15, #113)
+--   * 新規 ACTION_TYPE (`task_decompose_failed` / `task_decompose_skipped`) は
+--     ADR 0001 の方針通り SQL 側に CHECK を持たないので migration 不要。
+--     code 側 (src/entities/action-log) の登録で扱う (P3-13)。
+
+alter type public.decompose_status add value if not exists 'failed';


### PR DESCRIPTION
## 概要 (What)

ADR 0021 (AI 分解失敗の可視化と recovery 経路) の DB 層実装。`decompose_status` enum に終端 status `failed` を追加する。

## 関連 Issue

Closes #110

## 背景 (Why)

[ADR 0021](https://github.com/y-oga-819/kozutsumi/blob/main/docs/adr/0021-ai-decomposition-failure-visibility.md) で「AI 分解失敗を終端 status `failed` で表現する」と決めた。後続 issue (#111 server / #112 StatusPill / #113 詳細パネル) はすべて DB 上に `failed` 値が存在することが前提なので、本 PR を最初に通す必要がある。

ADR 0017 (非同期分解) / ADR 0013 (augmentation only) で「AI が落ちても core が止まらない」までは保証していたが、運用してみると **「core を止めない」が「失敗を見えなくする」になっている** ことが分かった (#107: Gemini 429 で `decomposing` のまま固まる)。本 PR はその DB 基盤。

## Before → After (概念・フロー・メンタルモデル)

**Before:** `decompose_status` の値域は `none | decomposing | decomposed | skipped` の 4 値。AI 分解の失敗パスは「`none` に rollback」で表現するしかなく、user から「試行したかどうか」「なぜ分解されなかったか」が消える。例外時は `decomposing` のまま固まることもある (#107)。

**After:** 終端 status として `failed` が DB enum に存在する。後続 issue で server 側の遷移ロジックが `failed` に倒せるようになり、UI も `failed` pill / 再実行ボタンを描画できるようになる。

## 追加したテスト (How verified)

- [x] `npm run typecheck` 通過
- [x] `npm test` 通過 (35 files / 315 tests)
- [ ] migration の dev / preview Supabase 適用は ADR 0019 / 0020 の手動 GitHub Actions trigger で行う (本 PR マージ後)

server / UI の振る舞いは scope 外なので新規テストは追加していない。型 union への追加で既存の switch / 比較が壊れないことだけ確認。

## リリース前チェックリスト (When / Before merge)

- [x] マイグレーションの適用順を確認した (タイムスタンプ `20260429000000` で既存より後)
- [x] 既存ユーザーへの影響: `failed` は新規値、既存タスクは `none/decomposing/decomposed/skipped` のまま残るので破壊的変更なし

マージ後、本番 Supabase への migration 適用は手動 GitHub Actions trigger で実行する。

## このPRの範囲外 (Out of scope)

- server 側の遷移ロジック (parse / quota / insert 失敗で `failed` に倒す) → #111 (P3-13)
- StatusPill の `failed` 分岐 → #112 (P3-14)
- 詳細パネルの「AI 分解情報エリア」+ 再実行ボタン → #113 (P3-15)
- 新規 ACTION_TYPE (`task_decompose_failed` / `task_decompose_skipped`) は ADR 0001 の方針通り SQL 制約を持たないので migration 不要 (#111 で TS 側に追加)
- 自動 retry / circuit breaker → ADR 0021 で別判断

https://claude.ai/code/session_01Da5Srb1ejEgpUSn3YSnGTw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Da5Srb1ejEgpUSn3YSnGTw)_