### PR TITLE
feat(ai): /api/ai/categorize + 非同期 task_category labeling (P3-4, #89)

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -24,6 +24,7 @@ import { useLazyCalendarSync } from "@/features/sync/useLazyCalendarSync";
 import { TaskDetailPanel } from "@/features/task-detail/TaskDetailPanel";
 import { PauseReasonModal } from "@/features/task-stack/PauseReasonModal";
 import { TaskStack, type TopTimerBinding } from "@/features/task-stack/TaskStack";
+import { triggerCategorize } from "@/features/task-stack/triggerCategorize";
 import { triggerDecompose } from "@/features/task-stack/triggerDecompose";
 import { useTaskTimer } from "@/features/task-stack/useTaskTimer";
 import { TreeView } from "@/features/tree-view/TreeView";
@@ -681,6 +682,11 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
                   : [...list, updated];
               });
               triggerDecompose(created.id);
+              // P3-4 / ADR 0015: AI 初期ラベリングも同経路で fire-and-forget。
+              // 失敗 / AI_ENABLED=false は server が `task_category=null` のまま残す
+              // (ADR 0013 augmentation only)。client 側の optimistic 反映はしない —
+              // category は UX 上「気づいたら埋まっている」体験で良い。
+              triggerCategorize(created.id);
             }}
             onCreateEvent={async (input) => {
               await createEventMutation.mutateAsync(input);

--- a/src/app/api/ai/categorize/route.test.ts
+++ b/src/app/api/ai/categorize/route.test.ts
@@ -1,0 +1,161 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+// withAiRoute の中で require する supabase server client を mock
+vi.mock("@/shared/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+// Gemini SDK を mock (テストでは API key 不要・実通信なし)
+const generateContentMock = vi.fn();
+vi.mock("@google/generative-ai", () => ({
+  GoogleGenerativeAI: function MockGoogleGenerativeAI() {
+    return {
+      getGenerativeModel: () => ({
+        generateContent: generateContentMock,
+      }),
+    };
+  },
+}));
+
+// categorizeTask 本体は別 test で踏むので、ここでは call 検証だけ行う
+const categorizeTaskMock = vi.fn();
+vi.mock("@/entities/task/categorize-server", () => ({
+  categorizeTask: (...args: unknown[]) => categorizeTaskMock(...args),
+}));
+
+import { createClient } from "@/shared/supabase/server";
+
+import { POST } from "./route";
+
+function makeSupabase(session: { user: { id: string } } | null): SupabaseClient {
+  return {
+    auth: {
+      getSession: vi.fn(async () => ({ data: { session }, error: null })),
+    },
+  } as unknown as SupabaseClient;
+}
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/ai/categorize", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+describe("POST /api/ai/categorize", () => {
+  const original = {
+    aiEnabled: process.env.AI_ENABLED,
+    geminiApiKey: process.env.GEMINI_API_KEY,
+  };
+
+  beforeEach(() => {
+    delete process.env.AI_ENABLED;
+    delete process.env.GEMINI_API_KEY;
+    vi.mocked(createClient).mockReset();
+    categorizeTaskMock.mockReset();
+    generateContentMock.mockReset();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (original.aiEnabled === undefined) delete process.env.AI_ENABLED;
+    else process.env.AI_ENABLED = original.aiEnabled;
+    if (original.geminiApiKey === undefined) delete process.env.GEMINI_API_KEY;
+    else process.env.GEMINI_API_KEY = original.geminiApiKey;
+    vi.restoreAllMocks();
+  });
+
+  test("AI_ENABLED=false → 200 skipped, categorizeTask は呼ばれない (e2e バイパス、ADR 0014)", async () => {
+    const response = await POST(makeRequest({ task_id: "t1" }));
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { skipped: boolean; reason: string };
+    expect(body).toEqual({ skipped: true, reason: "ai_disabled" });
+    expect(categorizeTaskMock).not.toHaveBeenCalled();
+  });
+
+  test("未ログイン → 401 unauthorized", async () => {
+    process.env.AI_ENABLED = "true";
+    process.env.GEMINI_API_KEY = "k";
+    vi.mocked(createClient).mockResolvedValue(makeSupabase(null));
+
+    const response = await POST(makeRequest({ task_id: "t1" }));
+
+    expect(response.status).toBe(401);
+    expect(categorizeTaskMock).not.toHaveBeenCalled();
+  });
+
+  test("body に task_id が無い → ok:false で error を返す (200、fire-and-forget client は無視)", async () => {
+    process.env.AI_ENABLED = "true";
+    process.env.GEMINI_API_KEY = "k";
+    vi.mocked(createClient).mockResolvedValue(makeSupabase({ user: { id: "u1" } }));
+
+    const response = await POST(makeRequest({ wrong_field: "x" }));
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { ok: boolean; error: string };
+    expect(body).toEqual({ ok: false, error: "missing task_id" });
+    expect(categorizeTaskMock).not.toHaveBeenCalled();
+  });
+
+  test("body が JSON でない → ok:false で error を返す (parse エラーで 500 にしない)", async () => {
+    process.env.AI_ENABLED = "true";
+    process.env.GEMINI_API_KEY = "k";
+    vi.mocked(createClient).mockResolvedValue(makeSupabase({ user: { id: "u1" } }));
+
+    const response = await POST(makeRequest("not json"));
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(categorizeTaskMock).not.toHaveBeenCalled();
+  });
+
+  test("正常系: categorizeTask を userId / taskId / generate 付きで呼び出す", async () => {
+    process.env.AI_ENABLED = "true";
+    process.env.GEMINI_API_KEY = "k";
+    vi.mocked(createClient).mockResolvedValue(makeSupabase({ user: { id: "u1" } }));
+    categorizeTaskMock.mockResolvedValue({ kind: "categorized", category: "coding" });
+    generateContentMock.mockResolvedValue({ response: { text: () => "coding" } });
+
+    const response = await POST(makeRequest({ task_id: "task-1" }));
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { ok: boolean; outcome: unknown };
+    expect(body).toEqual({
+      ok: true,
+      outcome: { kind: "categorized", category: "coding" },
+    });
+
+    expect(categorizeTaskMock).toHaveBeenCalledOnce();
+    const callArg = categorizeTaskMock.mock.calls[0][0] as {
+      userId: string;
+      taskId: string;
+      generate: (p: string) => Promise<string>;
+    };
+    expect(callArg.userId).toBe("u1");
+    expect(callArg.taskId).toBe("task-1");
+    expect(typeof callArg.generate).toBe("function");
+
+    // generate を実行すると Gemini が呼ばれることを確認
+    const text = await callArg.generate("dummy prompt");
+    expect(generateContentMock).toHaveBeenCalledWith("dummy prompt");
+    expect(text).toBe("coding");
+  });
+
+  test("categorizeTask が throw → 500 ai_failed (fail-soft、client は握り潰す)", async () => {
+    process.env.AI_ENABLED = "true";
+    process.env.GEMINI_API_KEY = "k";
+    vi.mocked(createClient).mockResolvedValue(makeSupabase({ user: { id: "u1" } }));
+    categorizeTaskMock.mockRejectedValue(new Error("unexpected db error"));
+
+    const response = await POST(makeRequest({ task_id: "t1" }));
+
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("ai_failed");
+  });
+});

--- a/src/app/api/ai/categorize/route.ts
+++ b/src/app/api/ai/categorize/route.ts
@@ -1,0 +1,53 @@
+import { categorizeTask } from "@/entities/task/categorize-server";
+import { createGeminiClient } from "@/shared/ai/client";
+import { withAiRoute } from "@/shared/ai/route";
+
+/**
+ * AI タスク分類 endpoint (P3-4, ADR 0015 / 0013)。
+ *
+ * 期待フロー:
+ * - client がタスク作成成功後に fire-and-forget で POST する (`{ task_id }`)
+ * - `withAiRoute` が AI_ENABLED / 認証を吸収する。AI_ENABLED=false なら 200 skipped で終わり
+ * - 本体は `categorizeTask` (race guard / parser / 条件付き UPDATE) を呼ぶ
+ * - 失敗 / parse 不能のときは `task_category` は null のまま残る (ADR 0013 augmentation only)
+ *
+ * クライアント側はレスポンスを使わない (fire-and-forget)。それでも outcome を返すのは
+ * dev / curl / 将来の retry で観測できるようにするため。
+ */
+
+const MODEL_ID = "gemini-2.5-flash";
+
+export async function POST(request: Request) {
+  return withAiRoute(request, async ({ supabase, userId, request: req }) => {
+    const body = await safeJsonBody(req);
+    const taskId = typeof body?.task_id === "string" ? body.task_id : null;
+    if (!taskId) {
+      return { ok: false, error: "missing task_id" };
+    }
+
+    const client = createGeminiClient();
+    const model = client.getGenerativeModel({ model: MODEL_ID });
+
+    const outcome = await categorizeTask({
+      supabase,
+      userId,
+      taskId,
+      generate: async (prompt) => {
+        const result = await model.generateContent(prompt);
+        return result.response.text();
+      },
+    });
+
+    return { ok: true, outcome };
+  });
+}
+
+async function safeJsonBody(req: Request): Promise<Record<string, unknown> | null> {
+  try {
+    const data = (await req.json()) as unknown;
+    if (typeof data !== "object" || data === null) return null;
+    return data as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}

--- a/src/entities/task/categorize-server.test.ts
+++ b/src/entities/task/categorize-server.test.ts
@@ -1,0 +1,234 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { Database, Tables } from "@/shared/types/database";
+
+import { categorizeTask, type CategorizeTaskDeps, type GenerateFn } from "./categorize-server";
+
+type Plan = {
+  fetch: { data: Partial<Tables<"tasks">> | null; error: { message: string } | null };
+  update: {
+    data: { id: string } | null;
+    error: { message: string } | null;
+  };
+};
+
+/**
+ * categorize-server が叩く Supabase の chain を最小モック化する。
+ *
+ * - fetch: `from('tasks').select(...).eq('id').eq('user_id').maybeSingle()`
+ * - update: `from('tasks').update({task_category}).eq('id').eq('user_id').is('task_category', null).select('id').maybeSingle()`
+ */
+function makeSupabase(plan: Plan): {
+  client: SupabaseClient<Database>;
+  calls: {
+    updates: Array<{
+      patch: Record<string, unknown>;
+      filters: Array<[string, unknown] | { kind: "is"; col: string; val: unknown }>;
+    }>;
+  };
+} {
+  const calls = {
+    updates: [] as Array<{
+      patch: Record<string, unknown>;
+      filters: Array<[string, unknown] | { kind: "is"; col: string; val: unknown }>;
+    }>,
+  };
+
+  const from = vi.fn((table: string) => {
+    if (table !== "tasks") {
+      throw new Error(`unexpected table: ${table}`);
+    }
+    return {
+      // fetchTask: select(...).eq("id").eq("user_id").maybeSingle()
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn(() =>
+              Promise.resolve({
+                data: plan.fetch.data ?? null,
+                error: plan.fetch.error,
+              }),
+            ),
+          })),
+        })),
+      })),
+      // update({...}).eq("id").eq("user_id").is("task_category", null).select("id").maybeSingle()
+      update: (patch: Record<string, unknown>) => {
+        const record: (typeof calls.updates)[number] = { patch, filters: [] };
+        calls.updates.push(record);
+        const chain = {
+          eq: (col: string, val: unknown) => {
+            record.filters.push([col, val]);
+            return chain;
+          },
+          is: (col: string, val: unknown) => {
+            record.filters.push({ kind: "is", col, val });
+            return chain;
+          },
+          select: () => ({
+            maybeSingle: () =>
+              Promise.resolve({
+                data: plan.update.data,
+                error: plan.update.error,
+              }),
+          }),
+        };
+        return chain;
+      },
+    };
+  });
+
+  const client = { from } as unknown as SupabaseClient<Database>;
+  return { client, calls };
+}
+
+function makeTaskRow(overrides: Partial<Tables<"tasks">> = {}): Partial<Tables<"tasks">> {
+  return {
+    id: "task-1",
+    title: "RLS ポリシーの追加",
+    body: "tasks に user_id スコープを敷く",
+    task_category: null,
+    ...overrides,
+  };
+}
+
+function defaultPlan(task: Partial<Tables<"tasks">> | null): Plan {
+  return {
+    fetch: { data: task, error: null },
+    update: { data: { id: "task-1" }, error: null },
+  };
+}
+
+function makeDeps(opts: {
+  client: SupabaseClient<Database>;
+  generate: GenerateFn;
+  taskId?: string;
+  userId?: string;
+}): CategorizeTaskDeps {
+  return {
+    supabase: opts.client,
+    userId: opts.userId ?? "user-1",
+    taskId: opts.taskId ?? "task-1",
+    generate: opts.generate,
+  };
+}
+
+describe("categorizeTask", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  test("happy path: AI が `coding` を返す → tasks.task_category を coding に UPDATE", async () => {
+    const { client, calls } = makeSupabase(defaultPlan(makeTaskRow()));
+    const generate = vi.fn(async () => "coding");
+
+    const result = await categorizeTask(makeDeps({ client, generate }));
+
+    expect(result).toEqual({ kind: "categorized", category: "coding" });
+    expect(calls.updates).toHaveLength(1);
+    expect(calls.updates[0].patch).toEqual({ task_category: "coding" });
+    // race guard: id / user_id / task_category IS NULL の 3 条件で UPDATE
+    expect(calls.updates[0].filters).toEqual([
+      ["id", "task-1"],
+      ["user_id", "user-1"],
+      { kind: "is", col: "task_category", val: null },
+    ]);
+    // prompt が title / body 入りで組まれている
+    expect(generate).toHaveBeenCalledOnce();
+    expect(generate).toHaveBeenCalledWith(expect.stringContaining("RLS ポリシーの追加"));
+  });
+
+  test("対象タスクが存在しない (RLS or 既に削除) → no-op で task_not_found", async () => {
+    const { client, calls } = makeSupabase(defaultPlan(null));
+    const generate = vi.fn();
+
+    const result = await categorizeTask(makeDeps({ client, generate }));
+
+    expect(result).toEqual({ kind: "skipped", reason: "task_not_found" });
+    expect(generate).not.toHaveBeenCalled();
+    expect(calls.updates).toHaveLength(0);
+  });
+
+  test("既に task_category が埋まっている (人間 override 等) → AI で上書きしない", async () => {
+    const { client, calls } = makeSupabase(defaultPlan(makeTaskRow({ task_category: "doc" })));
+    const generate = vi.fn();
+
+    const result = await categorizeTask(makeDeps({ client, generate }));
+
+    expect(result).toEqual({ kind: "skipped", reason: "already_categorized" });
+    // AI 呼び出しもスキップ (quota / latency 節約)
+    expect(generate).not.toHaveBeenCalled();
+    expect(calls.updates).toHaveLength(0);
+  });
+
+  test("AI が値域外を返す (例: meeting) → 何も書かず failed/ai_response_unparseable", async () => {
+    const { client, calls } = makeSupabase(defaultPlan(makeTaskRow()));
+    const generate = vi.fn(async () => "meeting");
+
+    const result = await categorizeTask(makeDeps({ client, generate }));
+
+    expect(result).toEqual({ kind: "failed", reason: "ai_response_unparseable" });
+    expect(calls.updates).toHaveLength(0); // null のまま残す (ADR 0013)
+  });
+
+  test("AI が空文字を返す → failed/ai_response_unparseable で null のまま残る", async () => {
+    const { client, calls } = makeSupabase(defaultPlan(makeTaskRow()));
+    const generate = vi.fn(async () => "");
+
+    const result = await categorizeTask(makeDeps({ client, generate }));
+
+    expect(result).toEqual({ kind: "failed", reason: "ai_response_unparseable" });
+    expect(calls.updates).toHaveLength(0);
+  });
+
+  test("Gemini が throw (429 quota / 503 / network 等) → failed/generate_failed", async () => {
+    const { client, calls } = makeSupabase(defaultPlan(makeTaskRow()));
+    const generate = vi.fn(async () => {
+      throw Object.assign(new Error("quota exceeded"), { status: 429 });
+    });
+
+    const result = await categorizeTask(makeDeps({ client, generate }));
+
+    expect(result).toEqual({ kind: "failed", reason: "generate_failed" });
+    expect(calls.updates).toHaveLength(0); // null のまま (ADR 0013)
+  });
+
+  test("UPDATE が DB エラー → failed/update_failed", async () => {
+    const plan = defaultPlan(makeTaskRow());
+    plan.update = { data: null, error: { message: "rls violation" } };
+    const { client, calls } = makeSupabase(plan);
+    const generate = vi.fn(async () => "research");
+
+    const result = await categorizeTask(makeDeps({ client, generate }));
+
+    expect(result).toEqual({ kind: "failed", reason: "update_failed" });
+    expect(calls.updates).toHaveLength(1);
+  });
+
+  test("AI 応答中に人間 override が走った (UPDATE が 0 行) → already_categorized", async () => {
+    // AI 呼び出し後の race: `task_category IS NULL` ガードに弾かれて 0 行更新になる。
+    const plan = defaultPlan(makeTaskRow());
+    plan.update = { data: null, error: null };
+    const { client, calls } = makeSupabase(plan);
+    const generate = vi.fn(async () => "admin");
+
+    const result = await categorizeTask(makeDeps({ client, generate }));
+
+    expect(result).toEqual({ kind: "skipped", reason: "already_categorized" });
+    expect(calls.updates).toHaveLength(1);
+  });
+
+  test("値域それぞれ (coding/doc/research/admin/other) を AI 応答として受理する", async () => {
+    for (const category of ["coding", "doc", "research", "admin", "other"] as const) {
+      const { client, calls } = makeSupabase(defaultPlan(makeTaskRow()));
+      const generate = vi.fn(async () => category);
+
+      const result = await categorizeTask(makeDeps({ client, generate }));
+
+      expect(result).toEqual({ kind: "categorized", category });
+      expect(calls.updates[0].patch).toEqual({ task_category: category });
+    }
+  });
+});

