### PR TITLE
feat(task-stack): StatusPill に failed pill 追加 (P3-14, #112)

### DIFF
--- a/src/features/task-stack/StatusPill.tsx
+++ b/src/features/task-stack/StatusPill.tsx
@@ -1,12 +1,13 @@
 import type { DecomposeStatus } from "@/entities/task/types";
 
 /**
- * 親の AI 分解状態を示す pill (ADR 0016 §4)。
+ * 親の AI 分解状態を示す pill (ADR 0016 §4 / ADR 0021 §3)。
  * Stack 行 / Top カード下ゾーン Row 3 右詰の「分解状態スロット」で
  * `ParallelogramProgress` と同じ位置に配置される。
  *
  * - `decomposing`: AI 分解中。`role=status` + `aria-live=polite` で読み上げる。
  * - `skipped`: AI が分解不要と判断。
+ * - `failed`: AI 分解失敗。reason は詳細パネルに譲る (ADR 0021 §3)。
  * - `none`: 分解未試行 (`AI_ENABLED=false` 等)。
  * - `decomposed`: pill は出さない (進捗バーが代わりに出る)。
  */
@@ -31,6 +32,13 @@ export function StatusPill({ status }: StatusPillProps) {
     return (
       <span className="rounded-[3px] bg-fg-weak/15 px-1.5 py-px font-jp text-[8px] text-fg-weak">
         分解不要
+      </span>
+    );
+  }
+  if (status === "failed") {
+    return (
+      <span className="rounded-[3px] bg-accent-red/15 px-1.5 py-px font-jp text-[8px] text-accent-red">
+        分解失敗
       </span>
     );
   }

--- a/src/features/task-stack/TaskStack.test.tsx
+++ b/src/features/task-stack/TaskStack.test.tsx
@@ -190,6 +190,15 @@ describe("TopTaskCard", () => {
     expect(queryByText(/⤷ /)).toBeNull();
   });
 
+  test("leaf-parent (failed) の Top は『分解失敗』pill を下ゾーンに出す (ADR 0021 §3)", () => {
+    const { getByText, queryByRole } = render(
+      <TopTaskCard {...topProps} task={{ ...baseTask, decomposeStatus: "failed" }} />,
+    );
+    expect(getByText("分解失敗")).toBeTruthy();
+    // failed は終端状態なので role=status (live region) は付けない
+    expect(queryByRole("status")).toBeNull();
+  });
+
   test("子の dependsOnEventId が null なら親の dep を継承する (ADR 0016 §6)", () => {
     const parent: Task = {
       ...baseTask,
@@ -323,6 +332,22 @@ describe("TaskRow", () => {
       />,
     );
     expect(getByText("未分解")).toBeTruthy();
+  });
+
+  test("leaf-parent (failed) の行カードは『分解失敗』pill を出す (ADR 0021 §3)", () => {
+    const { getByText, queryByRole } = render(
+      <TaskRow
+        task={{ ...baseTask, decomposeStatus: "failed" }}
+        events={[]}
+        now={NOW_MS}
+        isBeingDragged={false}
+        onPointerDown={noop}
+        onClick={noop}
+      />,
+    );
+    expect(getByText("分解失敗")).toBeTruthy();
+    // reason はカード上に出ない（詳細パネルに集約。ADR 0021 §3）
+    expect(queryByRole("status")).toBeNull();
   });
 });
 


### PR DESCRIPTION
## 概要 (What)

スタックの Top カード / 行カードに、AI 分解失敗 (`decompose_status='failed'`) を示す pill「分解失敗」(accent-red 系) を追加する。reason はカードに出さず、詳細パネル (P3-15) に集約する。

## 関連 Issue

Closes #112

## 背景 (Why)

[ADR 0021](../blob/main/docs/adr/0021-ai-decomposition-failure-visibility.md) §3「スタック card は status の pill のみ」を実装する。P3-12 (#110) で `failed` enum を追加し、P3-13 (#111) で server 側の `failed` 遷移を実装した。スタック画面では reason を出さず pill だけで「失敗が見える」状態を作るのが本 issue のスコープ。

## Before → After (概念・フロー・メンタルモデル)

**Before:**
- `decompose_status='failed'` のタスクはスタック画面に何も pill が出ず、失敗にユーザーが気付けない（fail-soft が「失敗を隠す」になっている状態）。

**After:**
- Top カード / 行カードの Row 3 右詰スロット (ADR 0016 §4) に「分解失敗」pill (accent-red 系) が出る。reason は出さない（情報密度を上げない、詳細パネルに譲る）。

## 追加したテスト (How verified)

- [x] `TopTaskCard` の `failed` ケース: 「分解失敗」pill が描画される / live region (`role=status`) は付かない
- [x] `TaskRow` の `failed` ケース: 同上
- [x] 既存の `decomposing` / `skipped` / `none` / `decomposed` の挙動は触らず、TaskStack.test.tsx 26 ケース全て pass
- [x] `tsc --noEmit` / `eslint` clean

## a11y 観点

- `failed` は終端状態（`decomposing` のような過渡状態ではない）なので `role="status"` + `aria-live` は付けず通常の span (issue 本文の方針に一致)。
- pill 文言「分解失敗」は他のボタン名と substring 包含関係なし。
- 配置は ADR 0016 §4 の Row 3 右詰スロット既定通り。

## このPRの範囲外 (Out of scope)

- 詳細パネルの AI 分解情報エリア (P3-15)
- 再実行ボタン (P3-15)
- pill の色 / トーンの精緻化（実装内で確定、ADR 範囲外）
- #109 (leaf-parent 下ゾーン空白問題) の修正

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYf19mKiVqVq3jrDnq3L2M)_