### PR TITLE
feat(task): 親除外集計ヘルパを entities/task/aggregations.ts に集約 (P3-10, #95)

### DIFF
--- a/src/entities/task/aggregations.test.ts
+++ b/src/entities/task/aggregations.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "vitest";
+
+import type { Task } from "./types";
+
+import {
+  aggregateChildren,
+  excludeDecomposedParents,
+  getChildren,
+  sumEstimatedMinutes,
+} from "./aggregations";
+
+const baseTask: Task = {
+  id: "t",
+  projectId: "p1",
+  title: "task",
+  body: "",
+  estimatedMinutes: 30,
+  status: "idle",
+  stackOrder: 0,
+  dependsOnEventId: null,
+  isInterruption: false,
+  parentTaskId: null,
+  decomposeStatus: "none",
+  taskCategory: null,
+  createdAt: "2026-04-27T00:00:00",
+  completedAt: null,
+};
+
+const t = (overrides: Partial<Task> & { id: string }): Task => ({ ...baseTask, ...overrides });
+
+describe("excludeDecomposedParents", () => {
+  test("decomposed 親を除外し、それ以外 (none / decomposing / skipped / failed / 子) は残す", () => {
+    const decomposed = t({ id: "p", decomposeStatus: "decomposed" });
+    const decomposing = t({ id: "a", decomposeStatus: "decomposing" });
+    const skipped = t({ id: "b", decomposeStatus: "skipped" });
+    const failed = t({ id: "f", decomposeStatus: "failed" });
+    const none = t({ id: "c", decomposeStatus: "none" });
+    const child = t({ id: "ch", parentTaskId: "p" });
+
+    const result = excludeDecomposedParents([
+      decomposed,
+      decomposing,
+      skipped,
+      failed,
+      none,
+      child,
+    ]);
+
+    expect(result.map((x) => x.id)).toEqual(["a", "b", "f", "c", "ch"]);
+  });
+
+  test("空配列なら空配列を返す", () => {
+    expect(excludeDecomposedParents([])).toEqual([]);
+  });
+
+  test("元配列を変更しない (不変性)", () => {
+    const tasks = [t({ id: "p", decomposeStatus: "decomposed" }), t({ id: "x" })];
+    const original = [...tasks];
+    excludeDecomposedParents(tasks);
+    expect(tasks).toEqual(original);
+  });
+});
+
+describe("getChildren", () => {
+  test("親 id 直下の子だけを返し、入力順を保つ", () => {
+    const parent = t({ id: "p", decomposeStatus: "decomposed" });
+    const c1 = t({ id: "c1", parentTaskId: "p" });
+    const c2 = t({ id: "c2", parentTaskId: "p" });
+    const otherParent = t({ id: "p2" });
+    const otherChild = t({ id: "c3", parentTaskId: "p2" });
+
+    expect(getChildren("p", [parent, c2, c1, otherParent, otherChild]).map((x) => x.id)).toEqual([
+      "c2",
+      "c1",
+    ]);
+  });
+
+  test("孫 (parent の子の子) は含まない (1 段のみ)", () => {
+    const parent = t({ id: "p" });
+    const child = t({ id: "c", parentTaskId: "p" });
+    const grandchild = t({ id: "gc", parentTaskId: "c" });
+
+    expect(getChildren("p", [parent, child, grandchild]).map((x) => x.id)).toEqual(["c"]);
+  });
+
+  test("該当する子がなければ空配列", () => {
+    expect(getChildren("missing", [t({ id: "x" })])).toEqual([]);
+  });
+});
+
+describe("sumEstimatedMinutes", () => {
+  test("全件に値があれば総和", () => {
+    expect(
+      sumEstimatedMinutes([
+        t({ id: "a", estimatedMinutes: 10 }),
+        t({ id: "b", estimatedMinutes: 25 }),
+      ]),
+    ).toBe(35);
+  });
+
+  test("一部 null は無視して残りの合計", () => {
+    expect(
+      sumEstimatedMinutes([
+        t({ id: "a", estimatedMinutes: 20 }),
+        t({ id: "b", estimatedMinutes: null }),
+        t({ id: "c", estimatedMinutes: 40 }),
+      ]),
+    ).toBe(60);
+  });
+
+  test("全件 null なら null (= 0 にフォールバックしない)", () => {
+    expect(
+      sumEstimatedMinutes([
+        t({ id: "a", estimatedMinutes: null }),
+        t({ id: "b", estimatedMinutes: null }),
+      ]),
+    ).toBeNull();
+  });
+
+  test("空配列なら null", () => {
+    expect(sumEstimatedMinutes([])).toBeNull();
+  });
+});
+
+describe("aggregateChildren", () => {
+  test("total / doneCount / totalEstimatedMinutes を返す", () => {
+    const parent = t({ id: "p", decomposeStatus: "decomposed" });
+    const c1 = t({ id: "c1", parentTaskId: "p", status: "done", estimatedMinutes: 30 });
+    const c2 = t({ id: "c2", parentTaskId: "p", status: "done", estimatedMinutes: 30 });
+    const c3 = t({ id: "c3", parentTaskId: "p", estimatedMinutes: 30 });
+
+    expect(aggregateChildren("p", [parent, c1, c2, c3])).toEqual({
+      total: 3,
+      doneCount: 2,
+      totalEstimatedMinutes: 90,
+    });
+  });
+
+  test("子に estimatedMinutes=null が混ざってもダブルカウントしない", () => {
+    const parent = t({ id: "p", decomposeStatus: "decomposed" });
+    const c1 = t({ id: "c1", parentTaskId: "p", estimatedMinutes: 20 });
+    const c2 = t({ id: "c2", parentTaskId: "p", estimatedMinutes: null });
+    const c3 = t({ id: "c3", parentTaskId: "p", estimatedMinutes: 40 });
+
+    expect(aggregateChildren("p", [parent, c1, c2, c3])).toEqual({
+      total: 3,
+      doneCount: 0,
+      totalEstimatedMinutes: 60,
+    });
+  });
+
+  test("子が居なければ total=0 / doneCount=0 / totalEstimatedMinutes=null", () => {
+    const parent = t({ id: "p" });
+    expect(aggregateChildren("p", [parent])).toEqual({
+      total: 0,
+      doneCount: 0,
+      totalEstimatedMinutes: null,
+    });
+  });
+});

--- a/src/entities/task/aggregations.ts
+++ b/src/entities/task/aggregations.ts
@@ -1,0 +1,74 @@
+import type { Task } from "./types";
+
+/**
+ * Task 集計の共通ヘルパ (issue #95 / P3-10、ADR 0018 Consequences)。
+ *
+ * Phase 3 で `decompose_status='decomposed'` の親が「Stack View では子に置き換わる
+ * (ADR 0016)」「集計上は残数にカウントしない」「`parent_task_id` は保持して
+ * 行動ログの再構築に使う (ADR 0018)」という二重の役割を持つようになった。
+ * このため未着手件数 / 進捗集計 / 階層クエリで「親除外」を毎回手書きすると
+ * ダブルカウントや漏れが起きやすい。集計の意味は 1 箇所に集約する。
+ */
+
+/**
+ * 集計対象から「分解済み親」(`decompose_status='decomposed'`) を除外する。
+ *
+ * 用途:
+ * - Stack 残件数 / 未着手タスク数 (= 子に置き換わっているので親はカウントしない)
+ * - 進捗集計の母集団 (= 親重複を排除した「実際に着手される単位」だけ集める)
+ *
+ * 「分解されていない親」(`none` / `decomposing` / `skipped` / `failed`) と
+ * 「子タスク」「単独タスク」はそのまま残る。
+ */
+export function excludeDecomposedParents(tasks: readonly Task[]): Task[] {
+  return tasks.filter((t) => t.decomposeStatus !== "decomposed");
+}
+
+/**
+ * 親 id 直下の子タスクを返す。順序は入力順 (= 呼び出し側の責務、通常 stack_order 昇順)。
+ *
+ * 孫タスクの再帰展開はしない。kozutsumi の仕様 (idea #121 / ADR 0016) で
+ * 孫は作らず「親の子に flatten」する方針なので、現時点では 1 段で十分。
+ * 将来 Tree View で再帰展開が必要になったら、この helper の上に再帰版を足す。
+ */
+export function getChildren(parentId: string, tasks: readonly Task[]): Task[] {
+  return tasks.filter((t) => t.parentTaskId === parentId);
+}
+
+/**
+ * `estimated_minutes` の null-safe な合計。1 件でも値があれば数値、全 null なら null。
+ *
+ * 「合計を見せるか / 見せないか」の分岐 (Top カード下ゾーン等) で
+ * `null vs 0` の区別が要るので 0 にフォールバックしない。
+ */
+export function sumEstimatedMinutes(tasks: readonly Task[]): number | null {
+  return tasks.reduce<number | null>((acc, t) => {
+    if (t.estimatedMinutes === null) return acc;
+    return (acc ?? 0) + t.estimatedMinutes;
+  }, null);
+}
+
+export type ChildrenAggregate = {
+  /** 子の総数 */
+  total: number;
+  /** `status='done'` の子数 */
+  doneCount: number;
+  /** 子の `estimated_minutes` 合計 (全 null なら null) */
+  totalEstimatedMinutes: number | null;
+};
+
+/**
+ * 親 id に紐づく子の集計 (件数 / 完了数 / 見積合計)。
+ *
+ * Stack View の進捗バー (ADR 0016 §5) / Top カード下ゾーンの「合計時間」/
+ * Done セクションの進捗表示で共通利用する。"現在位置" (currentIndex) は
+ * Stack 残中の位置に依存する派生値なので含めない (呼び出し側で計算)。
+ */
+export function aggregateChildren(parentId: string, tasks: readonly Task[]): ChildrenAggregate {
+  const children = getChildren(parentId, tasks);
+  return {
+    total: children.length,
+    doneCount: children.filter((t) => t.status === "done").length,
+    totalEstimatedMinutes: sumEstimatedMinutes(children),
+  };
+}

--- a/src/features/task-stack/stackItems.ts
+++ b/src/features/task-stack/stackItems.ts
@@ -1,3 +1,4 @@
+import { aggregateChildren } from "@/entities/task/aggregations";
 import type { Task } from "@/entities/task/types";
 
 /**
@@ -77,38 +78,33 @@ export function computeChildProgress(
   allTasks: readonly Task[],
   pendingItems: readonly StackItem[],
 ): Progress {
-  const siblings = allTasks.filter((t) => t.parentTaskId === parent.id);
-  const total = siblings.length;
-  const doneCount = siblings.filter((t) => t.status === "done").length;
-  const totalMinutes = sumEstimatedMinutes(siblings);
+  const { total, doneCount, totalEstimatedMinutes } = aggregateChildren(parent.id, allTasks);
   let position = 0;
   for (const it of pendingItems) {
     if (it.kind === "leaf-child" && it.parent.id === parent.id) {
       position++;
       if (it.task.id === child.id) {
-        return { total, doneCount, currentIndex: doneCount + position, totalMinutes };
+        return {
+          total,
+          doneCount,
+          currentIndex: doneCount + position,
+          totalMinutes: totalEstimatedMinutes,
+        };
       }
     }
   }
-  return { total, doneCount, currentIndex: 0, totalMinutes };
-}
-
-function sumEstimatedMinutes(tasks: readonly Task[]): number | null {
-  return tasks.reduce<number | null>((acc, t) => {
-    if (t.estimatedMinutes === null) return acc;
-    return (acc ?? 0) + t.estimatedMinutes;
-  }, null);
+  return { total, doneCount, currentIndex: 0, totalMinutes: totalEstimatedMinutes };
 }
 
 /**
  * Done セクション用の進捗。current 強調なし (Stack 側の current と被らない)。
  */
 export function computeDoneProgress(parent: Task, allTasks: readonly Task[]): Progress {
-  const siblings = allTasks.filter((t) => t.parentTaskId === parent.id);
+  const { total, doneCount, totalEstimatedMinutes } = aggregateChildren(parent.id, allTasks);
   return {
-    total: siblings.length,
-    doneCount: siblings.filter((t) => t.status === "done").length,
+    total,
+    doneCount,
     currentIndex: 0,
-    totalMinutes: sumEstimatedMinutes(siblings),
+    totalMinutes: totalEstimatedMinutes,
   };
 }


### PR DESCRIPTION
## 概要 (What)

`decompose_status='decomposed'` 親を集計から除外する helper と、子の進捗集計 (件数 / 完了数 / 見積合計) を `src/entities/task/aggregations.ts` に集約。`stackItems.ts` の `computeChildProgress` / `computeDoneProgress` を新 helper に寄せて手書き filter を消す。

## 関連 Issue

Closes #95

## 背景 (Why)

ADR 0018 Consequences で「`parent_task_id` は保持しつつ集計時は親を除外する helper を整備する」と予告していた。Phase 3 で `decompose_status='decomposed'` の親が「Stack View では子に置き換わる (ADR 0016)」「集計上は残数にカウントしない」「`parent_task_id` は行動ログ再構築用に保持 (ADR 0018)」という二重の役割を持つようになり、未着手件数 / 進捗集計 / 階層クエリで「親除外」を毎回手書きするとダブルカウントや漏れが構造的に起きやすい。Phase 4 の暗黙的フィードバック分析 (architecture.md §1.7 / §2.4) で「子のみカウント」が必要な集計が増える前に、集計の意味を 1 箇所に集約しておく。

## Before → After

**Before:** 「分解済み親を除外する」「子の進捗を集計する」ロジックは `stackItems.ts` の中に手書き filter (`allTasks.filter(t => t.parentTaskId === parent.id)`) として埋め込まれ、新しい集計箇所が増えるたびに同じ filter を再実装する状態だった。

**After:** 集計の意味は `entities/task/aggregations.ts` の純粋関数に集約。`stackItems.ts` は `aggregateChildren(parent.id, allTasks)` を呼ぶだけで `total / doneCount / totalEstimatedMinutes` を得る。Phase 4 で増える集計箇所もここに乗る。

## 追加したテスト

- [x] `src/entities/task/aggregations.test.ts` (12 ケース): `excludeDecomposedParents` (decomposed のみ除外 / 不変性) / `getChildren` (孫を含めない) / `sumEstimatedMinutes` (null 安全) / `aggregateChildren` (混在ケース)
- [x] 既存の `stackItems.test.ts` (10 ケース) は無改変で pass — 移行で振る舞いを変えていないことの retreat 検証
- [x] `npm test` 全 403 ケース pass / `npm run typecheck` / `npm run lint` / `npm run format:check`

## このPRの範囲外 (Out of scope)

- ACTION_TYPE の集約 — `src/entities/action-log/types.ts` で `task_category_changed` / `task_decomposed` / `decomposition_modified` / `task_decompose_failed` / `task_decompose_skipped` まで集約済みのためコード変更なし
- `task_merged` / `task_split` ACTION_TYPE — `decomposition_modified.kind` の `parent_merged` / `child_resplit` で代替可能 + 子の統合・再分割 UI が Phase 4 非スコープなので追加しない
- Tree View の再帰展開 helper — 現 TreeView は `HistoryEntry` ベースで tasks 階層を扱わない。`getChildren` の素朴な利用で十分なので必要になったタイミングで再帰版を足す
- 集計箇所の他コードへの寄せ替え — 現状 `stackItems.ts` 以外に「親除外集計」を手書きしている箇所はない (`AppShell.tsx` の `pendingTasks.length` は `stack_order` 計算用で件数表示ではない)

https://claude.ai/code/session_017QLryN7S7qTLdQX9ZezVRY

---
_Generated by [Claude Code](https://claude.ai/code/session_017QLryN7S7qTLdQX9ZezVRY)_