--- a/src/entities/task/categorize-server.ts
+++ b/src/entities/task/categorize-server.ts
@@ -1,0 +1,117 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { buildCategorizePrompt, parseCategorizeResponse } from "@/shared/ai/prompts/categorize";
+import type { Database, Tables } from "@/shared/types/database";
+
+/**
+ * AI タスク分類 (P3-4 / ADR 0015 / 0013) の server 側 orchestrator。
+ *
+ * 流れ:
+ * 1. 対象タスクを userId スコープで取得 (RLS 前提だが defense in depth)
+ * 2. race condition guard:
+ *    - 既に `task_category` が埋まっている → AI が後追いで上書きしない
+ *      (人間 override / 別経路 backfill が先に書いた可能性)
+ *    - parent_task_id が null でなく title が AI 分解で生成された子タスク
+ *      の場合も同経路で分類して構わないのでスキップしない
+ * 3. prompt 組み立て → generate (AI 呼び出し) → parse
+ * 4. 解釈成功 (`coding` / `doc` / ...) → `tasks.task_category` に UPDATE
+ *    解釈失敗 (null) → 何も書かない (null のまま残す。ADR 0013 augmentation only)
+ *
+ * action_log 記録は **しない**。`task_category_changed` は人間 override 専用
+ * (ADR 0015 Decision 4 / action-log/types.ts の metadata 注釈)。
+ * AI の初期ラベリングは「気づいたら埋まっている」体験で、行動データではない。
+ *
+ * 失敗 / quota / 解釈不能 / 解釈成功後の DB エラー、いずれも throw せず outcome として返す。
+ * Route Handler 側は outcome を握り潰す前提 (fire-and-forget client への 200 応答)。
+ */
+
+export type CategorizeTaskOutcome =
+  | { kind: "categorized"; category: TaskCategory }
+  | { kind: "skipped"; reason: SkipReason }
+  | { kind: "failed"; reason: FailReason };
+
+type TaskCategory = NonNullable<Tables<"tasks">["task_category"]>;
+
+type SkipReason = "task_not_found" | "already_categorized"; // 既に値が入っている (人間 override 等)
+
+type FailReason = "ai_response_unparseable" | "update_failed" | "generate_failed"; // AI 呼び出し自体が throw
+
+export type GenerateFn = (prompt: string) => Promise<string>;
+
+export type CategorizeTaskDeps = {
+  supabase: SupabaseClient<Database>;
+  userId: string;
+  taskId: string;
+  generate: GenerateFn;
+};
+
+export async function categorizeTask(deps: CategorizeTaskDeps): Promise<CategorizeTaskOutcome> {
+  const { supabase, userId, taskId, generate } = deps;
+
+  const target = await fetchTask(supabase, userId, taskId);
+  if (!target) {
+    return { kind: "skipped", reason: "task_not_found" };
+  }
+
+  if (target.task_category !== null) {
+    return { kind: "skipped", reason: "already_categorized" };
+  }
+
+  let responseText: string;
+  try {
+    const prompt = buildCategorizePrompt({ title: target.title, body: target.body });
+    responseText = await generate(prompt);
+  } catch (error) {
+    console.error("[ai/categorize] generate failed", error);
+    return { kind: "failed", reason: "generate_failed" };
+  }
+
+  const parsed = parseCategorizeResponse(responseText);
+  if (parsed === null) {
+    return { kind: "failed", reason: "ai_response_unparseable" };
+  }
+
+  // race condition: AI が応答を返している間に人間 override が走った可能性を最終チェック。
+  // `task_category IS NULL` でガードした条件付き UPDATE を投げ、上書きしない。
+  const { data: updated, error } = await supabase
+    .from("tasks")
+    .update({ task_category: parsed })
+    .eq("id", taskId)
+    .eq("user_id", userId)
+    .is("task_category", null)
+    .select("id")
+    .maybeSingle();
+
+  if (error) {
+    console.error("[ai/categorize] update failed", error);
+    return { kind: "failed", reason: "update_failed" };
+  }
+
+  // フィルタにマッチせず 0 行更新 (= 直前に人間 override が確定) も skipped 扱い。
+  if (!updated) {
+    return { kind: "skipped", reason: "already_categorized" };
+  }
+
+  return { kind: "categorized", category: parsed };
+}
+
+type TaskRow = Pick<Tables<"tasks">, "id" | "title" | "body" | "task_category">;
+
+async function fetchTask(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  taskId: string,
+): Promise<TaskRow | null> {
+  const { data, error } = await supabase
+    .from("tasks")
+    .select("id, title, body, task_category")
+    .eq("id", taskId)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (error) {
+    console.error("[ai/categorize] task fetch failed", error);
+    return null;
+  }
+  return (data as TaskRow | null) ?? null;
+}

