### PR TITLE
feat(task-detail): task_category override UI + 行動ログ (P3-5)

### DIFF
--- a/e2e/db.ts
+++ b/e2e/db.ts
@@ -133,6 +133,7 @@ export type TaskRow = {
   status: "idle" | "active" | "paused" | "done";
   stack_order: number | null;
   depends_on_event_id: string | null;
+  task_category: "coding" | "doc" | "research" | "admin" | "other" | null;
   completed_at: string | null;
 };
 

--- a/e2e/dependency-event.spec.ts
+++ b/e2e/dependency-event.spec.ts
@@ -95,8 +95,9 @@ test.describe("依存イベント設定 (TaskDetailPanel → DB → バッジ)",
     // --- 依存をクリアして task_dependency_cleared が記録される -------------
     // 依存設定後はボタン文言が "<relative> <title> を変更" になる。
     // 文言の relative-time 部分 (例: "5/14" / "3年後" など) に依存しないよう
-    // suffix `を変更` で取る。
-    await page.getByRole("button", { name: /を変更$/ }).click();
+    // event title を含めて識別する (詳細パネル内のタスク種類「未分類 を変更」とも
+    // 衝突しないように suffix だけでなく title を含める)。
+    await page.getByRole("button", { name: new RegExp(`${eventTitle}\\s*を変更$`) }).click();
     await page.locator("select").first().selectOption({ value: "" });
 
     await expect

--- a/e2e/task-category-override.spec.ts
+++ b/e2e/task-category-override.spec.ts
@@ -62,10 +62,11 @@ test.describe("task_category override (TaskDetailPanel → DB → action_log)", 
     // (dependency-event.spec.ts と同じパターン)。
     await row.getByText(taskTitle).first().click();
 
-    // <label> wrap の semantic 構造で取る (kozutsumi-frontend-a11y skill 2.3)。
-    const select = page.getByLabel("タスク種類");
-    await expect(select).toBeVisible();
-    await select.selectOption({ value: "doc" });
+    // 依存イベントと同じ「ボタン → select」パターン。デフォルトは「未分類 を変更」。
+    // 依存編集の「なし を変更」と substring で衝突しないので role + name で取れる。
+    await page.getByRole("button", { name: /未分類\s+を変更/ }).click();
+    // editingCategory=true で <select autoFocus> が render される。
+    await page.locator("select").first().selectOption({ value: "doc" });
 
     // --- DB: tasks.task_category 更新 --------------------------------------
     await expect
@@ -111,8 +112,9 @@ test.describe("task_category override (TaskDetailPanel → DB → action_log)", 
     const row = stack.getByRole("listitem").filter({ hasText: taskTitle });
     await row.getByText(taskTitle).first().click();
 
-    const select = page.getByLabel("タスク種類");
-    await select.selectOption({ value: "research" });
+    // 1 回目の override: 未分類 → research
+    await page.getByRole("button", { name: /未分類\s+を変更/ }).click();
+    await page.locator("select").first().selectOption({ value: "research" });
 
     const created = await getTaskByTitle(admin, userId, taskTitle);
     await expect
@@ -121,8 +123,9 @@ test.describe("task_category override (TaskDetailPanel → DB → action_log)", 
       })
       .toBe("research");
 
-    // 同じ値を再選択 (no-op) — onChange は発火しないはずなので追加 log は無い
-    await select.selectOption({ value: "research" });
+    // 2 回目: ボタン文言は「調査 を変更」になっているはず。同じ値で確定 (no-op)
+    await page.getByRole("button", { name: /調査\s+を変更/ }).click();
+    await page.locator("select").first().selectOption({ value: "research" });
 
     // 少し待って action_logs を取得
     await page.waitForTimeout(500);

--- a/e2e/task-category-override.spec.ts
+++ b/e2e/task-category-override.spec.ts
@@ -1,0 +1,137 @@
+import { createAdminClient, getTaskByTitle, waitForActionLog } from "./db";
+import { expect, test } from "./fixtures";
+
+/**
+ * P3-5 (#90) / ADR 0015:
+ *   タスク詳細パネルからの `task_category` override の DB / action_log 整合。
+ *
+ * `task_category` は Phase 3 / 4 の見積もり補正・行動パターン分析の入力軸で、
+ * 「人間が AI 初期ラベルを訂正した」操作自体が暗黙的フィードバックとして
+ * Phase 4 のラベリング精度改善ループに流れる (ADR 0015 / ADR 0001 延長)。
+ *
+ * 不変条件:
+ * - AddPanel には category 入力が出ない (vision §1.7「承認ステップは挟まない」)
+ * - 詳細パネル (`<select>` "タスク種類") から override すると
+ *   - tasks.task_category が更新される
+ *   - action_logs に `task_category_changed` が `{ from, to }` で記録される
+ */
+test.describe("task_category override (TaskDetailPanel → DB → action_log)", () => {
+  test("AddPanel のタスクタブには category 入力が出ない (ADR 0015 暗黙的フィードバック原則)", async ({
+    signedInPageWithProject: page,
+  }) => {
+    await page.getByRole("button", { name: "新規追加" }).click();
+    const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+    await addDialog.getByRole("tab", { name: "タスク" }).click();
+
+    // タイトル / プロジェクト / 見積もり / 依存イベント等は出るが、タスク種類はここに置かない。
+    // category を AddPanel から消しているのが ADR 0015 の核 (人間に「分類を選べ」という
+    // 明示プロンプトを出さない / AI 初期ラベル + override で済ませる) なので、
+    // ここに category 入力が紛れたら設計が崩れている = 落とす。
+    await expect(addDialog.getByLabel(/タスク種類|分類|カテゴリ/)).toHaveCount(0);
+  });
+
+  test("詳細パネルから category を override → tasks.task_category と task_category_changed が一致する", async ({
+    signedInPageWithProject: page,
+    projectName,
+    testUserId: userId,
+  }) => {
+    const taskTitle = "category override 対象";
+
+    const admin = createAdminClient();
+
+    // --- タスクを 1 件追加 -------------------------------------------------
+    await page.getByRole("button", { name: "新規追加" }).click();
+    const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+    await addDialog.getByRole("tab", { name: "タスク" }).click();
+    await addDialog.getByLabel("タイトル").fill(taskTitle);
+    await addDialog.getByLabel("プロジェクト").selectOption({ label: projectName });
+    await addDialog.getByRole("button", { name: "追加" }).click();
+    await expect(addDialog).toHaveCount(0);
+
+    const stack = page.getByRole("list", { name: "タスクスタック" });
+    const row = stack.getByRole("listitem").filter({ hasText: taskTitle });
+    await expect(row).toBeVisible();
+
+    // 初期状態: AI 経路は AI_ENABLED=false でバイパスされる (ADR 0014) ので
+    // task_category は null のまま。これが「override の `from`」になる。
+    const created = await getTaskByTitle(admin, userId, taskTitle);
+    expect(created.task_category).toBeNull();
+
+    // --- 詳細パネルを開いて category を override ---------------------------
+    // タイトル文字を狙うと TopTaskCard onClick で詳細パネルに遷移する
+    // (dependency-event.spec.ts と同じパターン)。
+    await row.getByText(taskTitle).first().click();
+
+    // <label> wrap の semantic 構造で取る (kozutsumi-frontend-a11y skill 2.3)。
+    const select = page.getByLabel("タスク種類");
+    await expect(select).toBeVisible();
+    await select.selectOption({ value: "doc" });
+
+    // --- DB: tasks.task_category 更新 --------------------------------------
+    await expect
+      .poll(async () => (await getTaskByTitle(admin, userId, taskTitle)).task_category, {
+        message: "tasks.task_category should equal the overridden value",
+        timeout: 5_000,
+      })
+      .toBe("doc");
+
+    // --- action_log: task_category_changed --------------------------------
+    const log = await waitForActionLog(
+      admin,
+      userId,
+      (l) =>
+        l.action_type === "task_category_changed" &&
+        (l.metadata as { task_id?: string }).task_id === created.id,
+      { description: "task_category_changed log" },
+    );
+    // from は AI 失敗 / 既存タスクで null になり得る (ADR 0015)。
+    // 本ケースは AI_ENABLED=false で null から override したので from=null。
+    expect((log.metadata as { from?: string | null }).from).toBeNull();
+    expect((log.metadata as { to?: string }).to).toBe("doc");
+  });
+
+  test("override → 同じ値で再選択しても重複ログを出さない", async ({
+    signedInPageWithProject: page,
+    projectName,
+    testUserId: userId,
+  }) => {
+    const taskTitle = "category 同値再選択";
+
+    const admin = createAdminClient();
+
+    await page.getByRole("button", { name: "新規追加" }).click();
+    const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+    await addDialog.getByRole("tab", { name: "タスク" }).click();
+    await addDialog.getByLabel("タイトル").fill(taskTitle);
+    await addDialog.getByLabel("プロジェクト").selectOption({ label: projectName });
+    await addDialog.getByRole("button", { name: "追加" }).click();
+    await expect(addDialog).toHaveCount(0);
+
+    const stack = page.getByRole("list", { name: "タスクスタック" });
+    const row = stack.getByRole("listitem").filter({ hasText: taskTitle });
+    await row.getByText(taskTitle).first().click();
+
+    const select = page.getByLabel("タスク種類");
+    await select.selectOption({ value: "research" });
+
+    const created = await getTaskByTitle(admin, userId, taskTitle);
+    await expect
+      .poll(async () => (await getTaskByTitle(admin, userId, taskTitle)).task_category, {
+        timeout: 5_000,
+      })
+      .toBe("research");
+
+    // 同じ値を再選択 (no-op) — onChange は発火しないはずなので追加 log は無い
+    await select.selectOption({ value: "research" });
+
+    // 少し待って action_logs を取得
+    await page.waitForTimeout(500);
+    const { data } = await admin
+      .from("action_logs")
+      .select("*")
+      .eq("user_id", userId)
+      .eq("action_type", "task_category_changed")
+      .eq("task_id", created.id);
+    expect(data?.length).toBe(1);
+  });
+});

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -11,7 +11,7 @@ import type { CreateProjectInput, UpdateProjectInput } from "@/entities/project/
 import { ProjectsProvider } from "@/entities/project/ProjectsContext";
 import type { Project } from "@/entities/project/types";
 import type { CreateTaskInput } from "@/entities/task/gateway";
-import type { Task } from "@/entities/task/types";
+import type { Task, TaskCategory } from "@/entities/task/types";
 import { AddButton } from "@/features/add-forms/AddButton";
 import { AddPanel } from "@/features/add-forms/AddPanel";
 import { DayTimeline } from "@/features/day-timeline/DayTimeline";
@@ -247,6 +247,41 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
       }
       queryClient.setQueryData<Task[]>(keys.tasks, (prev) =>
         (prev ?? []).map((t) => (t.id === id ? { ...t, dependsOnEventId } : t)),
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(keys.tasks, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: keys.tasks });
+    },
+  });
+
+  // P3-5 (#90) / ADR 0015: 詳細パネルからの task_category override。
+  // AddPanel には出さず、AI 初期ラベル → 人間 override のフローで暗黙的フィードバック
+  // (task_category_changed) を残す。Phase 4 のラベリング精度改善ループの入力源。
+  const updateCategoryMutation = useMutation({
+    mutationFn: ({ id, taskCategory }: { id: string; taskCategory: TaskCategory | null }) =>
+      taskGateway.update(id, { taskCategory }),
+    onMutate: async ({ id, taskCategory }) => {
+      await queryClient.cancelQueries({ queryKey: keys.tasks });
+      const previous = queryClient.getQueryData<Task[]>(keys.tasks);
+      const target = previous?.find((t) => t.id === id);
+      const from = target?.taskCategory ?? null;
+      // override 時のみ log。next === null (= 「未分類」へ戻す) は ADR 0015 の
+      // metadata.to: string と矛盾するので log を抑制する (DB は更新する)。
+      // Phase 4 のラベリング精度分析は「人間が AI ラベルを別の値で上書きした」事象を
+      // 拾えれば十分なので、null に戻す操作の追跡は今は持たない。
+      if (from !== taskCategory && taskCategory !== null) {
+        log(ACTION_TYPES.TASK_CATEGORY_CHANGED, {
+          task_id: id,
+          from,
+          to: taskCategory,
+        });
+      }
+      queryClient.setQueryData<Task[]>(keys.tasks, (prev) =>
+        (prev ?? []).map((t) => (t.id === id ? { ...t, taskCategory } : t)),
       );
       return { previous };
     },
@@ -615,6 +650,9 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
             onDelete={(id) => deleteTaskMutation.mutate(id)}
             onChangeDependency={(id, dependsOnEventId) =>
               updateDependencyMutation.mutate({ id, dependsOnEventId })
+            }
+            onChangeCategory={(id, taskCategory) =>
+              updateCategoryMutation.mutate({ id, taskCategory })
             }
             aiEnabled={aiEnabled}
             latestDecomposeLog={decomposeLogQuery.data ?? null}

--- a/src/features/task-detail/TaskDetailPanel.test.tsx
+++ b/src/features/task-detail/TaskDetailPanel.test.tsx
@@ -296,66 +296,92 @@ describe("TaskDetailPanel", () => {
 // ADR 0015 / #90: タスク種類 override UI。AI 初期ラベルに対する人間の override で、
 // 暗黙フィードバック (task_category_changed) の起点となる。logging 自体は呼び出し側
 // (AppShell) の責務なので、ここではコールバックの引数だけを担保する。
+//
+// 体験は依存イベントと揃える: 通常はボタンに現在値 + 「を変更」、押すと <select> に
+// 切り替わり、選ぶと閉じる (onBlur でも閉じる)。
 describe("TaskDetailPanel - task_category override (P3-5)", () => {
   test("onChangeCategory 未指定なら category 編集 UI を出さない (旧呼び出し互換)", () => {
-    const { queryByLabelText } = renderPanel();
-    expect(queryByLabelText("タスク種類")).toBeNull();
+    const { queryByText } = renderPanel();
+    expect(queryByText("タスク種類")).toBeNull();
+    expect(queryByText(/未分類\s+を変更/)).toBeNull();
   });
 
-  test("onChangeCategory 指定時はラベル付き select が出る (a11y: getByLabelText で取れる)", () => {
-    const { getByLabelText } = renderPanel({ onChangeCategory: vi.fn() });
-    const select = getByLabelText("タスク種類") as HTMLSelectElement;
-    expect(select.tagName.toLowerCase()).toBe("select");
+  test("onChangeCategory 指定時、デフォルトは「<現在値> を変更」ボタン", () => {
+    const { getByText, queryByRole } = renderPanel({ onChangeCategory: vi.fn() });
+    expect(getByText(/未分類\s+を変更/)).toBeTruthy();
+    expect(queryByRole("combobox")).toBeNull();
   });
 
-  test("taskCategory=null の場合は select の現在値が「未分類」", () => {
-    const { getByLabelText } = renderPanel({ onChangeCategory: vi.fn() });
-    const select = getByLabelText("タスク種類") as HTMLSelectElement;
-    expect(select.value).toBe("");
-  });
-
-  test("AI 初期ラベルが既にある場合は select がその値を反映する", () => {
-    const { getByLabelText } = renderPanel({
+  test("AI 初期ラベルがある場合はボタン文言にその表示ラベルが入る", () => {
+    const { getByText } = renderPanel({
       task: { ...baseTask, taskCategory: "coding" },
       onChangeCategory: vi.fn(),
     });
-    const select = getByLabelText("タスク種類") as HTMLSelectElement;
+    expect(getByText(/コーディング\s+を変更/)).toBeTruthy();
+  });
+
+  test("ボタン押下で <select> に切り替わり、現在値が反映されている", () => {
+    const { getByText, getByRole } = renderPanel({
+      task: { ...baseTask, taskCategory: "coding" },
+      onChangeCategory: vi.fn(),
+    });
+    fireEvent.click(getByText(/コーディング\s+を変更/));
+    const select = getByRole("combobox") as HTMLSelectElement;
     expect(select.value).toBe("coding");
   });
 
-  test("値変更で onChangeCategory(taskId, value) を呼ぶ (override)", () => {
+  test("値変更で onChangeCategory(taskId, value) を呼び、編集モードを抜ける", () => {
     const onChangeCategory = vi.fn();
-    const { getByLabelText } = renderPanel({
+    const { getByText, getByRole, queryByRole } = renderPanel({
       task: { ...baseTask, taskCategory: "coding" },
       onChangeCategory,
     });
-    fireEvent.change(getByLabelText("タスク種類"), { target: { value: "doc" } });
+    fireEvent.click(getByText(/コーディング\s+を変更/));
+    fireEvent.change(getByRole("combobox"), { target: { value: "doc" } });
     expect(onChangeCategory).toHaveBeenCalledWith("t1", "doc");
+    // 編集モード解除 (再びボタンに戻る)
+    expect(queryByRole("combobox")).toBeNull();
   });
 
   test("「未分類」(空文字) を選ぶと onChangeCategory(taskId, null) を呼ぶ", () => {
     const onChangeCategory = vi.fn();
-    const { getByLabelText } = renderPanel({
+    const { getByText, getByRole } = renderPanel({
       task: { ...baseTask, taskCategory: "coding" },
       onChangeCategory,
     });
-    fireEvent.change(getByLabelText("タスク種類"), { target: { value: "" } });
+    fireEvent.click(getByText(/コーディング\s+を変更/));
+    fireEvent.change(getByRole("combobox"), { target: { value: "" } });
     expect(onChangeCategory).toHaveBeenCalledWith("t1", null);
   });
 
-  test("同じ値が選ばれた場合は onChangeCategory を呼ばない (no-op)", () => {
+  test("同じ値が選ばれた場合は onChangeCategory を呼ばないが編集モードは抜ける", () => {
     const onChangeCategory = vi.fn();
-    const { getByLabelText } = renderPanel({
+    const { getByText, getByRole, queryByRole } = renderPanel({
       task: { ...baseTask, taskCategory: "coding" },
       onChangeCategory,
     });
-    fireEvent.change(getByLabelText("タスク種類"), { target: { value: "coding" } });
+    fireEvent.click(getByText(/コーディング\s+を変更/));
+    fireEvent.change(getByRole("combobox"), { target: { value: "coding" } });
     expect(onChangeCategory).not.toHaveBeenCalled();
+    expect(queryByRole("combobox")).toBeNull();
+  });
+
+  test("blur で編集モードを抜ける (selecter 確定せずに閉じる)", () => {
+    const onChangeCategory = vi.fn();
+    const { getByText, getByRole, queryByRole } = renderPanel({
+      task: { ...baseTask, taskCategory: "coding" },
+      onChangeCategory,
+    });
+    fireEvent.click(getByText(/コーディング\s+を変更/));
+    fireEvent.blur(getByRole("combobox"));
+    expect(onChangeCategory).not.toHaveBeenCalled();
+    expect(queryByRole("combobox")).toBeNull();
   });
 
   test("値域が UI に揃っている (coding / doc / research / admin / other + 未分類)", () => {
-    const { getByLabelText } = renderPanel({ onChangeCategory: vi.fn() });
-    const select = getByLabelText("タスク種類") as HTMLSelectElement;
+    const { getByText, getByRole } = renderPanel({ onChangeCategory: vi.fn() });
+    fireEvent.click(getByText(/未分類\s+を変更/));
+    const select = getByRole("combobox") as HTMLSelectElement;
     const values = Array.from(select.options).map((o) => o.value);
     expect(values).toEqual(["", "coding", "doc", "research", "admin", "other"]);
   });

--- a/src/features/task-detail/TaskDetailPanel.test.tsx
+++ b/src/features/task-detail/TaskDetailPanel.test.tsx
@@ -293,6 +293,74 @@ describe("TaskDetailPanel", () => {
   });
 });
 
+// ADR 0015 / #90: タスク種類 override UI。AI 初期ラベルに対する人間の override で、
+// 暗黙フィードバック (task_category_changed) の起点となる。logging 自体は呼び出し側
+// (AppShell) の責務なので、ここではコールバックの引数だけを担保する。
+describe("TaskDetailPanel - task_category override (P3-5)", () => {
+  test("onChangeCategory 未指定なら category 編集 UI を出さない (旧呼び出し互換)", () => {
+    const { queryByLabelText } = renderPanel();
+    expect(queryByLabelText("タスク種類")).toBeNull();
+  });
+
+  test("onChangeCategory 指定時はラベル付き select が出る (a11y: getByLabelText で取れる)", () => {
+    const { getByLabelText } = renderPanel({ onChangeCategory: vi.fn() });
+    const select = getByLabelText("タスク種類") as HTMLSelectElement;
+    expect(select.tagName.toLowerCase()).toBe("select");
+  });
+
+  test("taskCategory=null の場合は select の現在値が「未分類」", () => {
+    const { getByLabelText } = renderPanel({ onChangeCategory: vi.fn() });
+    const select = getByLabelText("タスク種類") as HTMLSelectElement;
+    expect(select.value).toBe("");
+  });
+
+  test("AI 初期ラベルが既にある場合は select がその値を反映する", () => {
+    const { getByLabelText } = renderPanel({
+      task: { ...baseTask, taskCategory: "coding" },
+      onChangeCategory: vi.fn(),
+    });
+    const select = getByLabelText("タスク種類") as HTMLSelectElement;
+    expect(select.value).toBe("coding");
+  });
+
+  test("値変更で onChangeCategory(taskId, value) を呼ぶ (override)", () => {
+    const onChangeCategory = vi.fn();
+    const { getByLabelText } = renderPanel({
+      task: { ...baseTask, taskCategory: "coding" },
+      onChangeCategory,
+    });
+    fireEvent.change(getByLabelText("タスク種類"), { target: { value: "doc" } });
+    expect(onChangeCategory).toHaveBeenCalledWith("t1", "doc");
+  });
+
+  test("「未分類」(空文字) を選ぶと onChangeCategory(taskId, null) を呼ぶ", () => {
+    const onChangeCategory = vi.fn();
+    const { getByLabelText } = renderPanel({
+      task: { ...baseTask, taskCategory: "coding" },
+      onChangeCategory,
+    });
+    fireEvent.change(getByLabelText("タスク種類"), { target: { value: "" } });
+    expect(onChangeCategory).toHaveBeenCalledWith("t1", null);
+  });
+
+  test("同じ値が選ばれた場合は onChangeCategory を呼ばない (no-op)", () => {
+    const onChangeCategory = vi.fn();
+    const { getByLabelText } = renderPanel({
+      task: { ...baseTask, taskCategory: "coding" },
+      onChangeCategory,
+    });
+    fireEvent.change(getByLabelText("タスク種類"), { target: { value: "coding" } });
+    expect(onChangeCategory).not.toHaveBeenCalled();
+  });
+
+  test("値域が UI に揃っている (coding / doc / research / admin / other + 未分類)", () => {
+    const { getByLabelText } = renderPanel({ onChangeCategory: vi.fn() });
+    const select = getByLabelText("タスク種類") as HTMLSelectElement;
+    const values = Array.from(select.options).map((o) => o.value);
+    expect(values).toEqual(["", "coding", "doc", "research", "admin", "other"]);
+  });
+});
+
 // AI 分解情報エリア (P3-15 / ADR 0021 §3)。
 // 親が `latestDecomposeLog` か `onTriggerDecompose` を渡したときだけセクションが描画される。
 describe("TaskDetailPanel - AI 分解情報エリア (P3-15)", () => {

--- a/src/features/task-detail/TaskDetailPanel.tsx
+++ b/src/features/task-detail/TaskDetailPanel.tsx
@@ -4,10 +4,11 @@ import type { DecomposeFailReason } from "../../entities/action-log/types";
 import type { Event } from "../../entities/event/types";
 import { getProject } from "../../entities/project/projects";
 import { useProjects } from "../../entities/project/ProjectsContext";
-import type { Task } from "../../entities/task/types";
+import type { Task, TaskCategory } from "../../entities/task/types";
 import { renderMarkdown } from "../../shared/lib/markdown";
 import { isDone } from "../../shared/lib/task";
 import { fmtDuration, formatRelativeTime } from "../../shared/lib/time";
+import { TASK_CATEGORY_VALUES } from "../../shared/types/database";
 
 export type TaskDetailPanelProps = {
   task: Task;
@@ -23,6 +24,13 @@ export type TaskDetailPanelProps = {
    * 未指定なら依存編集 UI も表示しない (テストや特殊呼び出しで省略可)。
    */
   onChangeDependency?: (id: string, eventId: string | null) => void;
+  /**
+   * `tasks.task_category` の override (ADR 0015 / #90)。AI 初期ラベルに対する
+   * 人間の override で、暗黙的フィードバックとして `task_category_changed`
+   * action_log に残る (logging は呼び出し側 = AppShell の責務)。
+   * 未指定なら category 編集 UI を出さない (旧呼び出し / テスト互換)。
+   */
+  onChangeCategory?: (id: string, category: TaskCategory | null) => void;
   /**
    * AI 分解の最新試行ログ (`task_decomposed` / `task_decompose_failed` /
    * `task_decompose_skipped` の最新 1 件)。なければ null。
@@ -46,6 +54,7 @@ export function TaskDetailPanel({
   onToggleDone,
   onDelete,
   onChangeDependency,
+  onChangeCategory,
   latestDecomposeLog,
   isDecomposeLogLoading,
   aiEnabled = true,
@@ -164,6 +173,31 @@ export function TaskDetailPanel({
                 </button>
               )}
             </div>
+          </div>
+        )}
+
+        {onChangeCategory && (
+          <div className="px-5 pb-2">
+            <label className="flex items-center gap-2">
+              <span className="font-jp text-[10px] text-fg-weak">タスク種類</span>
+              <select
+                value={task.taskCategory ?? ""}
+                onChange={(e) => {
+                  const raw = e.target.value;
+                  const next = raw === "" ? null : (raw as TaskCategory);
+                  if (next === (task.taskCategory ?? null)) return;
+                  onChangeCategory(task.id, next);
+                }}
+                className="flex-1 rounded border border-bg-divider bg-bg-elevated px-2 py-1 text-[11px] text-fg-default outline-none focus:border-accent-blue"
+              >
+                <option value="">未分類</option>
+                {TASK_CATEGORY_VALUES.map((value) => (
+                  <option key={value} value={value}>
+                    {TASK_CATEGORY_LABELS[value]}
+                  </option>
+                ))}
+              </select>
+            </label>
           </div>
         )}
 
@@ -393,6 +427,16 @@ function rawResponseFromLog(log: LatestDecomposeLog): string | null {
   // task_decompose_failed: raw_response は generate が応答を返した後に失敗した場合のみ存在
   return log.metadata.raw_response ?? null;
 }
+
+// ADR 0015 / #90: タスク種類 override の表示ラベル。値域 (TASK_CATEGORY_VALUES) は
+// DB の CHECK と single source of truth で揃え、ここでは表示用の和訳のみ持つ。
+const TASK_CATEGORY_LABELS: Record<TaskCategory, string> = {
+  coding: "コーディング",
+  doc: "ドキュメント",
+  research: "調査",
+  admin: "事務",
+  other: "その他",
+};
 
 const FAIL_REASON_MESSAGES: Record<DecomposeFailReason, string> = {
   quota_exhausted: "AI のクォータ上限に達しました。時間をおいて再実行してください",

--- a/src/features/task-detail/TaskDetailPanel.tsx
+++ b/src/features/task-detail/TaskDetailPanel.tsx
@@ -64,6 +64,7 @@ export function TaskDetailPanel({
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(task.body || "");
   const [editingDep, setEditingDep] = useState(false);
+  const [editingCategory, setEditingCategory] = useState(false);
   // パネル open 時刻を「今」として固定する。パネル中に分跨ぎしても候補や相対時刻が
   // ばたつかないようにするのが目的 (相対時刻はあくまで判断補助)。
   const [openedAt] = useState<number>(() => now ?? Date.now());
@@ -178,26 +179,40 @@ export function TaskDetailPanel({
 
         {onChangeCategory && (
           <div className="px-5 pb-2">
-            <label className="flex items-center gap-2">
+            <div className="flex items-center gap-2">
               <span className="font-jp text-[10px] text-fg-weak">タスク種類</span>
-              <select
-                value={task.taskCategory ?? ""}
-                onChange={(e) => {
-                  const raw = e.target.value;
-                  const next = raw === "" ? null : (raw as TaskCategory);
-                  if (next === (task.taskCategory ?? null)) return;
-                  onChangeCategory(task.id, next);
-                }}
-                className="flex-1 rounded border border-bg-divider bg-bg-elevated px-2 py-1 text-[11px] text-fg-default outline-none focus:border-accent-blue"
-              >
-                <option value="">未分類</option>
-                {TASK_CATEGORY_VALUES.map((value) => (
-                  <option key={value} value={value}>
-                    {TASK_CATEGORY_LABELS[value]}
-                  </option>
-                ))}
-              </select>
-            </label>
+              {editingCategory ? (
+                <select
+                  autoFocus
+                  value={task.taskCategory ?? ""}
+                  onChange={(e) => {
+                    const raw = e.target.value;
+                    const next = raw === "" ? null : (raw as TaskCategory);
+                    if (next !== (task.taskCategory ?? null)) {
+                      onChangeCategory(task.id, next);
+                    }
+                    setEditingCategory(false);
+                  }}
+                  onBlur={() => setEditingCategory(false)}
+                  className="flex-1 rounded border border-bg-divider bg-bg-elevated px-2 py-1 text-[11px] text-fg-default outline-none focus:border-accent-blue"
+                >
+                  <option value="">未分類</option>
+                  {TASK_CATEGORY_VALUES.map((value) => (
+                    <option key={value} value={value}>
+                      {TASK_CATEGORY_LABELS[value]}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setEditingCategory(true)}
+                  className="cursor-pointer rounded-[4px] border border-bg-divider bg-transparent px-2 py-[3px] font-jp text-[10px] text-fg-subtle"
+                >
+                  {task.taskCategory ? TASK_CATEGORY_LABELS[task.taskCategory] : "未分類"} を変更
+                </button>
+              )}
+            </div>
           </div>
         )}
 


### PR DESCRIPTION
## 概要 (What)

タスク詳細パネルに `task_category` の override UI を追加し、変更操作を `task_category_changed` action_log に記録する。AddPanel には category 入力を出さない。

## 関連 Issue

Closes #90

## 背景 (Why)

[ADR 0015](../blob/main/docs/adr/0015-task-category-ai-first-labeling.md) で「人間は override のみ / AddPanel には出さない / override は action_log に残す」と決めた方針の UI 実装。AI が初期ラベルを付け、人間が違和感を持ったときだけ override する暗黙的フィードバック動線が、Phase 4 のラベリング精度改善ループの入力源になる ([ADR 0001](../blob/main/docs/adr/0001-action-logs-from-phase1.md) 延長)。

## Before → After (概念・フロー・メンタルモデル)

**Before:** AI が `task_category` を付けても (P3-4)、人間は値を見ることも訂正することもできなかった。Phase 4 のラベリング精度改善ループに「人間が訂正した」事象が入ってこない。

**After:** 詳細パネルを開けば現在の category が select の現在値として見え、違和感があればその場で訂正できる。訂正操作は `task_category_changed` として action_log に流れ、Phase 4 の暗黙フィードバック分析の入力になる。AddPanel には category 入力を出さないので、タスク追加時に分類で迷わせない (vision §1.7 / ADR 0015 の核)。

## 追加したテスト (How verified)

- [x] **unit** (`TaskDetailPanel.test.tsx`): UI 非表示 / 値域 / select 値反映 / 変更時コールバック / 同値時 no-op / null 戻し の 7 ケース
- [x] **e2e** (`task-category-override.spec.ts`): AddPanel に category 入力が無いこと / 詳細パネル override が DB と `task_category_changed` action_log に届くこと / 同値再選択で重複ログが出ないこと
- [x] typecheck / lint / format:check / unit (389 passed)

未カバー: 実機での Supabase に対する e2e 実行は手元では未実施 (CI 任せ)。category UI の Top カード表示は本 PR スコープ外 (詳細パネルからのみ可視)。

## リリース前チェックリスト (When / Before merge)

該当なし (migration / env / feature flag / 破壊的変更なし)。

## このPRの範囲外 (Out of scope)

- Stack View Top カード / 行カードに current category を出す表示 (詳細パネルからのみ可視に留めた。違和感が出たら別 issue で起票判断)
- AI 初期ラベリング自体 (P3-4 で実装済)
- 既存タスクの backfill (ADR 0015 Notes / 別 issue)
- null へ戻す override の action_log 化 (`metadata.to: string` と矛盾するので今は log 抑制。必要になったら schema 側で判断)

https://claude.ai/code/session_016RQ5jDP8GksotBDVzhZr2k

---
_Generated by [Claude Code](https://claude.ai/code/session_016RQ5jDP8GksotBDVzhZr2k)_