### PR TITLE
feat(ai): decompose プロンプトに task_category 推論を統合 (P3-16, #124)

### DIFF
--- a/src/entities/task/decompose-server.test.ts
+++ b/src/entities/task/decompose-server.test.ts
@@ -134,8 +134,8 @@ describe("decomposeTask", () => {
   test("happy path: AI が 2 件返す → 子 insert + 親 decomposed + action_log 記録 (raw_response を含む)", async () => {
     const { client, calls } = makeSupabase(defaultPlan(makeParentRow()));
     const rawResponse = JSON.stringify([
-      { title: "子A", estimated_minutes: 30 },
-      { title: "子B", estimated_minutes: 15 },
+      { title: "子A", estimated_minutes: 30, task_category: "research" },
+      { title: "子B", estimated_minutes: 15, task_category: "doc" },
     ]);
     const generate = vi.fn(async () => rawResponse);
 
@@ -154,11 +154,13 @@ describe("decomposeTask", () => {
       parent_task_id: "parent-1",
       title: "子A",
       estimated_minutes: 30,
+      task_category: "research", // ADR 0022: decompose プロンプトが同時推論
       stack_order: 5, // baseStackOrder = parent.stack_order
       decompose_status: "none",
     });
     expect(inserted[1]).toMatchObject({
       title: "子B",
+      task_category: "doc",
       stack_order: 6, // baseStackOrder + 1
     });
 
@@ -469,6 +471,27 @@ describe("decomposeTask", () => {
     const inserted = calls.insertedTasks[0] as Array<Record<string, unknown>>;
     expect(inserted[0].depends_on_event_id).toBeNull();
     expect(inserted[1].depends_on_event_id).toBeNull();
+  });
+
+  test("task_category が混在 (値域内 / 値域外 / 欠損) → 値域内は採用 / それ以外は null で子は作られる (ADR 0022)", async () => {
+    const { client, calls } = makeSupabase(defaultPlan(makeParentRow()));
+    const generate = vi.fn(async () =>
+      JSON.stringify([
+        { title: "a", estimated_minutes: 15, task_category: "coding" },
+        { title: "b", estimated_minutes: 15, task_category: "general" }, // 値域外
+        { title: "c", estimated_minutes: 15 }, // 欠損
+      ]),
+    );
+
+    const result = await decomposeTask(makeDeps({ client, generate }));
+
+    // category の部分失敗で子の生成自体は止めない (フェイルソフト)
+    expect(result.kind).toBe("decomposed");
+    const inserted = calls.insertedTasks[0] as Array<Record<string, unknown>>;
+    expect(inserted).toHaveLength(3);
+    expect(inserted[0]).toMatchObject({ title: "a", task_category: "coding" });
+    expect(inserted[1]).toMatchObject({ title: "b", task_category: null });
+    expect(inserted[2]).toMatchObject({ title: "c", task_category: null });
   });
 });
 

--- a/src/entities/task/decompose-server.ts
+++ b/src/entities/task/decompose-server.ts
@@ -127,12 +127,15 @@ async function runDecompose(
   }
 
   const baseStackOrder = parent.stack_order ?? 0;
+  // 子の task_category は decompose プロンプトが同時推論する (ADR 0022 Decision 2)。
+  // categorize の fan-out を避けることで 1 親あたりの Gemini 呼び出しを最大 2 回に固定する。
   const childPayloads: TablesInsert<"tasks">[] = parsed.map((child, idx) => ({
     user_id: userId,
     project_id: parent.project_id,
     title: child.title,
     body: "",
     estimated_minutes: child.estimatedMinutes,
+    task_category: child.taskCategory,
     parent_task_id: parent.id,
     depends_on_event_id: parent.depends_on_event_id,
     stack_order: baseStackOrder + idx,

--- a/src/shared/ai/prompts/decompose.test.ts
+++ b/src/shared/ai/prompts/decompose.test.ts
@@ -39,34 +39,51 @@ describe("buildDecomposePrompt", () => {
     // ADR 0016 Notes「子タイトルの自立性」を担保する具体例
     expect(prompt).toContain("親タスクの文脈なしで");
   });
+
+  test("task_category の値域と各項目の定義が prompt に含まれる (ADR 0022)", () => {
+    const prompt = buildDecomposePrompt({
+      title: "x",
+      body: "",
+      estimatedMinutes: null,
+    });
+
+    // 値域 (categorize.ts と同じ集合)
+    expect(prompt).toContain("coding");
+    expect(prompt).toContain("doc");
+    expect(prompt).toContain("research");
+    expect(prompt).toContain("admin");
+    expect(prompt).toContain("other");
+    // 出力例に task_category フィールドが含まれる
+    expect(prompt).toContain('"task_category"');
+  });
 });
 
 describe("parseDecomposeResponse", () => {
-  test("正常な JSON 配列をパースする (estimated_minutes は数値 / null どちらも許容)", () => {
+  test("正常な JSON 配列をパースする (estimated_minutes / task_category とも値域内なら採用)", () => {
     const input = JSON.stringify([
-      { title: "下準備をする", estimated_minutes: 30 },
-      { title: "本作業を進める", estimated_minutes: null },
-      { title: "振り返り", estimated_minutes: 15 },
+      { title: "下準備をする", estimated_minutes: 30, task_category: "research" },
+      { title: "本作業を進める", estimated_minutes: null, task_category: "coding" },
+      { title: "振り返り", estimated_minutes: 15, task_category: "doc" },
     ]);
 
     const result = parseDecomposeResponse(input);
 
     expect(result).toEqual([
-      { title: "下準備をする", estimatedMinutes: 30 },
-      { title: "本作業を進める", estimatedMinutes: null },
-      { title: "振り返り", estimatedMinutes: 15 },
+      { title: "下準備をする", estimatedMinutes: 30, taskCategory: "research" },
+      { title: "本作業を進める", estimatedMinutes: null, taskCategory: "coding" },
+      { title: "振り返り", estimatedMinutes: 15, taskCategory: "doc" },
     ]);
   });
 
   test("markdown fence (```json ... ```) を剥がす", () => {
     const input =
-      '```json\n[{"title":"a","estimated_minutes":15},{"title":"b","estimated_minutes":15}]\n```';
+      '```json\n[{"title":"a","estimated_minutes":15,"task_category":"coding"},{"title":"b","estimated_minutes":15,"task_category":"doc"}]\n```';
 
     const result = parseDecomposeResponse(input);
 
     expect(result).toEqual([
-      { title: "a", estimatedMinutes: 15 },
-      { title: "b", estimatedMinutes: 15 },
+      { title: "a", estimatedMinutes: 15, taskCategory: "coding" },
+      { title: "b", estimatedMinutes: 15, taskCategory: "doc" },
     ]);
   });
 
@@ -76,7 +93,9 @@ describe("parseDecomposeResponse", () => {
   });
 
   test("1 件のみは「実質分解されていない」ので [] (skipped 扱い) に倒す", () => {
-    const input = JSON.stringify([{ title: "ひとつだけ", estimated_minutes: 10 }]);
+    const input = JSON.stringify([
+      { title: "ひとつだけ", estimated_minutes: 10, task_category: "coding" },
+    ]);
 
     const result = parseDecomposeResponse(input);
 
@@ -87,6 +106,7 @@ describe("parseDecomposeResponse", () => {
     const items = Array.from({ length: 12 }, (_, i) => ({
       title: `子${i + 1}`,
       estimated_minutes: 15,
+      task_category: "coding",
     }));
 
     const result = parseDecomposeResponse(JSON.stringify(items));
@@ -99,35 +119,91 @@ describe("parseDecomposeResponse", () => {
   test("title が空 / 80 文字超過のエントリは捨て、残りを採用する", () => {
     const longTitle = "あ".repeat(81);
     const items = [
-      { title: "", estimated_minutes: 15 }, // 空 → 捨てる
-      { title: longTitle, estimated_minutes: 15 }, // 80 文字超過 → 捨てる
-      { title: "ok-1", estimated_minutes: 15 },
-      { title: "ok-2", estimated_minutes: 15 },
+      { title: "", estimated_minutes: 15, task_category: "coding" }, // 空 → 捨てる
+      { title: longTitle, estimated_minutes: 15, task_category: "coding" }, // 80 文字超過 → 捨てる
+      { title: "ok-1", estimated_minutes: 15, task_category: "coding" },
+      { title: "ok-2", estimated_minutes: 15, task_category: "doc" },
     ];
 
     const result = parseDecomposeResponse(JSON.stringify(items));
 
     expect(result).toEqual([
-      { title: "ok-1", estimatedMinutes: 15 },
-      { title: "ok-2", estimatedMinutes: 15 },
+      { title: "ok-1", estimatedMinutes: 15, taskCategory: "coding" },
+      { title: "ok-2", estimatedMinutes: 15, taskCategory: "doc" },
     ]);
   });
 
   test("estimated_minutes が許容バケット外 / 文字列 / 小数 → null に倒す (entry は採用)", () => {
     const items = [
-      { title: "a", estimated_minutes: 7 }, // バケット外
-      { title: "b", estimated_minutes: "30" }, // 文字列
-      { title: "c", estimated_minutes: 15.5 }, // 小数
-      { title: "d", estimated_minutes: 30 }, // 許容
+      { title: "a", estimated_minutes: 7, task_category: "coding" }, // バケット外
+      { title: "b", estimated_minutes: "30", task_category: "coding" }, // 文字列
+      { title: "c", estimated_minutes: 15.5, task_category: "coding" }, // 小数
+      { title: "d", estimated_minutes: 30, task_category: "coding" }, // 許容
     ];
 
     const result = parseDecomposeResponse(JSON.stringify(items));
 
     expect(result).toEqual([
-      { title: "a", estimatedMinutes: null },
-      { title: "b", estimatedMinutes: null },
-      { title: "c", estimatedMinutes: null },
-      { title: "d", estimatedMinutes: 30 },
+      { title: "a", estimatedMinutes: null, taskCategory: "coding" },
+      { title: "b", estimatedMinutes: null, taskCategory: "coding" },
+      { title: "c", estimatedMinutes: null, taskCategory: "coding" },
+      { title: "d", estimatedMinutes: 30, taskCategory: "coding" },
+    ]);
+  });
+
+  test("task_category が値域外 / 欠損 / 型違い → null に倒す (entry は採用、ADR 0022 フェイルソフト)", () => {
+    const items = [
+      { title: "a", estimated_minutes: 15, task_category: "general" }, // 値域外
+      { title: "b", estimated_minutes: 15, task_category: "" }, // 空文字
+      { title: "c", estimated_minutes: 15 }, // 欠損
+      { title: "d", estimated_minutes: 15, task_category: 1 }, // 型違い (数値)
+      { title: "e", estimated_minutes: 15, task_category: null }, // 明示 null
+      { title: "f", estimated_minutes: 15, task_category: "doc" }, // 値域内
+    ];
+
+    const result = parseDecomposeResponse(JSON.stringify(items));
+
+    expect(result).toEqual([
+      { title: "a", estimatedMinutes: 15, taskCategory: null },
+      { title: "b", estimatedMinutes: 15, taskCategory: null },
+      { title: "c", estimatedMinutes: 15, taskCategory: null },
+      { title: "d", estimatedMinutes: 15, taskCategory: null },
+      { title: "e", estimatedMinutes: 15, taskCategory: null },
+      { title: "f", estimatedMinutes: 15, taskCategory: "doc" },
+    ]);
+  });
+
+  test("task_category は大文字 / 前後空白を許容して値域に合わせる (Coding → coding)", () => {
+    const items = [
+      { title: "a", estimated_minutes: 15, task_category: "Coding" },
+      { title: "b", estimated_minutes: 15, task_category: " admin " },
+    ];
+
+    const result = parseDecomposeResponse(JSON.stringify(items));
+
+    expect(result).toEqual([
+      { title: "a", estimatedMinutes: 15, taskCategory: "coding" },
+      { title: "b", estimatedMinutes: 15, taskCategory: "admin" },
+    ]);
+  });
+
+  test("category 値域内すべて (coding/doc/research/admin/other) を受理する", () => {
+    const items = [
+      { title: "a", estimated_minutes: 15, task_category: "coding" },
+      { title: "b", estimated_minutes: 15, task_category: "doc" },
+      { title: "c", estimated_minutes: 15, task_category: "research" },
+      { title: "d", estimated_minutes: 15, task_category: "admin" },
+      { title: "e", estimated_minutes: 15, task_category: "other" },
+    ];
+
+    const result = parseDecomposeResponse(JSON.stringify(items));
+
+    expect(result?.map((c) => c.taskCategory)).toEqual([
+      "coding",
+      "doc",
+      "research",
+      "admin",
+      "other",
     ]);
   });
 

--- a/src/shared/ai/prompts/decompose.ts
+++ b/src/shared/ai/prompts/decompose.ts
@@ -1,16 +1,21 @@
 /**
- * AI タスク分解 (P3-6, ADR 0017 / 0018) の prompt 構築 + 応答パース。
+ * AI タスク分解 (P3-6, ADR 0017 / 0018 / 0022) の prompt 構築 + 応答パース。
  *
  * Gemini 呼び出し境界の外側に純粋関数として置くことで、prompt 文字列の組み立てと
  * 応答 JSON の解釈をユニットテストで踏める形にしている (`/api/ai/decompose` 本体は
  * これをデータパイプとしてつなぐだけ)。
  *
- * 出力契約 (ADR 0016 §1, 0017 Decision 3-5, 0018 Decision):
+ * 出力契約 (ADR 0016 §1, 0017 Decision 3-5, 0018 Decision, 0022 Decision 2):
  * - 「これ以上分解する必要なし」と判定された場合は空配列 → 親は `decompose_status='skipped'` に倒す
  * - 子タイトルは親文脈なしで意味が読める独立した文言 (ADR 0016 Notes 「子タイトルの自立性」)
  * - 子の estimated_minutes は AI が自信を持てない場合 null。親見積もりの機械的等分はしない
  *   (補正後見積もりの責務は P3-9 / architecture.md §1.5)
+ * - 子の task_category も同じ AI 呼び出しで推論する (ADR 0022)。値域外・欠損は null に倒し、
+ *   `other` で握り潰さない (ADR 0013 augmentation only)。category だけの parse 失敗で
+ *   子の生成自体は止めない (title / estimated_minutes が取れていれば子を作る)。
  */
+
+import { TASK_CATEGORY_VALUES, type TaskCategoryValue } from "@/shared/types/database";
 
 export type DecomposeInput = {
   title: string;
@@ -21,6 +26,7 @@ export type DecomposeInput = {
 export type DecomposedChild = {
   title: string;
   estimatedMinutes: number | null;
+  taskCategory: TaskCategoryValue | null;
 };
 
 const MIN_CHILDREN = 2;
@@ -52,6 +58,14 @@ export function buildDecomposePrompt(parent: DecomposeInput): string {
     `- title は ${MAX_TITLE_LEN} 文字以内。装飾的なプレフィックス (Step 1: 等) は付けない。`,
     `- estimated_minutes は ${ALLOWED_ESTIMATE_BUCKETS.join("/")} のいずれかの整数か、自信が無ければ null。`,
     "",
+    "# task_category の値域 (各子タスクの作業種類)",
+    "- coding   : 実装 / バグ修正 / リファクタ / レビュー / セットアップなどコードを書く作業",
+    "- doc      : ドキュメント / 議事録 / 設計メモ / レポート / メール / 連絡文を書く作業",
+    "- research : 調査 / 比較検討 / 学習 / インタビュー / 仕様読解など情報収集の作業",
+    "- admin    : 事務手続き / 経費精算 / 予約 / スケジューリング / 雑務",
+    "- other    : 上記いずれにも当てはまらない作業",
+    "判断に確信が持てない場合は other を返す。",
+    "",
     "# 親タスク",
     `title: ${parent.title}`,
     `body: ${bodyText}`,
@@ -59,7 +73,8 @@ export function buildDecomposePrompt(parent: DecomposeInput): string {
     "",
     "# 出力形式",
     "JSON 配列のみを返す。前後に説明文や markdown fence を付けない。",
-    '例: [{"title":"...","estimated_minutes":30},{"title":"...","estimated_minutes":null}]',
+    "各要素は title / estimated_minutes / task_category の 3 フィールドを持つ。",
+    '例: [{"title":"...","estimated_minutes":30,"task_category":"coding"},{"title":"...","estimated_minutes":null,"task_category":"research"}]',
   ].join("\n");
 }
 
@@ -121,7 +136,10 @@ function normalizeChild(raw: unknown): DecomposedChild | null {
   if (title.length === 0 || title.length > MAX_TITLE_LEN) return null;
 
   const estimate = normalizeEstimate(obj.estimated_minutes);
-  return { title, estimatedMinutes: estimate };
+  // task_category だけの parse 失敗 (値域外 / 型違い / 欠損) では子の生成自体を止めない。
+  // null で埋めて子は作る (ADR 0022 §否定的影響: フェイルソフト)。
+  const taskCategory = normalizeCategory(obj.task_category);
+  return { title, estimatedMinutes: estimate, taskCategory };
 }
 
 function normalizeEstimate(raw: unknown): number | null {
@@ -132,4 +150,18 @@ function normalizeEstimate(raw: unknown): number | null {
     return null;
   }
   return raw;
+}
+
+/**
+ * task_category の値域 ガード。
+ *
+ * - 値域内 (`coding` / `doc` / `research` / `admin` / `other`) → そのまま採用
+ * - 値域外 / 型違い / 欠損 → null (`other` で握り潰さない: AI が判定不能だったケースと
+ *   AI が `other` と判定したケースを区別するため。ADR 0015 Notes / ADR 0022 §動機)
+ */
+function normalizeCategory(raw: unknown): TaskCategoryValue | null {
+  if (typeof raw !== "string") return null;
+  const cleaned = raw.trim().toLowerCase();
+  const found = TASK_CATEGORY_VALUES.find((v) => v === cleaned);
+  return found ?? null;
 }


### PR DESCRIPTION
## 概要 (What)

ADR 0022 (`task_category` は task 生成経路ごとに同じ AI 呼び出しで推論する) の AI 分解経路を実装。decompose プロンプトに category 推論を畳み込み、子レコード生成と同時に `task_category` を埋める。

## 関連 Issue

Closes #124

## 背景 (Why)

PR #123 (P3-4) で root task 経路の categorize は実装済みだったが、AI 分解で生まれた子タスクの category は空白のままだった (`decompose-server.ts` の bulk insert は `onCreateTask` 経路を通らないので categorize が飛ばない)。

子それぞれに `/api/ai/categorize` を fan-out すると 1 親で `1 + 1 + N` 回の Gemini 呼び出しになり quota / コスト / latency が線形にスケールしてしまう。ADR 0022 で「decompose プロンプトと同じ呼び出しで子の category も推論する」方針を確定させ、本 PR でその実装を入れた。

これにより Stack に並ぶ leaf (= root + 分解された子) の両方に category が乗り、補正エンジン (P3-9) / 行動パターン分析 (Phase 4) の入力カバレッジに穴ができない。

参照: [ADR 0022](../blob/main/docs/adr/0022-task-category-labeling-per-generation-path.md) / [ADR 0013](../blob/main/docs/adr/0013-ai-as-augmentation-only.md) / [ADR 0015](../blob/main/docs/adr/0015-task-category-ai-first-labeling.md)

## Before → After (概念・フロー・メンタルモデル)

**Before:**
- 1 親 task 追加 = `1 (categorize) + 1 (decompose) + N (子の categorize 想定)` 回の Gemini 呼び出しが見込まれる構造
- 実際には子の categorize が未配線なので、AI 分解された子の `task_category` は **常に null** で残る
- 補正エンジン (P3-9) / 行動パターン分析 (Phase 4) が分解された親由来の子の作業時間を集計に乗せられない

**After:**
- 1 親 task 追加 = 最大 **2 回** (categorize + decompose) 固定。子数 N に依存しない
- decompose プロンプト 1 回で title / estimated_minutes / task_category を同時生成
- AI 応答で category だけが値域外・欠損だった子は `task_category=null` で insert (子の生成自体は止めない / フェイルソフト)
- Stack に並びうる全 leaf (root + 分解子) に category が乗りうる状態

## 追加したテスト (How verified)

- [x] `decompose.ts` ユニット: prompt に値域 (`coding/doc/research/admin/other`) と各定義が含まれる
- [x] `decompose.ts` ユニット: 値域内全 5 値の受理 / 値域外 / 欠損 / 型違い / 大文字・前後空白の正規化
- [x] `decompose.ts` ユニット: category だけ値域外でも entry は採用 (title / estimated_minutes が取れていれば子は作る)
- [x] `decompose-server.test.ts`: happy path で `task_category: "research"` / `"doc"` が bulk insert payload に乗る
- [x] `decompose-server.test.ts`: 値域内 + 値域外 + 欠損が混在する応答で 3 件すべて子として insert され、それぞれ category / null が正しく振り分けられる
- [x] `npm run typecheck` / `npm run lint` / `npm run format:check` / `npm test` すべて pass (381 tests)

dev で `AI_ENABLED=true` のときの手動確認は別途実機で実施想定 (環境上 PR で踏めない)。

## リリース前チェックリスト (When / Before merge)

- マイグレーション: 不要 (`task_category` 列は P3-2 で追加済)
- 環境変数: 不要 (既存の `AI_ENABLED` / `GEMINI_API_KEY` のみ)
- フィーチャーフラグ: 不要 (`AI_ENABLED=false` で従来どおり子は生まれない / category も埋まらない)
- ドキュメント: 不要 (ADR 0022 が本 PR の根拠として既に accepted)
- 破壊的変更: なし。既存の AI 失敗時の挙動 (親が `failed` に倒れる、子が生まれない) は維持

## このPRの範囲外 (Out of scope)

- 既存タスクの category backfill (Phase 1〜2 で作られた null タスク。ADR 0015 Notes / ADR 0022 Notes で別 issue 扱い)
- 分解された親 (`decompose_status='decomposed'`) の category を集計から除外する処理 (#95 P3-10 の集計ヘルパで扱う)
- override UI (#90 P3-5)
- 値域 (`coding`/`doc`/`research`/`admin`/`other`) の追加・改訂

https://claude.ai/code/session_0135E3wyRVGXinbKjeSeLMpZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0135E3wyRVGXinbKjeSeLMpZ)_