--- a/src/features/task-stack/triggerCategorize.ts
+++ b/src/features/task-stack/triggerCategorize.ts
@@ -1,0 +1,21 @@
+/**
+ * AI タスク分類の fire-and-forget 起動 (P3-4, ADR 0015 / 0013)。
+ *
+ * AppShell の onCreateTask 成功後にこれを呼ぶ。await しない:
+ * - latency をタスク追加 UX に乗せない (ADR 0013 augmentation only)
+ * - AI 失敗 / `AI_ENABLED=false` で 200 skipped が返っても呼び出し元は知らない
+ * - `task_category` は server 側で fire-and-forget に書かれる。UI には数秒後の
+ *   refetch (action_log invalidate / TanStack Query refetchOnFocus 等) で反映される
+ *
+ * 戻り値は無し。例外も握り潰す (fire-and-forget の契約)。
+ */
+export function triggerCategorize(taskId: string): void {
+  void fetch("/api/ai/categorize", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ task_id: taskId }),
+  }).catch((err) => {
+    // 失敗しても core は止まらない。dev では console に出して気付けるようにする
+    console.error("[ai/categorize] fire-and-forget failed", err);
+  });
+}

--- a/src/shared/ai/prompts/categorize.test.ts
+++ b/src/shared/ai/prompts/categorize.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "vitest";
+
+import { buildCategorizePrompt, parseCategorizeResponse } from "./categorize";
+
+describe("buildCategorizePrompt", () => {
+  test("title / body を埋め込み、本文ありの分類を促す", () => {
+    const prompt = buildCategorizePrompt({
+      title: "RLS ポリシーの実装",
+      body: "tasks テーブルの user_id 制約を追加する",
+    });
+
+    expect(prompt).toContain("RLS ポリシーの実装");
+    expect(prompt).toContain("tasks テーブルの user_id 制約を追加する");
+  });
+
+  test("body が空のときも壊れず (本文なし) として扱う", () => {
+    const prompt = buildCategorizePrompt({ title: "x", body: "" });
+
+    expect(prompt).toContain("(本文なし)");
+  });
+
+  test("値域 (coding/doc/research/admin/other) と 1 語のみ返す制約が含まれる", () => {
+    const prompt = buildCategorizePrompt({ title: "x", body: "y" });
+
+    expect(prompt).toContain("coding");
+    expect(prompt).toContain("doc");
+    expect(prompt).toContain("research");
+    expect(prompt).toContain("admin");
+    expect(prompt).toContain("other");
+    expect(prompt).toContain("1 語のみ");
+  });
+});
+
+describe("parseCategorizeResponse", () => {
+  test.each([["coding"], ["doc"], ["research"], ["admin"], ["other"]])(
+    "値域そのままの応答 %s を採用する",
+    (raw) => {
+      expect(parseCategorizeResponse(raw)).toBe(raw);
+    },
+  );
+
+  test("前後の空白 / 改行を削る", () => {
+    expect(parseCategorizeResponse("  coding\n")).toBe("coding");
+  });
+
+  test("末尾の句読点 (。 . ) や引用符を削る", () => {
+    expect(parseCategorizeResponse("coding.")).toBe("coding");
+    expect(parseCategorizeResponse("coding。")).toBe("coding");
+    expect(parseCategorizeResponse('"doc"')).toBe("doc");
+    expect(parseCategorizeResponse("`research`")).toBe("research");
+  });
+
+  test("大小文字差を吸収する (LLM が `Coding` / `CODING` を返しても拾う)", () => {
+    expect(parseCategorizeResponse("Coding")).toBe("coding");
+    expect(parseCategorizeResponse("DOC")).toBe("doc");
+  });
+
+  test("markdown fence (```...```) を剥がす", () => {
+    expect(parseCategorizeResponse("```\ncoding\n```")).toBe("coding");
+    expect(parseCategorizeResponse("```text\nadmin\n```")).toBe("admin");
+  });
+
+  test("値域外の単語は null (= AI 失敗扱い、`task_category` は null のまま残す)", () => {
+    expect(parseCategorizeResponse("meeting")).toBeNull();
+    expect(parseCategorizeResponse("learning")).toBeNull();
+    expect(parseCategorizeResponse("作業")).toBeNull();
+  });
+
+  test("空文字 / 空白だけ → null", () => {
+    expect(parseCategorizeResponse("")).toBeNull();
+    expect(parseCategorizeResponse("   \n  ")).toBeNull();
+  });
+
+  test("文章で説明されると null (1 語制約を破った応答は採用しない)", () => {
+    // ADR 0015 Notes: ラベリング失敗は null で残し、Phase 4 のラベリング精度
+    // 改善ループで「AI が分類できなかった事象」として観測可能にする。
+    expect(parseCategorizeResponse("これは coding に分類できます")).toBeNull();
+  });
+});

