### PR TITLE
feat(task-detail): AI 分解情報エリア新設 + 再実行ボタン (P3-15, #113)

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -32,6 +32,7 @@ import type { PauseReason } from "@/entities/task/time-entries";
 import { historyData } from "@/mocks/history";
 import { clearAllUserData, seedSampleData } from "@/mocks/seed";
 import {
+  useActionLogGateway,
   useEventGateway,
   useProjectGateway,
   useTaskGateway,
@@ -44,6 +45,12 @@ type View = "stack" | "tree";
 
 type AppShellProps = {
   initialView: View;
+  /**
+   * `AI_ENABLED` kill-switch (`isAiEnabled()` の評価結果)。`/api/ai/*` の入口で
+   * 同じ値を見て early-return するため、UI 側でも一致させて再実行ボタンを
+   * 無駄に enable しないようにする。Server Component 側で `process.env` を読んで渡す。
+   */
+  aiEnabled: boolean;
   user: {
     email: string | null;
     avatarUrl: string | null;
@@ -58,13 +65,16 @@ const keys = {
   projects: ["projects"] as const,
   tasks: ["tasks"] as const,
   events: ["events"] as const,
+  /** 詳細パネル (P3-15) で fetch する AI 分解の最新試行ログ。タスク id 単位で分離する。 */
+  decomposeLog: (taskId: string) => ["actionLog", "decompose", taskId] as const,
 };
 
-export function AppShell({ initialView, user }: AppShellProps) {
+export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
   const view = initialView;
   const taskGateway = useTaskGateway();
   const projectGateway = useProjectGateway();
   const eventGateway = useEventGateway();
+  const actionLogGateway = useActionLogGateway();
   const queryClient = useQueryClient();
   const seedGateways = useMemo(
     () => ({ projectGateway, eventGateway, taskGateway }),
@@ -92,6 +102,17 @@ export function AppShell({ initialView, user }: AppShellProps) {
   const [eventDetailId, setEventDetailId] = useState<string | null>(null);
   const [projectDetailId, setProjectDetailId] = useState<string | null>(null);
   const [addOpen, setAddOpen] = useState(false);
+
+  // P3-15 / ADR 0021 §3: 詳細パネル open 時に当該タスクの AI 分解最新試行を 1 件だけ fetch。
+  // detailId が null の間は無効化して supabase を叩かない。
+  const decomposeLogQuery = useQuery({
+    queryKey: detailId ? keys.decomposeLog(detailId) : ["actionLog", "decompose", "_idle"],
+    queryFn: () => {
+      if (!detailId) return Promise.resolve(null);
+      return actionLogGateway.getLatestDecomposeForTask(detailId);
+    },
+    enabled: detailId !== null,
+  });
   // ms 表現の「今」。SSR は 0 placeholder で hydration mismatch を回避し、
   // mount 後に実時刻へ差し替える。nowMin (タイムライン用) と依存イベント比較用に共用する。
   const [nowMs, setNowMs] = useState<number>(0);
@@ -594,6 +615,21 @@ export function AppShell({ initialView, user }: AppShellProps) {
             onChangeDependency={(id, dependsOnEventId) =>
               updateDependencyMutation.mutate({ id, dependsOnEventId })
             }
+            aiEnabled={aiEnabled}
+            latestDecomposeLog={decomposeLogQuery.data ?? null}
+            isDecomposeLogLoading={decomposeLogQuery.isPending}
+            onTriggerDecompose={(id) => {
+              // P3-15 / ADR 0021 §4: optimistic に decomposing pill を出しつつ fire-and-forget。
+              // server 側でも `decompose_status='decomposing'` に倒す (重複設定は無害)。
+              queryClient.setQueryData<Task[]>(keys.tasks, (prev) =>
+                (prev ?? []).map((t) =>
+                  t.id === id ? { ...t, decomposeStatus: "decomposing" } : t,
+                ),
+              );
+              // 既存 log は陳腐化するので invalidate (新たな試行が完了したら再 fetch される)
+              queryClient.invalidateQueries({ queryKey: keys.decomposeLog(id) });
+              triggerDecompose(id);
+            }}
           />
         )}
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 
 import { GatewayProvider } from "@/shared/gateway/GatewayContext";
+import { isAiEnabled } from "@/shared/ai/env";
 import { createClient } from "@/shared/supabase/server";
 
 import { AppShell } from "./AppShell";
@@ -20,6 +21,7 @@ export default async function Page() {
     <GatewayProvider>
       <AppShell
         initialView="stack"
+        aiEnabled={isAiEnabled()}
         user={{
           email: user.email ?? null,
           avatarUrl: typeof meta.avatar_url === "string" ? meta.avatar_url : null,

--- a/src/app/tree/page.tsx
+++ b/src/app/tree/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 
 import { GatewayProvider } from "@/shared/gateway/GatewayContext";
+import { isAiEnabled } from "@/shared/ai/env";
 import { createClient } from "@/shared/supabase/server";
 
 import { AppShell } from "../AppShell";
@@ -20,6 +21,7 @@ export default async function TreePage() {
     <GatewayProvider>
       <AppShell
         initialView="tree"
+        aiEnabled={isAiEnabled()}
         user={{
           email: user.email ?? null,
           avatarUrl: typeof meta.avatar_url === "string" ? meta.avatar_url : null,

--- a/src/entities/action-log/gateway.ts
+++ b/src/entities/action-log/gateway.ts
@@ -1,0 +1,29 @@
+import type { ActionLogEntry } from "./types";
+
+/**
+ * 詳細パネル (P3-15 / ADR 0021) で参照する、AI 分解の終端 action_type 群。
+ * `task_decomposed` / `task_decompose_failed` / `task_decompose_skipped` の最新 1 件で
+ * raw response や reason を表示する。
+ */
+export type DecomposeActionType =
+  | "task_decomposed"
+  | "task_decompose_failed"
+  | "task_decompose_skipped";
+
+export type LatestDecomposeLog =
+  | ActionLogEntry<"task_decomposed">
+  | ActionLogEntry<"task_decompose_failed">
+  | ActionLogEntry<"task_decompose_skipped">;
+
+/**
+ * action_logs を Phase 3 詳細パネル用途で読み出す Gateway。
+ * 書き込みは fire-and-forget の `entities/action-log/logger` が担当するので、
+ * ここでは「詳細パネルから 1 タスク分の最新試行を取る」という限定された read に絞る。
+ */
+export interface ActionLogGateway {
+  /**
+   * 指定タスクの AI 分解結果 (decomposed / failed / skipped) のうち最新 1 件を返す。
+   * 履歴が無い (none / decomposing で固有のログ未生成) 場合は `null`。
+   */
+  getLatestDecomposeForTask(taskId: string): Promise<LatestDecomposeLog | null>;
+}

--- a/src/entities/action-log/supabase-gateway.ts
+++ b/src/entities/action-log/supabase-gateway.ts
@@ -1,0 +1,39 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { Database } from "@/shared/types/database";
+
+import type {
+  ActionLogGateway,
+  DecomposeActionType,
+  LatestDecomposeLog,
+} from "./gateway";
+import type { ActionMetadataMap } from "./types";
+
+const DECOMPOSE_ACTION_TYPES: readonly DecomposeActionType[] = [
+  "task_decomposed",
+  "task_decompose_failed",
+  "task_decompose_skipped",
+];
+
+export class SupabaseActionLogGateway implements ActionLogGateway {
+  constructor(private readonly supabase: SupabaseClient<Database>) {}
+
+  async getLatestDecomposeForTask(taskId: string): Promise<LatestDecomposeLog | null> {
+    const { data, error } = await this.supabase
+      .from("action_logs")
+      .select("action_type, metadata, created_at")
+      .eq("task_id", taskId)
+      .in("action_type", DECOMPOSE_ACTION_TYPES as unknown as string[])
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (error) throw error;
+    if (!data) return null;
+    const actionType = data.action_type as DecomposeActionType;
+    return {
+      action_type: actionType,
+      metadata: data.metadata as ActionMetadataMap[DecomposeActionType],
+      created_at: data.created_at,
+    } as LatestDecomposeLog;
+  }
+}

--- a/src/entities/action-log/supabase-gateway.ts
+++ b/src/entities/action-log/supabase-gateway.ts
@@ -2,11 +2,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 
 import type { Database } from "@/shared/types/database";
 
-import type {
-  ActionLogGateway,
-  DecomposeActionType,
-  LatestDecomposeLog,
-} from "./gateway";
+import type { ActionLogGateway, DecomposeActionType, LatestDecomposeLog } from "./gateway";
 import type { ActionMetadataMap } from "./types";
 
 const DECOMPOSE_ACTION_TYPES: readonly DecomposeActionType[] = [

--- a/src/features/task-detail/TaskDetailPanel.test.tsx
+++ b/src/features/task-detail/TaskDetailPanel.test.tsx
@@ -1,9 +1,10 @@
 import { fireEvent, render as rtlRender } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import type { Task } from "../../entities/task/types";
+import type { LatestDecomposeLog } from "../../entities/action-log/gateway";
 import type { Event } from "../../entities/event/types";
 import type { Project } from "../../entities/project/types";
 import { ProjectsProvider } from "../../entities/project/ProjectsContext";
+import type { Task } from "../../entities/task/types";
 import { TaskDetailPanel, type TaskDetailPanelProps } from "./TaskDetailPanel";
 
 // 依存イベント表示は現在時刻依存。テストは固定時刻 2026-04-11T09:00 で評価する。
@@ -289,5 +290,213 @@ describe("TaskDetailPanel", () => {
       task: { ...baseTask, estimatedMinutes: 90 },
     });
     expect(getByText("1h30m")).toBeTruthy();
+  });
+});
+
+// AI 分解情報エリア (P3-15 / ADR 0021 §3)。
+// 親が `latestDecomposeLog` か `onTriggerDecompose` を渡したときだけセクションが描画される。
+describe("TaskDetailPanel - AI 分解情報エリア (P3-15)", () => {
+  test("latestDecomposeLog / onTriggerDecompose 未指定なら AI 分解情報エリアを描画しない (旧呼び出し互換)", () => {
+    const { queryByText } = renderPanel();
+    expect(queryByText("AI 分解")).toBeNull();
+    expect(queryByText("AI 分解未試行")).toBeNull();
+  });
+
+  test("decomposeStatus=none + onTriggerDecompose 指定: 「AI 分解未試行」と「AI 分解を実行」ボタンを表示する", () => {
+    const onTriggerDecompose = vi.fn();
+    const { getByRole, getByText } = renderPanel({
+      task: { ...baseTask, decomposeStatus: "none" },
+      latestDecomposeLog: null,
+      onTriggerDecompose,
+    });
+    expect(getByText("AI 分解未試行")).toBeTruthy();
+    const btn = getByRole("button", { name: "AI 分解を実行" });
+    expect(btn).toBeTruthy();
+    expect((btn as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  test("AI 分解を実行ボタン押下で onTriggerDecompose(taskId) を呼ぶ", () => {
+    const onTriggerDecompose = vi.fn();
+    const { getByRole } = renderPanel({
+      task: { ...baseTask, decomposeStatus: "none" },
+      latestDecomposeLog: null,
+      onTriggerDecompose,
+    });
+    fireEvent.click(getByRole("button", { name: "AI 分解を実行" }));
+    expect(onTriggerDecompose).toHaveBeenCalledWith("t1");
+  });
+
+  test("aiEnabled=false なら「AI 分解を実行」ボタンが disabled", () => {
+    const onTriggerDecompose = vi.fn();
+    const { getByRole } = renderPanel({
+      task: { ...baseTask, decomposeStatus: "none" },
+      latestDecomposeLog: null,
+      aiEnabled: false,
+      onTriggerDecompose,
+    });
+    const btn = getByRole("button", { name: "AI 分解を実行" }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  test("decomposeStatus=decomposing は「分解中…」を表示し、再実行ボタンは出さない", () => {
+    const { getByText, queryByRole } = renderPanel({
+      task: { ...baseTask, decomposeStatus: "decomposing" },
+      latestDecomposeLog: null,
+      onTriggerDecompose: vi.fn(),
+    });
+    expect(getByText("分解中…")).toBeTruthy();
+    expect(queryByRole("button", { name: "AI 分解を実行" })).toBeNull();
+    expect(queryByRole("button", { name: "再実行" })).toBeNull();
+  });
+
+  test("decomposeStatus=decomposed: 子タスク件数を表示し、再実行ボタンは出さない", () => {
+    const log: LatestDecomposeLog = {
+      action_type: "task_decomposed",
+      metadata: { task_id: "t1", child_ids: ["c1", "c2", "c3"], raw_response: "raw" },
+      created_at: "2026-04-11T00:30:00.000Z",
+    };
+    const { getByText, queryByRole } = renderPanel({
+      task: { ...baseTask, decomposeStatus: "decomposed" },
+      latestDecomposeLog: log,
+      onTriggerDecompose: vi.fn(),
+    });
+    expect(getByText("分解完了（子タスク 3 件）")).toBeTruthy();
+    expect(queryByRole("button", { name: "再実行" })).toBeNull();
+    expect(queryByRole("button", { name: "AI 分解を実行" })).toBeNull();
+  });
+
+  test("decomposeStatus=skipped: 「AI が分解不要と判断」を表示し、再実行ボタンは出さない", () => {
+    const log: LatestDecomposeLog = {
+      action_type: "task_decompose_skipped",
+      metadata: { task_id: "t1", raw_response: "small task, not splitting" },
+      created_at: "2026-04-11T00:30:00.000Z",
+    };
+    const { getByText, queryByRole } = renderPanel({
+      task: { ...baseTask, decomposeStatus: "skipped" },
+      latestDecomposeLog: log,
+      onTriggerDecompose: vi.fn(),
+    });
+    expect(getByText("AI が分解不要と判断")).toBeTruthy();
+    expect(queryByRole("button", { name: "再実行" })).toBeNull();
+  });
+
+  test("decomposeStatus=failed (quota_exhausted): reason 文言と「再実行」ボタンを表示する", () => {
+    const log: LatestDecomposeLog = {
+      action_type: "task_decompose_failed",
+      metadata: { task_id: "t1", reason: "quota_exhausted", error_message: "429" },
+      created_at: "2026-04-11T00:30:00.000Z",
+    };
+    const onTriggerDecompose = vi.fn();
+    const { getByText, getByRole } = renderPanel({
+      task: { ...baseTask, decomposeStatus: "failed" },
+      latestDecomposeLog: log,
+      onTriggerDecompose,
+    });
+    expect(getByText(/分解失敗 — AI のクォータ上限に達しました/)).toBeTruthy();
+    const btn = getByRole("button", { name: "再実行" }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+  });
+
+  test("再実行ボタン押下で onTriggerDecompose(taskId) を呼ぶ", () => {
+    const log: LatestDecomposeLog = {
+      action_type: "task_decompose_failed",
+      metadata: { task_id: "t1", reason: "upstream_unavailable" },
+      created_at: "2026-04-11T00:30:00.000Z",
+    };
+    const onTriggerDecompose = vi.fn();
+    const { getByRole } = renderPanel({
+      task: { ...baseTask, decomposeStatus: "failed" },
+      latestDecomposeLog: log,
+      onTriggerDecompose,
+    });
+    fireEvent.click(getByRole("button", { name: "再実行" }));
+    expect(onTriggerDecompose).toHaveBeenCalledWith("t1");
+  });
+
+  test("failed + aiEnabled=false: 「再実行」ボタンは disabled", () => {
+    const log: LatestDecomposeLog = {
+      action_type: "task_decompose_failed",
+      metadata: { task_id: "t1", reason: "internal_error" },
+      created_at: "2026-04-11T00:30:00.000Z",
+    };
+    const { getByRole } = renderPanel({
+      task: { ...baseTask, decomposeStatus: "failed" },
+      latestDecomposeLog: log,
+      aiEnabled: false,
+      onTriggerDecompose: vi.fn(),
+    });
+    expect((getByRole("button", { name: "再実行" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  test("decomposed: raw_response が <details>/<summary> で折りたたみ表示されている", () => {
+    const log: LatestDecomposeLog = {
+      action_type: "task_decomposed",
+      metadata: {
+        task_id: "t1",
+        child_ids: ["c1"],
+        raw_response: "[{title:'準備', estimated:30}]",
+      },
+      created_at: "2026-04-11T00:30:00.000Z",
+    };
+    const { getByText, container } = renderPanel({
+      task: { ...baseTask, decomposeStatus: "decomposed" },
+      latestDecomposeLog: log,
+      onTriggerDecompose: vi.fn(),
+    });
+    const summary = getByText("AI 応答を表示");
+    expect(summary.tagName.toLowerCase()).toBe("summary");
+    const details = container.querySelector("details") as HTMLDetailsElement;
+    expect(details).toBeTruthy();
+    // 初期状態は閉じている
+    expect(details.open).toBe(false);
+    // raw response が DOM 内に存在 (details が閉じていても content は描画される)
+    expect(getByText(/準備/)).toBeTruthy();
+  });
+
+  test("isDecomposeLogLoading=true: spinner (読み込み中) を表示し、raw response は出さない", () => {
+    const { getByText, queryByText } = renderPanel({
+      task: { ...baseTask, decomposeStatus: "decomposed" },
+      latestDecomposeLog: null,
+      isDecomposeLogLoading: true,
+      onTriggerDecompose: vi.fn(),
+    });
+    expect(getByText("読み込み中…")).toBeTruthy();
+    expect(queryByText("AI 応答を表示")).toBeNull();
+    expect(queryByText("履歴なし")).toBeNull();
+  });
+
+  test("decomposed だが action_log が無い (legacy data) → 「履歴なし」", () => {
+    const { getByText, queryByText } = renderPanel({
+      task: { ...baseTask, decomposeStatus: "decomposed" },
+      latestDecomposeLog: null,
+      onTriggerDecompose: vi.fn(),
+    });
+    expect(getByText("履歴なし")).toBeTruthy();
+    expect(queryByText("AI 応答を表示")).toBeNull();
+  });
+
+  test("failed で raw_response が無い (generate 自体が throw) ケースは AI 応答なし表示", () => {
+    const log: LatestDecomposeLog = {
+      action_type: "task_decompose_failed",
+      metadata: { task_id: "t1", reason: "upstream_unavailable", error_message: "ETIMEDOUT" },
+      created_at: "2026-04-11T00:30:00.000Z",
+    };
+    const { getByText } = renderPanel({
+      task: { ...baseTask, decomposeStatus: "failed" },
+      latestDecomposeLog: log,
+      onTriggerDecompose: vi.fn(),
+    });
+    expect(getByText("AI 応答なし")).toBeTruthy();
+  });
+
+  test("AI 分解情報エリアは role=region (aria-label='AI 分解情報') として scope できる", () => {
+    const { getByRole } = renderPanel({
+      task: { ...baseTask, decomposeStatus: "none" },
+      latestDecomposeLog: null,
+      onTriggerDecompose: vi.fn(),
+    });
+    // <section aria-label="..."> は ARIA で region として扱われる
+    const section = getByRole("region", { name: "AI 分解情報" });
+    expect(section).toBeTruthy();
   });
 });

--- a/src/features/task-detail/TaskDetailPanel.tsx
+++ b/src/features/task-detail/TaskDetailPanel.tsx
@@ -1,11 +1,13 @@
 import { useMemo, useState } from "react";
-import type { Task } from "../../entities/task/types";
+import type { LatestDecomposeLog } from "../../entities/action-log/gateway";
+import type { DecomposeFailReason } from "../../entities/action-log/types";
 import type { Event } from "../../entities/event/types";
 import { getProject } from "../../entities/project/projects";
 import { useProjects } from "../../entities/project/ProjectsContext";
+import type { Task } from "../../entities/task/types";
+import { renderMarkdown } from "../../shared/lib/markdown";
 import { isDone } from "../../shared/lib/task";
 import { fmtDuration, formatRelativeTime } from "../../shared/lib/time";
-import { renderMarkdown } from "../../shared/lib/markdown";
 
 export type TaskDetailPanelProps = {
   task: Task;
@@ -21,6 +23,18 @@ export type TaskDetailPanelProps = {
    * 未指定なら依存編集 UI も表示しない (テストや特殊呼び出しで省略可)。
    */
   onChangeDependency?: (id: string, eventId: string | null) => void;
+  /**
+   * AI 分解の最新試行ログ (`task_decomposed` / `task_decompose_failed` /
+   * `task_decompose_skipped` の最新 1 件)。なければ null。
+   * 親が undefined を渡した場合は AI 分解情報エリアを描画しない (旧呼び出し互換)。
+   */
+  latestDecomposeLog?: LatestDecomposeLog | null;
+  /** action_log fetch 中フラグ。spinner 表示判定に使う。 */
+  isDecomposeLogLoading?: boolean;
+  /** AI_ENABLED kill-switch。false のとき「AI 分解を実行」/「再実行」を disable する (ADR 0021)。 */
+  aiEnabled?: boolean;
+  /** 「AI 分解を実行」/「再実行」押下時の callback。fire-and-forget で server に投げる。 */
+  onTriggerDecompose?: (id: string) => void;
 };
 
 export function TaskDetailPanel({
@@ -32,6 +46,10 @@ export function TaskDetailPanel({
   onToggleDone,
   onDelete,
   onChangeDependency,
+  latestDecomposeLog,
+  isDecomposeLogLoading,
+  aiEnabled = true,
+  onTriggerDecompose,
 }: TaskDetailPanelProps) {
   const { projectsById } = useProjects();
   const [editing, setEditing] = useState(false);
@@ -61,6 +79,8 @@ export function TaskDetailPanel({
     onUpdate(task.id, draft);
     setEditing(false);
   };
+
+  const showDecomposeSection = latestDecomposeLog !== undefined || onTriggerDecompose !== undefined;
 
   return (
     <div className="fixed inset-0 z-[200] flex flex-col">
@@ -147,6 +167,16 @@ export function TaskDetailPanel({
           </div>
         )}
 
+        {showDecomposeSection && (
+          <DecomposeInfoSection
+            task={task}
+            log={latestDecomposeLog}
+            isLoading={isDecomposeLogLoading ?? false}
+            aiEnabled={aiEnabled}
+            onTriggerDecompose={onTriggerDecompose}
+          />
+        )}
+
         <div className="mx-5 h-px bg-bg-border" />
 
         <div className="flex-1 overflow-auto px-5 pb-6 pt-3">
@@ -228,4 +258,151 @@ export function TaskDetailPanel({
       </div>
     </div>
   );
+}
+
+/**
+ * AI 分解情報エリア (P3-15 / ADR 0021 §3)。
+ * `decompose_status` 別に状態 / recovery ボタン / raw response を出し分ける。
+ */
+function DecomposeInfoSection({
+  task,
+  log,
+  isLoading,
+  aiEnabled,
+  onTriggerDecompose,
+}: {
+  task: Task;
+  log: LatestDecomposeLog | null | undefined;
+  isLoading: boolean;
+  aiEnabled: boolean;
+  onTriggerDecompose: ((id: string) => void) | undefined;
+}) {
+  const status = task.decomposeStatus;
+  const canTrigger = (status === "none" || status === "failed") && onTriggerDecompose !== undefined;
+  const buttonLabel = status === "failed" ? "再実行" : "AI 分解を実行";
+
+  // raw_response が期待される状態 (decomposed / skipped / failed)。
+  // none / decomposing は終端 log を持たないので raw 表示自体を出さない。
+  const showLogArea = status === "decomposed" || status === "skipped" || status === "failed";
+
+  return (
+    <section aria-label="AI 分解情報" className="px-5 pb-2 pt-1">
+      <div className="mb-1 font-jp text-[10px] text-fg-weak">AI 分解</div>
+      <div className="flex flex-wrap items-center gap-2">
+        <DecomposeStatusLabel status={status} log={log} />
+        {canTrigger && onTriggerDecompose ? (
+          <button
+            type="button"
+            onClick={() => onTriggerDecompose(task.id)}
+            disabled={!aiEnabled}
+            className="cursor-pointer rounded-[4px] border border-bg-divider bg-transparent px-2.5 py-[3px] font-jp text-[10px] text-fg-subtle disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {buttonLabel}
+          </button>
+        ) : null}
+      </div>
+      {showLogArea ? (
+        <div className="mt-2">
+          {isLoading ? (
+            <span role="status" className="font-jp text-[10px] text-fg-faint">
+              読み込み中…
+            </span>
+          ) : log === null || log === undefined ? (
+            <span className="font-jp text-[10px] text-fg-faint">履歴なし</span>
+          ) : (
+            <RawResponseDetails log={log} />
+          )}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function DecomposeStatusLabel({
+  status,
+  log,
+}: {
+  status: Task["decomposeStatus"];
+  log: LatestDecomposeLog | null | undefined;
+}) {
+  if (status === "decomposing") {
+    return (
+      <span
+        role="status"
+        aria-live="polite"
+        className="inline-flex items-center gap-1 rounded-[3px] bg-accent-blue/15 px-1.5 py-px font-jp text-[10px] text-accent-blue"
+      >
+        <span className="h-1 w-1 animate-pulse rounded-full bg-accent-blue" aria-hidden="true" />
+        分解中…
+      </span>
+    );
+  }
+  if (status === "decomposed") {
+    const childCount =
+      log?.action_type === "task_decomposed" ? log.metadata.child_ids.length : null;
+    return (
+      <span className="rounded-[3px] bg-fg-weak/10 px-1.5 py-px font-jp text-[10px] text-fg-subtle">
+        {childCount !== null ? `分解完了（子タスク ${childCount} 件）` : "分解完了"}
+      </span>
+    );
+  }
+  if (status === "skipped") {
+    return (
+      <span className="rounded-[3px] bg-fg-weak/15 px-1.5 py-px font-jp text-[10px] text-fg-weak">
+        AI が分解不要と判断
+      </span>
+    );
+  }
+  if (status === "failed") {
+    const reason =
+      log?.action_type === "task_decompose_failed" ? log.metadata.reason : null;
+    return (
+      <span
+        role="alert"
+        className="rounded-[3px] bg-accent-red/15 px-1.5 py-px font-jp text-[10px] text-accent-red"
+      >
+        {reason ? `分解失敗 — ${failedReasonText(reason)}` : "分解失敗"}
+      </span>
+    );
+  }
+  // status === "none"
+  return (
+    <span className="rounded-[3px] bg-fg-weak/10 px-1.5 py-px font-jp text-[10px] text-fg-faint">
+      AI 分解未試行
+    </span>
+  );
+}
+
+function RawResponseDetails({ log }: { log: LatestDecomposeLog }) {
+  const raw = rawResponseFromLog(log);
+  if (raw === null || raw.length === 0) {
+    return <span className="font-jp text-[10px] text-fg-faint">AI 応答なし</span>;
+  }
+  return (
+    <details className="font-jp text-[10px] text-fg-subtle">
+      <summary className="cursor-pointer select-none text-fg-weak">AI 応答を表示</summary>
+      <pre className="mt-1 whitespace-pre-wrap rounded border border-bg-divider bg-bg-elevated p-2 font-mono text-[10px] leading-[1.5] text-fg-default">
+        {raw}
+      </pre>
+    </details>
+  );
+}
+
+function rawResponseFromLog(log: LatestDecomposeLog): string | null {
+  if (log.action_type === "task_decomposed") return log.metadata.raw_response;
+  if (log.action_type === "task_decompose_skipped") return log.metadata.raw_response;
+  // task_decompose_failed: raw_response は generate が応答を返した後に失敗した場合のみ存在
+  return log.metadata.raw_response ?? null;
+}
+
+const FAIL_REASON_MESSAGES: Record<DecomposeFailReason, string> = {
+  quota_exhausted: "AI のクォータ上限に達しました。時間をおいて再実行してください",
+  upstream_unavailable: "AI サービスに一時的に接続できませんでした",
+  ai_response_unparseable: "AI の応答を解釈できませんでした",
+  insert_failed: "タスクの保存に失敗しました",
+  internal_error: "予期しないエラーが発生しました",
+};
+
+function failedReasonText(reason: DecomposeFailReason): string {
+  return FAIL_REASON_MESSAGES[reason];
 }

--- a/src/features/task-detail/TaskDetailPanel.tsx
+++ b/src/features/task-detail/TaskDetailPanel.tsx
@@ -354,8 +354,7 @@ function DecomposeStatusLabel({
     );
   }
   if (status === "failed") {
-    const reason =
-      log?.action_type === "task_decompose_failed" ? log.metadata.reason : null;
+    const reason = log?.action_type === "task_decompose_failed" ? log.metadata.reason : null;
     return (
       <span
         role="alert"

--- a/src/shared/gateway/GatewayContext.tsx
+++ b/src/shared/gateway/GatewayContext.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext, useMemo, type ReactNode } from "react";
 
+import type { ActionLogGateway } from "@/entities/action-log/gateway";
 import type { EventGateway } from "@/entities/event/gateway";
 import type { ProjectGateway } from "@/entities/project/gateway";
 import type { TaskGateway } from "@/entities/task/gateway";
@@ -14,6 +15,7 @@ export type GatewayBundle = {
   taskTimeEntryGateway: TaskTimeEntryGateway;
   projectGateway: ProjectGateway;
   eventGateway: EventGateway;
+  actionLogGateway: ActionLogGateway;
 };
 
 const GatewayContext = createContext<GatewayBundle | null>(null);
@@ -64,4 +66,8 @@ export function useProjectGateway(): ProjectGateway {
 
 export function useEventGateway(): EventGateway {
   return useGatewayBundle().eventGateway;
+}
+
+export function useActionLogGateway(): ActionLogGateway {
+  return useGatewayBundle().actionLogGateway;
 }

--- a/src/shared/gateway/createSupabaseGateways.ts
+++ b/src/shared/gateway/createSupabaseGateways.ts
@@ -1,3 +1,4 @@
+import { SupabaseActionLogGateway } from "@/entities/action-log/supabase-gateway";
 import { SupabaseEventGateway } from "@/entities/event/supabase-gateway";
 import { SupabaseProjectGateway } from "@/entities/project/supabase-gateway";
 import { SupabaseTaskGateway } from "@/entities/task/supabase-gateway";
@@ -17,5 +18,6 @@ export function createSupabaseGateways(): GatewayBundle {
     taskTimeEntryGateway: new SupabaseTaskTimeEntryGateway(supabase),
     projectGateway: new SupabaseProjectGateway(supabase),
     eventGateway: new SupabaseEventGateway(supabase),
+    actionLogGateway: new SupabaseActionLogGateway(supabase),
   };
 }

--- a/src/shared/gateway/test-helpers.tsx
+++ b/src/shared/gateway/test-helpers.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 
+import type { ActionLogGateway } from "@/entities/action-log/gateway";
 import type { EventGateway } from "@/entities/event/gateway";
 import type { ProjectGateway } from "@/entities/project/gateway";
 import type { TaskGateway } from "@/entities/task/gateway";
@@ -30,6 +31,7 @@ export type GatewayOverrides = {
   taskTimeEntryGateway?: Partial<TaskTimeEntryGateway>;
   projectGateway?: Partial<ProjectGateway>;
   eventGateway?: Partial<EventGateway>;
+  actionLogGateway?: Partial<ActionLogGateway>;
 };
 
 export type WithGatewaysResult = {
@@ -52,6 +54,10 @@ export function withGateways(overrides: GatewayOverrides = {}): WithGatewaysResu
     ),
     projectGateway: strictMockGateway<ProjectGateway>("ProjectGateway", overrides.projectGateway),
     eventGateway: strictMockGateway<EventGateway>("EventGateway", overrides.eventGateway),
+    actionLogGateway: strictMockGateway<ActionLogGateway>(
+      "ActionLogGateway",
+      overrides.actionLogGateway,
+    ),
   };
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 } },


### PR DESCRIPTION
## 概要 (What)

タスク詳細パネルに「AI 分解情報エリア」を新設し、`decompose_status` 別に試行結果と recovery 経路を提示する。`failed` / `none` のとき再実行ボタンを enable し、最新の `action_log` から raw response を折りたたみ表示する。

## 関連 Issue

Closes #113

## 背景 (Why)

ADR 0021 で「AI 分解の失敗を `failed` 終端 + `action_log` に raw response を残す」と決め、#110 (DB enum) / #111 (server logic) / #112 (StatusPill) を順に実装してきた。本 PR は最後のピース：詳細パネルから「失敗が見える / recovery が押せる / 履歴が残っている」を user 経路で完結させる。

参照: [ADR 0021](docs/adr/0021-ai-decomposition-failure-visibility.md) §3 / §4 / [ADR 0001](docs/adr/0001-action-logs-from-phase1.md) / [ADR 0013](docs/adr/0013-ai-as-augmentation-only.md)

## Before → After (概念・フロー・メンタルモデル)

**Before:**

- `failed` に倒れた親タスクを user が見ても、なぜ落ちたか / どう復旧するかが分からない。リスト UI / pill には reason が出ない設計。
- `none` 状態のタスクから AI 分解を手動で再走させる UI 経路がない (作成時の auto trigger のみ)。

**After:**

- 詳細パネルを開くと `decompose_status` に応じた状態ラベルが出る (`分解中…` / `分解完了（子タスク N 件）` / `AI が分解不要と判断` / `分解失敗 — {reason}` / `AI 分解未試行`)。
- `failed` / `none` で再実行ボタンが enable。押すと `decomposing` に optimistic 更新しつつ `triggerDecompose(id)` を fire-and-forget。
- `decomposed` / `skipped` / `failed` では `<details>` で AI raw response を折りたたみ表示し、debug / 判断理由が読める。
- `AI_ENABLED=false` のときはボタンを disabled (server の early-return と一致させる)。

## 追加したテスト (How verified)

- [x] `TaskDetailPanel.test.tsx` を 18 → 32 ケースに拡張 (各 `decompose_status` の描画 / 再実行ボタン enable/disable / raw response 折りたたみ / loading spinner / 履歴なし / `role="region"` で scope できる)
- [x] `npm run typecheck` / `npm run lint` / `npm test` (346/346) green
- [ ] **dev で「Gemini を 429 に倒してタスク追加 → 詳細パネルで再実行 → 復旧」の手動シナリオ** — 別 PR の手動確認が必要 (この環境では Gemini 実環境にアクセスできないため未実施)

## リリース前チェックリスト (When / Before merge)

- [x] 環境変数: `AI_ENABLED` の評価を server component (`page.tsx` / `tree/page.tsx`) で行い prop 経由で AppShell に渡す形に変更。env そのものの追加はなし
- [x] DB migration: なし (#110 で適用済の `failed` enum と #111 で書かれる action_log を読むだけ)
- [x] 既存ユーザーへの影響: 旧データ (action_log なし) は「履歴なし」表示で fail-soft

## このPRの範囲外 (Out of scope)

- AI 分解専用タブ / 一覧画面 (ADR 0021 で YAGNI)
- `decomposed` / `skipped` の再分解 UI (ADR 0021 で別 ADR)
- 自動 retry / circuit breaker (ADR 0021 で別判断)
- 子タスクから親タスクへのリンク (独立した一般機能、別 issue)
- 行動ログ全履歴の閲覧 UI (最新 1 件のみ表示)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ex2xJ7EgZGMuSjhjtzhh1M)_