### PR TITLE
fix(task-stack): AI 分解タスクを含む Stack の並び替えで誤ったタスクが動くのを修正

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -23,6 +23,7 @@ import { useCalendarSync } from "@/features/sync/useCalendarSync";
 import { useLazyCalendarSync } from "@/features/sync/useLazyCalendarSync";
 import { TaskDetailPanel } from "@/features/task-detail/TaskDetailPanel";
 import { PauseReasonModal } from "@/features/task-stack/PauseReasonModal";
+import { reorderTasksById } from "@/features/task-stack/reorderTasks";
 import { TaskStack, type TopTimerBinding } from "@/features/task-stack/TaskStack";
 import { triggerCategorize } from "@/features/task-stack/triggerCategorize";
 import { triggerDecompose } from "@/features/task-stack/triggerDecompose";
@@ -471,19 +472,18 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
   );
 
   const reorder = useCallback(
-    (fromIdx: number, toIdx: number) => {
+    (fromId: string, toId: string) => {
+      if (fromId === toId) return;
       const cached = queryClient.getQueryData<Task[]>(keys.tasks) ?? [];
       const pending = cached.filter((t) => !isDone(t));
       const done = cached.filter((t) => isDone(t));
-      if (fromIdx < 0 || fromIdx >= pending.length) return;
-      if (toIdx < 0 || toIdx >= pending.length) return;
-      const next = [...pending];
-      const [item] = next.splice(fromIdx, 1);
-      next.splice(toIdx, 0, item);
-      const reordered = next.map((t, i) => ({ ...t, stackOrder: i }));
+      const fromIdx = pending.findIndex((t) => t.id === fromId);
+      const toIdx = pending.findIndex((t) => t.id === toId);
+      if (fromIdx < 0 || toIdx < 0) return;
+      const reordered = reorderTasksById(pending, fromId, toId);
       queryClient.setQueryData<Task[]>(keys.tasks, [...reordered, ...done]);
       log(ACTION_TYPES.TASK_REORDERED, {
-        task_id: item.id,
+        task_id: fromId,
         from_position: fromIdx,
         to_position: toIdx,
       });
@@ -812,7 +812,7 @@ type StackViewProps = {
   doneTasks: Task[];
   topTimer: TopTimerBinding;
   toggleDone: (id: string) => void;
-  reorder: (from: number, to: number) => void;
+  reorder: (fromId: string, toId: string) => void;
   nowMin: number;
   now: number;
   today: string;

--- a/src/features/task-stack/TaskStack.tsx
+++ b/src/features/task-stack/TaskStack.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 import type { Event } from "@/entities/event/types";
 import type { PauseReason } from "@/entities/task/time-entries";
@@ -42,7 +42,13 @@ type TaskStackProps = {
   topTimer: TopTimerBinding;
   /** 現在時刻 (ms)。依存イベントの相対時刻 / 直近判定で使う。0 は SSR 時の placeholder。 */
   now: number;
-  onReorder: (from: number, to: number) => void;
+  /**
+   * 並び替え操作。`fromId` を `toId` の位置に移す。
+   * Stack 行の index ではなく id ベースで受け取るのは、`buildStackItems` が
+   * decomposed 親を除外するため、UI 上の index と pending Task[] の index が
+   * 一致しないことがあるため。
+   */
+  onReorder: (fromId: string, toId: string) => void;
   onToggleDone: (id: string) => void;
   onOpenDetail: (id: string) => void;
 };
@@ -64,7 +70,16 @@ export function TaskStack({
     [pendingTasks, allTasks],
   );
 
-  const { dragIdx, overIdx, rowRefs, handlePointerDown } = useStackDnD(onReorder);
+  const handleReorderByIdx = useCallback(
+    (fromIdx: number, toIdx: number) => {
+      const fromItem = items[fromIdx];
+      const toItem = items[toIdx];
+      if (!fromItem || !toItem) return;
+      onReorder(fromItem.task.id, toItem.task.id);
+    },
+    [items, onReorder],
+  );
+  const { dragIdx, overIdx, rowRefs, handlePointerDown } = useStackDnD(handleReorderByIdx);
 
   return (
     <>

--- a/src/features/task-stack/reorderTasks.test.ts
+++ b/src/features/task-stack/reorderTasks.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "vitest";
+
+import type { Task } from "@/entities/task/types";
+
+import { reorderTasksById } from "./reorderTasks";
+
+const baseTask: Task = {
+  id: "t",
+  projectId: "p1",
+  title: "task",
+  body: "",
+  estimatedMinutes: 30,
+  status: "idle",
+  stackOrder: 0,
+  dependsOnEventId: null,
+  isInterruption: false,
+  parentTaskId: null,
+  decomposeStatus: "none",
+  taskCategory: null,
+  createdAt: "2026-04-27T00:00:00",
+  completedAt: null,
+};
+
+const t = (overrides: Partial<Task> & { id: string }): Task => ({ ...baseTask, ...overrides });
+
+describe("reorderTasksById", () => {
+  test("通常タスクのみ: from を to の位置に移し stackOrder を 0..n-1 で振り直す", () => {
+    const pending = [
+      t({ id: "a", stackOrder: 0 }),
+      t({ id: "b", stackOrder: 1 }),
+      t({ id: "c", stackOrder: 2 }),
+    ];
+
+    const result = reorderTasksById(pending, "c", "a");
+
+    expect(result.map((x) => x.id)).toEqual(["c", "a", "b"]);
+    expect(result.map((x) => x.stackOrder)).toEqual([0, 1, 2]);
+  });
+
+  test("decomposed 親が pending に混在しても、UI 行 (子+通常) が指定した順に並び、親は移動しない", () => {
+    // pending は stack_order 昇順。decomposed 親 p は子 c1/c2 の間に紛れている。
+    // UI (buildStackItems) では p は除外され items = [c1, c2, s] と見える。
+    // ユーザが items 上で「s を c1 の前に」ドラッグしたとき、p が動いたり
+    // s の代わりに p が動くといったバグが起きないことを確認する (regression)。
+    const pending = [
+      t({ id: "c1", parentTaskId: "p", stackOrder: 0 }),
+      t({ id: "c2", parentTaskId: "p", stackOrder: 1 }),
+      t({ id: "p", decomposeStatus: "decomposed", stackOrder: 2 }),
+      t({ id: "s", stackOrder: 3 }),
+    ];
+
+    const result = reorderTasksById(pending, "s", "c1");
+
+    expect(result.map((x) => x.id)).toEqual(["s", "c1", "c2", "p"]);
+    expect(result.map((x) => x.stackOrder)).toEqual([0, 1, 2, 3]);
+  });
+
+  test("fromId === toId は no-op (元配列のコピーを返す)", () => {
+    const pending = [t({ id: "a", stackOrder: 0 }), t({ id: "b", stackOrder: 1 })];
+    const result = reorderTasksById(pending, "a", "a");
+    expect(result.map((x) => x.id)).toEqual(["a", "b"]);
+  });
+
+  test("存在しない id は no-op", () => {
+    const pending = [t({ id: "a", stackOrder: 0 }), t({ id: "b", stackOrder: 1 })];
+    const result = reorderTasksById(pending, "a", "missing");
+    expect(result.map((x) => x.id)).toEqual(["a", "b"]);
+  });
+
+  test("不変性: 入力配列・要素は変更しない", () => {
+    const a = t({ id: "a", stackOrder: 0 });
+    const b = t({ id: "b", stackOrder: 1 });
+    const pending = [a, b];
+
+    reorderTasksById(pending, "b", "a");
+
+    expect(pending.map((x) => x.id)).toEqual(["a", "b"]);
+    expect(a.stackOrder).toBe(0);
+    expect(b.stackOrder).toBe(1);
+  });
+});

--- a/src/features/task-stack/reorderTasks.ts
+++ b/src/features/task-stack/reorderTasks.ts
@@ -1,0 +1,21 @@
+import type { Task } from "@/entities/task/types";
+
+/**
+ * `pending` 配列内で `fromId` を `toId` の位置に移し、`stackOrder` を 0..n-1 で振り直す。
+ *
+ * id ベースで受けるのは、UI 上の Stack 行 (`buildStackItems` で decomposed 親を
+ * 除外した items) と pending Task[] の index が一致しないため。index で渡すと
+ * 「分解済み親を含むスタック」を並び替えたとき無関係なタスクが動いてしまう。
+ *
+ * いずれかの id が無い、もしくは同一 id なら `pending` をそのまま返す (no-op)。
+ */
+export function reorderTasksById(pending: readonly Task[], fromId: string, toId: string): Task[] {
+  if (fromId === toId) return [...pending];
+  const fromIdx = pending.findIndex((t) => t.id === fromId);
+  const toIdx = pending.findIndex((t) => t.id === toId);
+  if (fromIdx < 0 || toIdx < 0) return [...pending];
+  const next = [...pending];
+  const [item] = next.splice(fromIdx, 1);
+  next.splice(toIdx, 0, item);
+  return next.map((t, i) => ({ ...t, stackOrder: i }));
+}


### PR DESCRIPTION
## 概要 (What)

AI 分解タスクを含む Stack を並び替えると、ドラッグした行とは別のタスクが動いたり `stackOrder` が誤って上書きされるバグを修正。`onReorder` API を index ベースから id ベースに変更。

## 背景 (Why)

ADR 0016 §1 に従い `buildStackItems` は `decomposeStatus === 'decomposed'` の親を Stack 行から除外して子をフラット化する。一方 `AppShell` の `reorder` は `cached.filter(!isDone)` で **decomposed 親を含む** pending Task[] を作って同じ index で `splice` していたため、UI 上の items index と pending index が一致しないケース（= AI 分解後）で意図しない要素が並び替わる結果になっていた。

たとえば:

- pending (stack_order 昇順) = `[c1(child), c2(child), p(decomposed parent), s]`
- items (UI 行) = `[c1, c2, s]`
- ユーザが items 上で `s` を `c1` の前に移動 (`from=2, to=0`)
- 旧実装: `pending.splice(2, 1)` で **`p` を抜いて先頭に挿入** → 視覚的には何も動かず、`p.stackOrder` だけが裏で書き換わる

ドメインルール（「decomposed 親は Stack 行に出さない」）と、並び替え操作の index 計算が同じ層に同居していたのが原因。

## Before → After

**Before:** UI 行と pending Task[] の index が一致する前提で reorder API が `(fromIdx, toIdx)` を受けていた。decomposed 親を含むスタックではこの前提が崩れ、index translation バグが発生。

**After:** reorder API を `(fromId, toId)` の id ベースに変更。「Stack 行に出すかどうか」と「並び替え対象の同定」を id で疎結合にした。並び替えロジックは `reorderTasksById` という純粋関数に切り出してテスト可能にし、AppShell からはそれを呼ぶだけ。

## 追加したテスト (How verified)

- [x] `src/features/task-stack/reorderTasks.test.ts` (5 ケース): 通常並び替え / **decomposed 親が pending に混在しても UI 行のみが指定通りに並び親は移動しない (regression)** / no-op (同 id / 不在 id) / 入力配列の不変性
- [x] `npm run typecheck` ✅
- [x] `npm test` ✅ (39 files / 395 tests pass)
- [x] `npm run lint` ✅
- [x] `npm run format:check` ✅

## このPRの範囲外 (Out of scope)

- **「Stack に decomposed 親を出さない」をドメイン側に寄せる** リファクタ: 現状フロントの `buildStackItems` がドメインルール（ADR 0016 §1）を再現している構造は今回触らない。今回の修正は「reorder の index 翻訳を id ベースに変える」最小スコープ。責務分離（backend or 共有 query が Stack 行を返す）は別 ADR / issue で扱う想定。
- e2e の追加: drag-and-drop の e2e は既存に無く、本 PR でも追加していない。regression は pure function の unit test で押さえている。
- PR #128（`aggregateChildren` 集計 helper 集約）とはテーマ隣接だが触る層が違うため独立。コンフリクトなし。

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGFz47hUzq3shrNYy7p9A3)_