### PR TITLE
fix(ai): /api/ai/* の auth ガードを getUser() に切り替え

### DIFF
--- a/src/app/api/ai/categorize/route.test.ts
+++ b/src/app/api/ai/categorize/route.test.ts
@@ -28,10 +28,10 @@ import { createClient } from "@/shared/supabase/server";
 
 import { POST } from "./route";
 
-function makeSupabase(session: { user: { id: string } } | null): SupabaseClient {
+function makeSupabase(user: { id: string } | null): SupabaseClient {
   return {
     auth: {
-      getSession: vi.fn(async () => ({ data: { session }, error: null })),
+      getUser: vi.fn(async () => ({ data: { user }, error: null })),
     },
   } as unknown as SupabaseClient;
 }
@@ -91,7 +91,7 @@ describe("POST /api/ai/categorize", () => {
   test("body に task_id が無い → ok:false で error を返す (200、fire-and-forget client は無視)", async () => {
     process.env.AI_ENABLED = "true";
     process.env.GEMINI_API_KEY = "k";
-    vi.mocked(createClient).mockResolvedValue(makeSupabase({ user: { id: "u1" } }));
+    vi.mocked(createClient).mockResolvedValue(makeSupabase({ id: "u1" }));
 
     const response = await POST(makeRequest({ wrong_field: "x" }));
 
@@ -104,7 +104,7 @@ describe("POST /api/ai/categorize", () => {
   test("body が JSON でない → ok:false で error を返す (parse エラーで 500 にしない)", async () => {
     process.env.AI_ENABLED = "true";
     process.env.GEMINI_API_KEY = "k";
-    vi.mocked(createClient).mockResolvedValue(makeSupabase({ user: { id: "u1" } }));
+    vi.mocked(createClient).mockResolvedValue(makeSupabase({ id: "u1" }));
 
     const response = await POST(makeRequest("not json"));
 
@@ -117,7 +117,7 @@ describe("POST /api/ai/categorize", () => {
   test("正常系: categorizeTask を userId / taskId / generate 付きで呼び出す", async () => {
     process.env.AI_ENABLED = "true";
     process.env.GEMINI_API_KEY = "k";
-    vi.mocked(createClient).mockResolvedValue(makeSupabase({ user: { id: "u1" } }));
+    vi.mocked(createClient).mockResolvedValue(makeSupabase({ id: "u1" }));
     categorizeTaskMock.mockResolvedValue({ kind: "categorized", category: "coding" });
     generateContentMock.mockResolvedValue({ response: { text: () => "coding" } });
 
@@ -149,7 +149,7 @@ describe("POST /api/ai/categorize", () => {
   test("categorizeTask が throw → 500 ai_failed (fail-soft、client は握り潰す)", async () => {
     process.env.AI_ENABLED = "true";
     process.env.GEMINI_API_KEY = "k";
-    vi.mocked(createClient).mockResolvedValue(makeSupabase({ user: { id: "u1" } }));
+    vi.mocked(createClient).mockResolvedValue(makeSupabase({ id: "u1" }));
     categorizeTaskMock.mockRejectedValue(new Error("unexpected db error"));
 
     const response = await POST(makeRequest({ task_id: "t1" }));

--- a/src/app/api/ai/decompose/route.test.ts
+++ b/src/app/api/ai/decompose/route.test.ts
@@ -28,10 +28,10 @@ import { createClient } from "@/shared/supabase/server";
 
 import { POST } from "./route";
 
-function makeSupabase(session: { user: { id: string } } | null): SupabaseClient {
+function makeSupabase(user: { id: string } | null): SupabaseClient {
   return {
     auth: {
-      getSession: vi.fn(async () => ({ data: { session }, error: null })),
+      getUser: vi.fn(async () => ({ data: { user }, error: null })),
     },
   } as unknown as SupabaseClient;
 }
@@ -91,7 +91,7 @@ describe("POST /api/ai/decompose", () => {
   test("body に task_id が無い → ok:false で error を返す (200 で握る、fire-and-forget client は無視)", async () => {
     process.env.AI_ENABLED = "true";
     process.env.GEMINI_API_KEY = "k";
-    vi.mocked(createClient).mockResolvedValue(makeSupabase({ user: { id: "u1" } }));
+    vi.mocked(createClient).mockResolvedValue(makeSupabase({ id: "u1" }));
 
     const response = await POST(makeRequest({ wrong_field: "x" }));
 
@@ -104,7 +104,7 @@ describe("POST /api/ai/decompose", () => {
   test("body が JSON でない → ok:false で error を返す (parse エラーで 500 にしない)", async () => {
     process.env.AI_ENABLED = "true";
     process.env.GEMINI_API_KEY = "k";
-    vi.mocked(createClient).mockResolvedValue(makeSupabase({ user: { id: "u1" } }));
+    vi.mocked(createClient).mockResolvedValue(makeSupabase({ id: "u1" }));
 
     const response = await POST(makeRequest("not json"));
 
@@ -117,7 +117,7 @@ describe("POST /api/ai/decompose", () => {
   test("正常系: decomposeTask を userId / taskId / generate 付きで呼び出す", async () => {
     process.env.AI_ENABLED = "true";
     process.env.GEMINI_API_KEY = "k";
-    const supabase = makeSupabase({ user: { id: "u1" } });
+    const supabase = makeSupabase({ id: "u1" });
     vi.mocked(createClient).mockResolvedValue(supabase);
     decomposeTaskMock.mockResolvedValue({
       kind: "decomposed",
@@ -153,7 +153,7 @@ describe("POST /api/ai/decompose", () => {
   test("decomposeTask が throw → 500 ai_failed (fail-soft、client は握り潰す)", async () => {
     process.env.AI_ENABLED = "true";
     process.env.GEMINI_API_KEY = "k";
-    vi.mocked(createClient).mockResolvedValue(makeSupabase({ user: { id: "u1" } }));
+    vi.mocked(createClient).mockResolvedValue(makeSupabase({ id: "u1" }));
     decomposeTaskMock.mockRejectedValue(new Error("gemini quota exceeded"));
 
     const response = await POST(makeRequest({ task_id: "p1" }));

--- a/src/app/api/ai/ping/route.test.ts
+++ b/src/app/api/ai/ping/route.test.ts
@@ -17,8 +17,8 @@ import { POST } from "./route";
 function makeSupabase(): SupabaseClient {
   return {
     auth: {
-      getSession: vi.fn(async () => ({
-        data: { session: { user: { id: "user-1" } } },
+      getUser: vi.fn(async () => ({
+        data: { user: { id: "user-1" } },
         error: null,
       })),
     },

--- a/src/shared/ai/route.test.ts
+++ b/src/shared/ai/route.test.ts
@@ -9,12 +9,12 @@ import { createClient } from "@/shared/supabase/server";
 
 import { withAiRoute } from "./route";
 
-type SessionShape = { user: { id: string } } | null;
+type UserShape = { id: string } | null;
 
-function makeSupabase(session: SessionShape): SupabaseClient {
+function makeSupabase(user: UserShape): SupabaseClient {
   return {
     auth: {
-      getSession: vi.fn(async () => ({ data: { session }, error: null })),
+      getUser: vi.fn(async () => ({ data: { user }, error: null })),
     },
   } as unknown as SupabaseClient;
 }
@@ -90,7 +90,7 @@ describe("withAiRoute", () => {
   test("AI 有効 + ログイン済み → handler に userId と supabase が渡る", async () => {
     process.env.AI_ENABLED = "true";
     process.env.GEMINI_API_KEY = "k";
-    const supabase = makeSupabase({ user: { id: "user-1" } });
+    const supabase = makeSupabase({ id: "user-1" });
     vi.mocked(createClient).mockResolvedValue(supabase);
     const handler = vi.fn(async () => ({ ok: true }));
 
@@ -106,7 +106,7 @@ describe("withAiRoute", () => {
   test("handler が throw → 500 ai_failed (ユーザー操作は別経路で続行する前提)", async () => {
     process.env.AI_ENABLED = "true";
     process.env.GEMINI_API_KEY = "k";
-    vi.mocked(createClient).mockResolvedValue(makeSupabase({ user: { id: "user-1" } }));
+    vi.mocked(createClient).mockResolvedValue(makeSupabase({ id: "user-1" }));
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     const response = await withAiRoute(makeRequest(), async () => {

--- a/src/shared/ai/route.ts
+++ b/src/shared/ai/route.ts
@@ -12,7 +12,8 @@ import { isAiEnabled } from "./env";
  * 順序:
  * 1. `AI_ENABLED` kill-switch — false なら 200 `{ skipped: true }` で early return。
  *    e2e (`AI_ENABLED=false`)・障害時 kill・env 設定漏れ (fail-soft) はここで吸収する。
- * 2. auth — Supabase session が無ければ 401。
+ * 2. auth — `getUser()` で Supabase Auth サーバーに token を検証させ、user が無ければ 401。
+ *    `getSession()` は cookie 由来データをそのまま返すため auth 境界に置かない (Supabase の警告)。
  * 3. handler — 例外は 500 `{ error: "ai_failed" }`。client は fire-and-forget で握り潰す前提。
  *
  * 本番 / e2e で同じコードパスが走る (ADR 0014)。`if (e2e)` のような専用分岐は作らない。
@@ -40,16 +41,16 @@ export async function withAiRoute(
 
   const supabase = await createClient();
   const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  if (!session) {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
 
   try {
     const result = await handler({
       supabase: supabase as unknown as SupabaseClient<Database>,
-      userId: session.user.id,
+      userId: user.id,
       request,
     });
     return NextResponse.json(result);


### PR DESCRIPTION
## 概要 (What)

`withAiRoute` の auth ガードを `supabase.auth.getSession()` から `getUser()` に変更し、Supabase SDK の insecure warning を解消する。

## 関連 Issue

Closes #108

## 背景 (Why)

`/api/ai/*` を叩くと server console に Supabase の警告が出ていた:

> Using the user object as returned from supabase.auth.getSession() ... could be insecure! ... Use supabase.auth.getUser() instead which authenticates the data by contacting the Supabase Auth server.

`getSession()` は cookie 由来データをそのまま返すため、auth 境界に置くと cookie 偽装時に認証が信頼できない。kozutsumi は単一ユーザー前提でリスクは限定的だが、AI route hot path に認証境界があるので best practice に寄せる。

関連 ADR: 0012 (AI call via Route Handler)

## Before → After (概念・フロー・メンタルモデル)

**Before:** `/api/ai/*` の auth は cookie に入った session を信頼していた (Supabase Auth サーバーへの検証なし)。

**After:** `getUser()` で Supabase Auth サーバーに token を検証させた上で `userId` を取り出す。token / cookie 改ざん時はそこで弾ける。

## 追加したテスト (How verified)

- [x] `withAiRoute` の 401 / 200 / handler 例外パスを既存テストで踏み直し (mock を `getUser` に更新)
- [x] `/api/ai/{ping,categorize,decompose}` の test も同様に mock 切り替え
- [x] `npm test` (408 passed) / `npm run typecheck` / `npm run lint`

## このPRの範囲外 (Out of scope)

- `src/shared/google/token.ts` — `session.provider_token` / `provider_refresh_token` を読むため `getSession()` が必須
- `src/app/api/calendar/sync/route.ts` の auth ガード — `session.user` を参照していないため警告は出ず、`token.ts` 側で結局 `getSession()` を呼ぶので `getUser()` を足すと Auth API への往復が増えるだけ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fdb15A72K9Mugxc8aK5FNd)_