--- a/src/shared/ai/prompts/categorize.ts
+++ b/src/shared/ai/prompts/categorize.ts
@@ -1,0 +1,83 @@
+/**
+ * AI タスク分類 (P3-4, ADR 0015 / 0013) の prompt 構築 + 応答パース。
+ *
+ * Gemini 呼び出し境界の外側に純粋関数として置くことで、prompt 文字列の組み立てと
+ * 応答テキストの解釈をユニットテストで踏める形にしている (`/api/ai/categorize`
+ * 本体はこれをデータパイプとしてつなぐだけ)。
+ *
+ * 出力契約:
+ * - AI 失敗 / 解釈不能 / 想定外の値 → `null` (`task_category` は null のまま残す)
+ * - 解釈成功 → `TaskCategoryValue` のいずれか
+ *
+ * 値域は `tasks.task_category` の CHECK と一致させる必要があり、
+ * `TaskCategoryValue` (database.ts) を single source of truth として再利用する。
+ */
+
+import { TASK_CATEGORY_VALUES, type TaskCategoryValue } from "@/shared/types/database";
+
+export type CategorizeInput = {
+  title: string;
+  body: string;
+};
+
+const ALLOWED = TASK_CATEGORY_VALUES;
+
+/**
+ * Gemini に渡す prompt 文字列を構築する。
+ *
+ * - 値域 (coding / doc / research / admin / other) を明示し、それ以外を返さないよう縛る
+ * - 出力は値そのもの 1 トークン (例: `coding`)。json/markdown を強要しない方が
+ *   小モデルでの応答揺れに耐性が高い
+ * - 各カテゴリの定義を簡潔に書くことで、判定基準を user 個別の感覚に寄せ過ぎない
+ */
+export function buildCategorizePrompt(task: CategorizeInput): string {
+  const bodyText = task.body.trim().length > 0 ? task.body.trim() : "(本文なし)";
+
+  return [
+    "あなたは個人特化のタスク管理アシスタント。次のタスクを 1 つのカテゴリに分類する。",
+    "",
+    "# カテゴリ定義",
+    "- coding   : 実装 / バグ修正 / リファクタ / レビュー / セットアップなどコードを書く作業",
+    "- doc      : ドキュメント / 議事録 / 設計メモ / レポート / メール / 連絡文を書く作業",
+    "- research : 調査 / 比較検討 / 学習 / インタビュー / 仕様読解など情報収集の作業",
+    "- admin    : 事務手続き / 経費精算 / 予約 / スケジューリング / 雑務",
+    "- other    : 上記いずれにも当てはまらない作業",
+    "",
+    "# タスク",
+    `title: ${task.title}`,
+    `body: ${bodyText}`,
+    "",
+    "# 出力形式",
+    `${ALLOWED.join(" / ")} のいずれか 1 語のみを返す。説明文・記号・改行・前後の空白を付けない。`,
+    "判断に確信が持てない場合は other を返す。",
+  ].join("\n");
+}
+
+/**
+ * Gemini 応答テキストを `TaskCategoryValue` に解釈する。
+ *
+ * - markdown fence (```...```) を剥がす
+ * - 前後の空白 / 末尾句読点を削る
+ * - lowercase で値域と完全一致した場合のみ採用
+ * - それ以外は `null` (= AI 失敗扱い、`task_category` は null のまま)
+ *
+ * `other` を fallback で返さない: 値域外を `other` に倒すと「AI が分類した」と
+ * 「AI が判定不能だった」が区別できなくなり、Phase 4 のラベリング精度分析の
+ * 入力が劣化する (ADR 0015 Notes / 暗黙フィードバック設計)。
+ */
+export function parseCategorizeResponse(text: string): TaskCategoryValue | null {
+  const cleaned = stripMarkdownFence(text)
+    .trim()
+    .replace(/^["'`\s]+|["'`\s。.]+$/gu, "")
+    .toLowerCase();
+  if (cleaned.length === 0) return null;
+
+  const found = ALLOWED.find((v) => v === cleaned);
+  return found ?? null;
+}
+
+function stripMarkdownFence(text: string): string {
+  const fenceRe = /^```(?:[a-z]+)?\s*\n?([\s\S]*?)\n?```$/i;
+  const match = text.trim().match(fenceRe);
+  return match ? match[1] : text;
+}

--- a/src/shared/types/database.ts
+++ b/src/shared/types/database.ts
@@ -15,8 +15,12 @@ export type Json = string | number | boolean | null | { [key: string]: Json | un
  * tasks.task_category の値域 (#87, ADR 0015)。
  * DB 側は text + CHECK 制約 (supabase/migrations/20260427000000_task_category.sql)。
  * 値の追加・名称変更は ADR の supersede ではなく migration + ここの更新で行う。
+ *
+ * 配列は AI 応答 parser (P3-4) など runtime で値域チェックする箇所で再利用する
+ * 単一の真実の場所。type は配列から導出して二重管理を避ける。
  */
-export type TaskCategoryValue = "coding" | "doc" | "research" | "admin" | "other";
+export const TASK_CATEGORY_VALUES = ["coding", "doc", "research", "admin", "other"] as const;
+export type TaskCategoryValue = (typeof TASK_CATEGORY_VALUES)[number];
 
 export type Database = {
   public: {


### PR DESCRIPTION
## 概要 (What)

タスク作成後に fire-and-forget で AI が `task_category` を初期ラベリングする経路を追加する (P3-4)。

## 関連 Issue

Closes #89

## 背景 (Why)

Phase 3 / 4 の見積もり補正エンジン (architecture.md §1.5) と行動パターン分析 (§1.6) は「タスク種類別の集計」が前提になっている。#87 で `tasks.task_category` 列と `task_category_changed` action_type は揃ったので、ここで AI 初期ラベリングの経路を埋める。

設計上の制約:
- [ADR 0013](docs/adr/0013-ai-as-augmentation-only.md): AI は augmentation only。失敗 / quota / `AI_ENABLED=false` で core 機能を止めない
- [ADR 0015](docs/adr/0015-task-category-ai-first-labeling.md): AI が初期ラベル / 人間は override / **AI 初期ラベリングは action_log に記録しない** (`task_category_changed` は人間 override 専用の暗黙フィードバック源)

## Before → After (概念・フロー・メンタルモデル)

**Before:**
タスク作成時、`task_category` は常に `null`。Phase 3 / 4 の補正・分析の入力軸が空のままで、機能が成立しない。

**After:**
AppShell の `onCreateTask` 成功後に `triggerCategorize(id)` を fire-and-forget で投げる。server 側 (`/api/ai/categorize`) は `AI_ENABLED` kill-switch → 既値ガード → Gemini 呼び出し → `task_category IS NULL` 条件付き UPDATE という流れ。AI 失敗 / 値域外 / quota は `task_category=null` のまま残し、core 動作は不変 (ADR 0013)。

UX 上は「気づいたら category が埋まっている」体験 — vision の「AI を育てている自覚を持たせない」と整合。

## 追加したテスト (How verified)

- [x] `shared/ai/prompts/categorize.test.ts`: prompt 構築 / parse の純粋関数 (値域 一致 / fence 剥離 / 値域外 → null / fallback で `other` に倒さない契約)
- [x] `entities/task/categorize-server.test.ts`: 既値ガード / race condition (`IS NULL` で 0 行更新 → skipped) / generate throw → null 維持 / 値域それぞれ受理
- [x] `app/api/ai/categorize/route.test.ts`: `AI_ENABLED=false` で skipped / 401 / 不正 body / Gemini 疎通 / fail-soft 500
- [x] vitest 全件: 376/376 pass、tsc / eslint / prettier クリーン
- [ ] **未検証**: dev で `AI_ENABLED=true` + 実 Gemini 疎通でタスク作成後数秒で category が埋まる手動確認 (issue 完了条件)
- [ ] **未検証**: e2e (P3-11 の対象。`AI_ENABLED=false` で skipped 経路は通る)

## リリース前チェックリスト (When / Before merge)

- [ ] dev で `AI_ENABLED=true` のときタスク作成 → 数秒後に category が埋まることを手動確認 (issue #89 完了条件)
- [ ] `AI_ENABLED=false` のとき category が null のまま、core 機能が通常動作することを確認

## このPRの範囲外 (Out of scope)

- override UI (P3-5)
- 既存タスクの backfill (別 issue、ADR 0015 Notes)
- `task_category` の値域追加・名称変更 (運用で更新する想定)
- 補正エンジン本体 (P3-9) / 集計ヘルパ (P3-10)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKCiRR649N7RjEwKpAwjbi)_