### PR TITLE
feat(ai): AI 分解失敗時の rollback / failed 遷移 + 試行結果の action_log 記録 (P3-13)

### DIFF
--- a/src/entities/action-log/logger.test.ts
+++ b/src/entities/action-log/logger.test.ts
@@ -174,6 +174,8 @@ describe("ACTION_TYPES", () => {
       STACK_PROPOSAL_ACCEPTED: "stack_proposal_accepted",
       CALENDAR_SYNCED: "calendar_synced",
       TASK_DECOMPOSED: "task_decomposed",
+      TASK_DECOMPOSE_FAILED: "task_decompose_failed",
+      TASK_DECOMPOSE_SKIPPED: "task_decompose_skipped",
       DECOMPOSITION_MODIFIED: "decomposition_modified",
     });
   });
@@ -193,17 +195,107 @@ describe("log(task_decomposed)", () => {
     vi.restoreAllMocks();
   });
 
-  test("親の task_id を column に書き、metadata に child_ids を含める", async () => {
+  test("親の task_id を column に書き、metadata に child_ids と raw_response を含める (ADR 0021)", async () => {
     log(ACTION_TYPES.TASK_DECOMPOSED, {
       task_id: "parent-1",
       child_ids: ["child-a", "child-b"],
+      raw_response: '[{"title":"a"},{"title":"b"}]',
     });
     await flushMicrotasks();
     expect(insertMock).toHaveBeenCalledWith({
       user_id: "user-1",
       action_type: "task_decomposed",
       task_id: "parent-1",
-      metadata: { task_id: "parent-1", child_ids: ["child-a", "child-b"] },
+      metadata: {
+        task_id: "parent-1",
+        child_ids: ["child-a", "child-b"],
+        raw_response: '[{"title":"a"},{"title":"b"}]',
+      },
+    });
+  });
+});
+
+describe("log(task_decompose_failed)", () => {
+  beforeEach(() => {
+    clearLog();
+    __resetLoggerClientForTest();
+    insertMock.mockClear();
+    fromMock.mockClear();
+    getUserMock.mockClear();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ADR 0021: AI 分解の失敗種別ごとに reason を機械可読タグで残し、詳細パネル (P3-15) で
+  // recovery 文言を出すための一次データ。raw_response は generate が応答を返した後に
+  // 失敗した場合のみ存在する (quota / network 等で generate 自体が throw した場合は無し)。
+  test("metadata に reason / raw_response / error_message を含めて insert する", async () => {
+    log(ACTION_TYPES.TASK_DECOMPOSE_FAILED, {
+      task_id: "parent-1",
+      reason: "ai_response_unparseable",
+      raw_response: "I cannot decompose this",
+    });
+    await flushMicrotasks();
+    expect(insertMock).toHaveBeenCalledWith({
+      user_id: "user-1",
+      action_type: "task_decompose_failed",
+      task_id: "parent-1",
+      metadata: {
+        task_id: "parent-1",
+        reason: "ai_response_unparseable",
+        raw_response: "I cannot decompose this",
+      },
+    });
+  });
+
+  test("quota_exhausted: raw_response 無し、error_message 有りで insert する", async () => {
+    log(ACTION_TYPES.TASK_DECOMPOSE_FAILED, {
+      task_id: "parent-1",
+      reason: "quota_exhausted",
+      error_message: "RESOURCE_EXHAUSTED",
+    });
+    await flushMicrotasks();
+    expect(insertMock).toHaveBeenCalledWith({
+      user_id: "user-1",
+      action_type: "task_decompose_failed",
+      task_id: "parent-1",
+      metadata: {
+        task_id: "parent-1",
+        reason: "quota_exhausted",
+        error_message: "RESOURCE_EXHAUSTED",
+      },
+    });
+  });
+});
+
+describe("log(task_decompose_skipped)", () => {
+  beforeEach(() => {
+    clearLog();
+    __resetLoggerClientForTest();
+    insertMock.mockClear();
+    fromMock.mockClear();
+    getUserMock.mockClear();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("metadata に raw_response を含めて insert する (= AI が分解不要と判断した根拠)", async () => {
+    log(ACTION_TYPES.TASK_DECOMPOSE_SKIPPED, {
+      task_id: "parent-1",
+      raw_response: "[]",
+    });
+    await flushMicrotasks();
+    expect(insertMock).toHaveBeenCalledWith({
+      user_id: "user-1",
+      action_type: "task_decompose_skipped",
+      task_id: "parent-1",
+      metadata: { task_id: "parent-1", raw_response: "[]" },
     });
   });
 });

--- a/src/entities/action-log/logger.ts
+++ b/src/entities/action-log/logger.ts
@@ -33,6 +33,8 @@ export const ACTION_TYPES = Object.freeze({
   STACK_PROPOSAL_ACCEPTED: "stack_proposal_accepted",
   CALENDAR_SYNCED: "calendar_synced",
   TASK_DECOMPOSED: "task_decomposed",
+  TASK_DECOMPOSE_FAILED: "task_decompose_failed",
+  TASK_DECOMPOSE_SKIPPED: "task_decompose_skipped",
   DECOMPOSITION_MODIFIED: "decomposition_modified",
 }) satisfies Readonly<Record<string, ActionType>>;
 

--- a/src/entities/action-log/types.ts
+++ b/src/entities/action-log/types.ts
@@ -15,7 +15,26 @@ export type ActionType =
   | "stack_proposal_accepted"
   | "calendar_synced"
   | "task_decomposed"
+  | "task_decompose_failed"
+  | "task_decompose_skipped"
   | "decomposition_modified";
+
+/**
+ * AI 分解の失敗種別 (ADR 0021)。詳細パネル (P3-15) で reason ごとに recovery 文言を出すため
+ * 機械可読タグとして action_log に保存する。
+ *
+ * - quota_exhausted     : Gemini 429 / billing
+ * - upstream_unavailable: network / 503 / timeout
+ * - ai_response_unparseable: parser 失敗
+ * - insert_failed       : 子 insert 失敗
+ * - internal_error      : その他想定外 throw (last-resort safety net)
+ */
+export type DecomposeFailReason =
+  | "quota_exhausted"
+  | "upstream_unavailable"
+  | "ai_response_unparseable"
+  | "insert_failed"
+  | "internal_error";
 
 /**
  * `decomposition_modified.kind` の値域。Phase 3 ではこの 1 ACTION_TYPE で
@@ -87,12 +106,29 @@ export type ActionMetadataMap = {
     deleted: number;
     trigger: CalendarSyncTrigger;
   };
-  // Phase 3 #88: AI 分解成功時、子作成と同時に記録 (ADR 0017 / 0018)。
+  // Phase 3 #88: AI 分解成功時、子作成と同時に記録 (ADR 0017 / 0018 / 0021)。
   // task_id は親 = 分解元タスク。child_ids は parent_task_id = task_id で
   // 紐づく子タスクの id 列で、Phase 4 の暗黙フィードバック分析の出発点になる。
+  // raw_response (ADR 0021) は詳細パネルで折りたたみ表示する Gemini の生応答。
   task_decomposed: {
     task_id: string;
     child_ids: string[];
+    raw_response: string;
+  };
+  // Phase 3 #111 / ADR 0021: AI 分解失敗時に reason と raw_response を残す。
+  // raw_response は generate が応答を返した後に失敗した場合のみ存在する
+  // (quota / network 等で generate 自体が throw した場合は無し)。
+  task_decompose_failed: {
+    task_id: string;
+    reason: DecomposeFailReason;
+    raw_response?: string;
+    error_message?: string;
+  };
+  // Phase 3 #111 / ADR 0021: AI が「分解不要」と判断したケースを記録。
+  // 詳細パネルで「AI が分解不要と判断」+ raw_response (判断理由) を表示する。
+  task_decompose_skipped: {
+    task_id: string;
+    raw_response: string;
   };
   // Phase 3 #88: 分解後に親子関係が動いた事象の総称 (ADR 0018 Notes)。
   // task_id は当該イベントの主体 (削除された子 / 編集された子 / 削除された親)、

--- a/src/entities/task/decompose-server.test.ts
+++ b/src/entities/task/decompose-server.test.ts
@@ -3,7 +3,12 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import type { Database, Tables } from "@/shared/types/database";
 
-import { decomposeTask, type DecomposeTaskDeps, type GenerateFn } from "./decompose-server";
+import {
+  classifyGenerateError,
+  decomposeTask,
+  type DecomposeTaskDeps,
+  type GenerateFn,
+} from "./decompose-server";
 
 type Plan = {
   fetch: { data: Partial<Tables<"tasks">> | null; error: { message: string } | null };
@@ -126,14 +131,13 @@ describe("decomposeTask", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
-  test("happy path: AI が 2 件返す → 子 insert + 親 decomposed + action_log 記録", async () => {
+  test("happy path: AI が 2 件返す → 子 insert + 親 decomposed + action_log 記録 (raw_response を含む)", async () => {
     const { client, calls } = makeSupabase(defaultPlan(makeParentRow()));
-    const generate = vi.fn(async () =>
-      JSON.stringify([
-        { title: "子A", estimated_minutes: 30 },
-        { title: "子B", estimated_minutes: 15 },
-      ]),
-    );
+    const rawResponse = JSON.stringify([
+      { title: "子A", estimated_minutes: 30 },
+      { title: "子B", estimated_minutes: 15 },
+    ]);
+    const generate = vi.fn(async () => rawResponse);
 
     const result = await decomposeTask(makeDeps({ client, generate }));
 
@@ -164,13 +168,17 @@ describe("decomposeTask", () => {
       { id: "parent-1", decompose_status: "decomposed" },
     ]);
 
-    // action_log: task_decomposed
+    // action_log: task_decomposed (ADR 0021 で raw_response を必須化)
     expect(calls.actionLogs).toHaveLength(1);
     expect(calls.actionLogs[0]).toMatchObject({
       user_id: "user-1",
       action_type: "task_decomposed",
       task_id: "parent-1",
-      metadata: { task_id: "parent-1", child_ids: ["child-1", "child-2"] },
+      metadata: {
+        task_id: "parent-1",
+        child_ids: ["child-1", "child-2"],
+        raw_response: rawResponse,
+      },
     });
 
     // prompt が組まれている
@@ -238,23 +246,45 @@ describe("decomposeTask", () => {
     expect(generate).not.toHaveBeenCalled();
   });
 
-  test("AI が parse 不能なテキストを返す → none に戻して failed (core を止めない)", async () => {
+  test("既に failed → 再分解しない (再実行は詳細パネルから明示的に行う想定 / ADR 0021)", async () => {
+    const { client } = makeSupabase(defaultPlan(makeParentRow({ decompose_status: "failed" })));
+    const generate = vi.fn();
+
+    const result = await decomposeTask(makeDeps({ client, generate }));
+
+    expect(result).toEqual({ kind: "skipped", reason: "already_resolved" });
+    expect(generate).not.toHaveBeenCalled();
+  });
+
+  test("AI が parse 不能なテキストを返す → failed に倒し task_decompose_failed を記録 (ADR 0021)", async () => {
     const { client, calls } = makeSupabase(defaultPlan(makeParentRow()));
-    const generate = vi.fn(async () => "I can't help you decompose this");
+    const raw = "I can't help you decompose this";
+    const generate = vi.fn(async () => raw);
 
     const result = await decomposeTask(makeDeps({ client, generate }));
 
     expect(result).toEqual({ kind: "failed", reason: "ai_response_unparseable" });
     expect(calls.insertedTasks).toHaveLength(0);
-    // 状態: decomposing → none (戻す)
+    // 状態: decomposing → failed (旧: none に戻していたのを ADR 0021 で変更)
     expect(calls.statusUpdates).toEqual([
       { id: "parent-1", decompose_status: "decomposing" },
-      { id: "parent-1", decompose_status: "none" },
+      { id: "parent-1", decompose_status: "failed" },
     ]);
-    expect(calls.actionLogs).toHaveLength(0);
+    // action_log: 失敗 reason と raw_response を記録
+    expect(calls.actionLogs).toHaveLength(1);
+    expect(calls.actionLogs[0]).toMatchObject({
+      user_id: "user-1",
+      action_type: "task_decompose_failed",
+      task_id: "parent-1",
+      metadata: {
+        task_id: "parent-1",
+        reason: "ai_response_unparseable",
+        raw_response: raw,
+      },
+    });
   });
 
-  test("AI が空配列 → 親を skipped に倒す (= 分解不要と判断)", async () => {
+  test("AI が空配列 → 親を skipped に倒し task_decompose_skipped を記録 (ADR 0021)", async () => {
     const { client, calls } = makeSupabase(defaultPlan(makeParentRow()));
     const generate = vi.fn(async () => "[]");
 
@@ -266,7 +296,13 @@ describe("decomposeTask", () => {
       { id: "parent-1", decompose_status: "decomposing" },
       { id: "parent-1", decompose_status: "skipped" },
     ]);
-    expect(calls.actionLogs).toHaveLength(0);
+    expect(calls.actionLogs).toHaveLength(1);
+    expect(calls.actionLogs[0]).toMatchObject({
+      user_id: "user-1",
+      action_type: "task_decompose_skipped",
+      task_id: "parent-1",
+      metadata: { task_id: "parent-1", raw_response: "[]" },
+    });
   });
 
   test("AI が 1 件しか返さない (実質分解されてない) → skipped に倒す (parser 仕様)", async () => {
@@ -279,27 +315,126 @@ describe("decomposeTask", () => {
 
     expect(result).toEqual({ kind: "skipped", reason: "ai_decided_not_to_split" });
     expect(calls.insertedTasks).toHaveLength(0);
+    // 1 件 → parser が空配列扱いにするので task_decompose_skipped 記録
+    expect(calls.actionLogs).toHaveLength(1);
+    expect(calls.actionLogs[0]).toMatchObject({
+      action_type: "task_decompose_skipped",
+    });
   });
 
-  test("子 insert が DB 失敗 → none に戻して failed", async () => {
+  test("子 insert が DB 失敗 → failed に倒し task_decompose_failed を記録 (raw_response 付き)", async () => {
     const plan = defaultPlan(makeParentRow());
     plan.insertTasks = { data: null, error: { message: "FK violation" } };
     const { client, calls } = makeSupabase(plan);
-    const generate = vi.fn(async () =>
-      JSON.stringify([
-        { title: "a", estimated_minutes: 15 },
-        { title: "b", estimated_minutes: 15 },
-      ]),
-    );
+    const raw = JSON.stringify([
+      { title: "a", estimated_minutes: 15 },
+      { title: "b", estimated_minutes: 15 },
+    ]);
+    const generate = vi.fn(async () => raw);
 
     const result = await decomposeTask(makeDeps({ client, generate }));
 
     expect(result).toEqual({ kind: "failed", reason: "insert_failed" });
+    // 旧: none に戻す → ADR 0021 で failed に変更
     expect(calls.statusUpdates).toEqual([
       { id: "parent-1", decompose_status: "decomposing" },
-      { id: "parent-1", decompose_status: "none" },
+      { id: "parent-1", decompose_status: "failed" },
     ]);
-    expect(calls.actionLogs).toHaveLength(0);
+    expect(calls.actionLogs).toHaveLength(1);
+    expect(calls.actionLogs[0]).toMatchObject({
+      action_type: "task_decompose_failed",
+      task_id: "parent-1",
+      metadata: {
+        task_id: "parent-1",
+        reason: "insert_failed",
+        raw_response: raw,
+        error_message: "FK violation",
+      },
+    });
+  });
+
+  test("Gemini が 429 で throw → failed/quota_exhausted (ADR 0021、#107 の bug 修正)", async () => {
+    const { client, calls } = makeSupabase(defaultPlan(makeParentRow()));
+    const error = Object.assign(new Error("Quota exceeded"), { status: 429 });
+    const generate = vi.fn(async () => {
+      throw error;
+    });
+
+    const result = await decomposeTask(makeDeps({ client, generate }));
+
+    expect(result).toEqual({ kind: "failed", reason: "quota_exhausted" });
+    // generate throw でも parent は decomposing で固まらず failed に倒れる
+    expect(calls.statusUpdates).toEqual([
+      { id: "parent-1", decompose_status: "decomposing" },
+      { id: "parent-1", decompose_status: "failed" },
+    ]);
+    expect(calls.insertedTasks).toHaveLength(0);
+    expect(calls.actionLogs).toHaveLength(1);
+    expect(calls.actionLogs[0]).toMatchObject({
+      action_type: "task_decompose_failed",
+      task_id: "parent-1",
+      metadata: {
+        task_id: "parent-1",
+        reason: "quota_exhausted",
+        error_message: "Quota exceeded",
+      },
+    });
+  });
+
+  test("Gemini が 503 で throw → failed/upstream_unavailable", async () => {
+    const { client, calls } = makeSupabase(defaultPlan(makeParentRow()));
+    const error = Object.assign(new Error("service unavailable"), { status: 503 });
+    const generate = vi.fn(async () => {
+      throw error;
+    });
+
+    const result = await decomposeTask(makeDeps({ client, generate }));
+
+    expect(result).toEqual({ kind: "failed", reason: "upstream_unavailable" });
+    expect(calls.statusUpdates).toEqual([
+      { id: "parent-1", decompose_status: "decomposing" },
+      { id: "parent-1", decompose_status: "failed" },
+    ]);
+    expect(calls.actionLogs[0]).toMatchObject({
+      action_type: "task_decompose_failed",
+      metadata: { reason: "upstream_unavailable" },
+    });
+  });
+
+  test("Gemini が status 無しで throw → failed/internal_error (last-resort safety net)", async () => {
+    const { client, calls } = makeSupabase(defaultPlan(makeParentRow()));
+    const generate = vi.fn(async () => {
+      throw new Error("oops something weird");
+    });
+
+    const result = await decomposeTask(makeDeps({ client, generate }));
+
+    expect(result).toEqual({ kind: "failed", reason: "internal_error" });
+    expect(calls.statusUpdates).toEqual([
+      { id: "parent-1", decompose_status: "decomposing" },
+      { id: "parent-1", decompose_status: "failed" },
+    ]);
+    expect(calls.actionLogs[0]).toMatchObject({
+      action_type: "task_decompose_failed",
+      metadata: {
+        reason: "internal_error",
+        error_message: "oops something weird",
+      },
+    });
+  });
+
+  test("network error (fetch failed) → failed/upstream_unavailable", async () => {
+    const { client, calls } = makeSupabase(defaultPlan(makeParentRow()));
+    const generate = vi.fn(async () => {
+      throw new TypeError("fetch failed");
+    });
+
+    const result = await decomposeTask(makeDeps({ client, generate }));
+
+    expect(result).toEqual({ kind: "failed", reason: "upstream_unavailable" });
+    expect(calls.actionLogs[0]).toMatchObject({
+      metadata: { reason: "upstream_unavailable" },
+    });
   });
 
   test("親の stack_order が null でも子は 0 始まりで割り当てられる", async () => {
@@ -334,5 +469,55 @@ describe("decomposeTask", () => {
     const inserted = calls.insertedTasks[0] as Array<Record<string, unknown>>;
     expect(inserted[0].depends_on_event_id).toBeNull();
     expect(inserted[1].depends_on_event_id).toBeNull();
+  });
+});
+
+describe("classifyGenerateError", () => {
+  test("status: 429 → quota_exhausted", () => {
+    expect(classifyGenerateError(Object.assign(new Error("quota"), { status: 429 }))).toBe(
+      "quota_exhausted",
+    );
+  });
+
+  test("status: 500/502/503/504 → upstream_unavailable", () => {
+    for (const status of [500, 502, 503, 504]) {
+      expect(classifyGenerateError(Object.assign(new Error("x"), { status }))).toBe(
+        "upstream_unavailable",
+      );
+    }
+  });
+
+  test("AbortError / TimeoutError → upstream_unavailable", () => {
+    const abort = Object.assign(new Error("aborted"), { name: "AbortError" });
+    expect(classifyGenerateError(abort)).toBe("upstream_unavailable");
+    const timeout = Object.assign(new Error("timeout"), { name: "TimeoutError" });
+    expect(classifyGenerateError(timeout)).toBe("upstream_unavailable");
+  });
+
+  test("network 系メッセージ (fetch failed / ECONNRESET / ETIMEDOUT / ENOTFOUND) → upstream_unavailable", () => {
+    expect(classifyGenerateError(new TypeError("fetch failed"))).toBe("upstream_unavailable");
+    expect(classifyGenerateError(new Error("ECONNRESET on socket"))).toBe("upstream_unavailable");
+    expect(classifyGenerateError(new Error("connect ETIMEDOUT 1.2.3.4:443"))).toBe(
+      "upstream_unavailable",
+    );
+    expect(classifyGenerateError(new Error("getaddrinfo ENOTFOUND host"))).toBe(
+      "upstream_unavailable",
+    );
+  });
+
+  test("status 4xx (429 以外) → internal_error (auth / quota 以外の client error)", () => {
+    expect(classifyGenerateError(Object.assign(new Error("bad"), { status: 400 }))).toBe(
+      "internal_error",
+    );
+    expect(classifyGenerateError(Object.assign(new Error("forbidden"), { status: 403 }))).toBe(
+      "internal_error",
+    );
+  });
+
+  test("素の Error / 文字列 / null → internal_error", () => {
+    expect(classifyGenerateError(new Error("oops"))).toBe("internal_error");
+    expect(classifyGenerateError("oops")).toBe("internal_error");
+    expect(classifyGenerateError(null)).toBe("internal_error");
+    expect(classifyGenerateError(undefined)).toBe("internal_error");
   });
 });

--- a/src/entities/task/decompose-server.ts
+++ b/src/entities/task/decompose-server.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 import { logServerSide } from "@/entities/action-log/server";
+import type { DecomposeFailReason } from "@/entities/action-log/types";
 import {
   buildDecomposePrompt,
   parseDecomposeResponse,
@@ -9,36 +10,31 @@ import {
 import type { Database, Tables, TablesInsert } from "@/shared/types/database";
 
 /**
- * AI タスク分解 (P3-6) の server 側 orchestrator。
+ * AI タスク分解 (P3-6 / ADR 0017 / 0018 / 0016 / 0021) の server 側 orchestrator。
  *
- * 流れ (ADR 0017 / 0018 / 0016):
+ * 流れ:
  * 1. 親タスクを userId スコープで取得 (RLS 前提だが defense in depth)。見つからなければ no-op
- * 2. race condition guard: 親が active/paused/done か、既に decomposed/skipped なら no-op
+ * 2. race condition guard: 親が active/paused/done か、既に decomposed/skipped/failed なら no-op
  *    (ADR 0017 Notes: 親 active 化済みは分解対象から外す。冪等性のため重複時もスキップ)
- * 3. 親の decompose_status を `decomposing` に倒す (client が optimistic に既に倒している
- *    可能性もあるが、server で再確定して fire-and-forget の重複呼びでも壊れないようにする)
- * 4. Gemini に prompt を投げて応答を取る (caller injected `generate` で境界を切る → ユニット可能)
- * 5. parser が null → `none` に戻す (失敗 = 親をそのまま残す)。空配列 → `skipped`
- * 6. children を bulk insert (parent_task_id = parent.id)。project_id / depends_on_event_id を
- *    親から継承、stack_order = parent.stack_order + i で割り当てる (P3-7 の UI が描画分岐する)
- * 7. 親を `decomposed` に倒し、`task_decomposed` action_log を書く
+ * 3. 親の decompose_status を `decomposing` に倒す
+ * 4. ここから先は ADR 0021 の不変条件: 「`decomposing` で固まらない」。
+ *    すべての失敗経路で parent を必ず終端 status (`failed` / `skipped` / `decomposed`) に倒し、
+ *    試行結果を `action_logs` に記録する。
  *
- * 純粋ではないが、Gemini 呼び出しを props で受け取ることでユニットテスト可能にしている。
- * Supabase 周辺は薄ラッパーなのでクエリチェーンを mock することで検証する。
+ * 失敗種別の reason は `DecomposeFailReason` (action-log/types) に定義。
+ * 例外発生時は `classifyGenerateError` で `error.status` / SDK error 型から分類する。
  */
 
 export type DecomposeTaskOutcome =
   | { kind: "decomposed"; childIds: string[] }
   | { kind: "skipped"; reason: SkipReason }
-  | { kind: "failed"; reason: FailReason };
+  | { kind: "failed"; reason: DecomposeFailReason };
 
 type SkipReason =
   | "task_not_found"
   | "parent_active_or_locked" // status=active/paused/done
-  | "already_resolved" // decompose_status=decomposed/skipped
+  | "already_resolved" // decompose_status=decomposed/skipped/failed
   | "ai_decided_not_to_split"; // 空配列 / 1 件
-
-type FailReason = "ai_response_unparseable" | "insert_failed";
 
 export type GenerateFn = (prompt: string) => Promise<string>;
 
@@ -50,7 +46,8 @@ export type DecomposeTaskDeps = {
 };
 
 const SKIP_STATUSES = new Set(["active", "paused", "done"]);
-const ALREADY_RESOLVED = new Set(["decomposed", "skipped"]);
+// `failed` も「終端」なので二重分解させない。再実行は詳細パネルから明示的に none → decomposing で行う (ADR 0021)。
+const ALREADY_RESOLVED = new Set(["decomposed", "skipped", "failed"]);
 
 export async function decomposeTask(deps: DecomposeTaskDeps): Promise<DecomposeTaskOutcome> {
   const { supabase, userId, taskId, generate } = deps;
@@ -70,19 +67,62 @@ export async function decomposeTask(deps: DecomposeTaskDeps): Promise<DecomposeT
   // 重複 fire-and-forget や client 側 optimistic ズレに耐えるよう、ここで decomposing に確定させる。
   await setDecomposeStatus(supabase, parent.id, "decomposing");
 
-  const prompt = buildDecomposePrompt(toPromptInput(parent));
-  const responseText = await generate(prompt);
+  try {
+    return await runDecompose(supabase, userId, parent, generate);
+  } catch (error) {
+    // Last-resort safety net (ADR 0021): runDecompose が想定外に throw しても
+    // parent を `decomposing` で固まらせない。internal_error として終端に倒す。
+    console.error("[ai/decompose] unexpected error", error);
+    await setDecomposeStatus(supabase, parent.id, "failed");
+    await logServerSide(supabase, userId, "task_decompose_failed", {
+      task_id: parent.id,
+      reason: "internal_error",
+      error_message: error instanceof Error ? error.message : String(error),
+    });
+    return { kind: "failed", reason: "internal_error" };
+  }
+}
+
+async function runDecompose(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  parent: ParentRow,
+  generate: GenerateFn,
+): Promise<DecomposeTaskOutcome> {
+  let responseText: string;
+  try {
+    const prompt = buildDecomposePrompt(toPromptInput(parent));
+    responseText = await generate(prompt);
+  } catch (error) {
+    const reason = classifyGenerateError(error);
+    console.error("[ai/decompose] generate failed", { reason, error });
+    await setDecomposeStatus(supabase, parent.id, "failed");
+    await logServerSide(supabase, userId, "task_decompose_failed", {
+      task_id: parent.id,
+      reason,
+      error_message: error instanceof Error ? error.message : String(error),
+    });
+    return { kind: "failed", reason };
+  }
+
   const parsed = parseDecomposeResponse(responseText);
 
   if (parsed === null) {
-    // ADR 0013 augmentation only: AI 失敗で core を止めない。none に戻して終わり
-    // (再試行は将来 issue。本実装ではユーザーが override で操作する)
-    await setDecomposeStatus(supabase, parent.id, "none");
+    await setDecomposeStatus(supabase, parent.id, "failed");
+    await logServerSide(supabase, userId, "task_decompose_failed", {
+      task_id: parent.id,
+      reason: "ai_response_unparseable",
+      raw_response: responseText,
+    });
     return { kind: "failed", reason: "ai_response_unparseable" };
   }
 
   if (parsed.length === 0) {
     await setDecomposeStatus(supabase, parent.id, "skipped");
+    await logServerSide(supabase, userId, "task_decompose_skipped", {
+      task_id: parent.id,
+      raw_response: responseText,
+    });
     return { kind: "skipped", reason: "ai_decided_not_to_split" };
   }
 
@@ -106,7 +146,13 @@ export async function decomposeTask(deps: DecomposeTaskDeps): Promise<DecomposeT
 
   if (insertErr || !insertedRows) {
     console.error("[ai/decompose] child insert failed", insertErr);
-    await setDecomposeStatus(supabase, parent.id, "none");
+    await setDecomposeStatus(supabase, parent.id, "failed");
+    await logServerSide(supabase, userId, "task_decompose_failed", {
+      task_id: parent.id,
+      reason: "insert_failed",
+      raw_response: responseText,
+      error_message: insertErr?.message,
+    });
     return { kind: "failed", reason: "insert_failed" };
   }
 
@@ -116,9 +162,40 @@ export async function decomposeTask(deps: DecomposeTaskDeps): Promise<DecomposeT
   await logServerSide(supabase, userId, "task_decomposed", {
     task_id: parent.id,
     child_ids: childIds,
+    raw_response: responseText,
   });
 
   return { kind: "decomposed", childIds };
+}
+
+/**
+ * Gemini 呼び出しの throw を ADR 0021 の reason 値域に分類する。
+ *
+ * - 429 (RESOURCE_EXHAUSTED) → quota_exhausted
+ * - 5xx / network / timeout → upstream_unavailable
+ * - それ以外 → internal_error
+ *
+ * `@google/generative-ai` SDK の `GoogleGenerativeAIFetchError` は `status` プロパティに
+ * HTTP status を持つので、まずそれで判定する。fetch failed / AbortError 等は Error の
+ * name / message から拾う。ここでは特定 SDK に強く依存しないよう duck-typing する。
+ */
+export function classifyGenerateError(error: unknown): DecomposeFailReason {
+  if (error && typeof error === "object" && "status" in error) {
+    const status = (error as { status?: unknown }).status;
+    if (typeof status === "number") {
+      if (status === 429) return "quota_exhausted";
+      if (status >= 500 && status < 600) return "upstream_unavailable";
+    }
+  }
+  if (error instanceof Error) {
+    if (error.name === "AbortError" || error.name === "TimeoutError") {
+      return "upstream_unavailable";
+    }
+    if (/fetch failed|network|timeout|ECONNRESET|ETIMEDOUT|ENOTFOUND/i.test(error.message)) {
+      return "upstream_unavailable";
+    }
+  }
+  return "internal_error";
 }
 
 type ParentRow = Pick<


### PR DESCRIPTION
## 概要 (What)

AI 分解 (`decomposeTask`) のすべての失敗経路を「parent を必ず終端 status (`failed` / `skipped` / `decomposed`) に倒し、試行結果を `action_logs` に残す」設計に揃える。`decomposing` で固まる bug (#107) を構造的に解消し、Phase 4 学習素材となる AI 動作ログの蓄積を始める。

## 関連 Issue

Closes #111
Closes #107

## 背景 (Why)

[ADR 0021](../blob/main/docs/adr/0021-ai-decomposition-failure-visibility.md) の server 側実装。

これまで `decomposeTask` は parse / insert 失敗時に `none` に戻していた (= AI が試みた事実が消える)。さらに Gemini SDK throw は `withAiRoute` の catch-all 500 で握られて parent が `decomposing` のまま残る (#107)。ADR 0013 の augmentation only を「失敗を隠さない / recovery の判断材料を残す」に強化する。

## Before → After

**Before:**

```
decomposing  ─ generate throw  → (catch-all 500) → DB は decomposing で固まる ←#107
             ─ parser null     → none rollback   → 試行ログなし
             ─ insert error    → none rollback   → 試行ログなし
             ─ 空配列          → skipped         → 試行ログなし
             ─ 成功            → decomposed      → task_decomposed (raw_response 無し)
```

**After:**

```
decomposing  ─ generate throw  → failed (reason: classifyGenerateError で分類)
                                 + task_decompose_failed { reason, error_message }
             ─ parser null     → failed (reason: ai_response_unparseable)
                                 + task_decompose_failed { reason, raw_response }
             ─ insert error    → failed (reason: insert_failed)
                                 + task_decompose_failed { reason, raw_response, error_message }
             ─ 空配列          → skipped + task_decompose_skipped { raw_response }
             ─ 成功            → decomposed + task_decomposed { child_ids, raw_response }
             ─ 想定外 throw    → failed (reason: internal_error) ←last-resort safety net
```

不変条件: **`decomposing` で固まる経路を残さない**。`runDecompose` を外側 try/catch で包み、想定外 throw も internal_error 失敗ログに倒す。

`ALREADY_RESOLVED` に `failed` を追加 (= 終端) し、再実行は詳細パネル (P3-15) から明示的に `none → decomposing` で開始する想定 (ADR 0021 §1)。

reason 分類は `error.status` を主に見る duck-typing (`@google/generative-ai` の `GoogleGenerativeAIFetchError` に依存しない):

| 条件 | reason |
|---|---|
| `error.status === 429` | `quota_exhausted` |
| `error.status` が 500-599 | `upstream_unavailable` |
| `name === "AbortError"` / `"TimeoutError"` | `upstream_unavailable` |
| `message` に `fetch failed` / `ECONNRESET` / `ETIMEDOUT` / `ENOTFOUND` / network / timeout | `upstream_unavailable` |
| 上記以外 | `internal_error` |

`route.ts` 側の catch-all は変更なし (handler-side discipline で `decomposing` 固まりは構造的に消えるので、route 側に decompose 専用の rollback を入れる abstraction 違反を避けた)。

## 追加したテスト (How verified)

- [x] `decompose-server.test.ts`:
  - happy path: `task_decomposed` metadata に `raw_response` が含まれる
  - parser null → `failed` + `task_decompose_failed { ai_response_unparseable, raw_response }`
  - 子 insert 失敗 → `failed` + `task_decompose_failed { insert_failed, raw_response, error_message }`
  - 空配列 / 1 件 → `skipped` + `task_decompose_skipped { raw_response }`
  - generate throw (status 429) → `failed/quota_exhausted` (← #107 の再現パス)
  - generate throw (status 503) → `failed/upstream_unavailable`
  - generate throw (status 無し) → `failed/internal_error`
  - generate throw (`fetch failed`) → `failed/upstream_unavailable`
  - 既に `failed` の親 → `already_resolved` で skip
- [x] `classifyGenerateError` の単体テスト (status 429 / 5xx / AbortError / network / 4xx / null)
- [x] `logger.test.ts`: `task_decomposed.raw_response` 必須化、`task_decompose_failed` / `task_decompose_skipped` の column.task_id / metadata 形を踏む
- [x] 既存 `route.test.ts` / `app/api/ai/decompose/route.test.ts` に regression なし
- [x] `npm run typecheck` / `npm run lint` / `npm test` (35 files / 329 tests) 全パス
- [ ] **dev で手動確認 (#111 完了条件)**: Gemini 429 でタスク追加 → 親が `failed` に倒れることを確認 (本 PR 範囲外、merge 前に動作確認予定)

## このPRの範囲外 (Out of scope)

- StatusPill の `failed` 分岐 (P3-14)
- 詳細パネルの AI 分解情報エリア / 再実行ボタン (P3-15)
- 自動 retry / circuit breaker (ADR 0021 で別判断と明記)
- `decomposed` / `skipped` からの再分解 (ADR 0021 で scope 外)

https://claude.ai/code/session_01NvnPUmjxnuYdN25LN8AAJd

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvnPUmjxnuYdN25LN8AAJd)_