### PR TITLE
feat(ai): decompose プロンプトに子タスク body 生成を統合 (#120)

### DIFF
--- a/src/entities/task/decompose-server.test.ts
+++ b/src/entities/task/decompose-server.test.ts
@@ -134,8 +134,13 @@ describe("decomposeTask", () => {
   test("happy path: AI が 2 件返す → 子 insert + 親 decomposed + action_log 記録 (raw_response を含む)", async () => {
     const { client, calls } = makeSupabase(defaultPlan(makeParentRow()));
     const rawResponse = JSON.stringify([
-      { title: "子A", estimated_minutes: 30, task_category: "research" },
-      { title: "子B", estimated_minutes: 15, task_category: "doc" },
+      {
+        title: "子A",
+        body: "- 手順を書く\n- 注意点を確認",
+        estimated_minutes: 30,
+        task_category: "research",
+      },
+      { title: "子B", body: "", estimated_minutes: 15, task_category: "doc" },
     ]);
     const generate = vi.fn(async () => rawResponse);
 
@@ -153,6 +158,7 @@ describe("decomposeTask", () => {
       depends_on_event_id: "evt-1", // 親から継承
       parent_task_id: "parent-1",
       title: "子A",
+      body: "- 手順を書く\n- 注意点を確認", // #120: AI 生成 body を子 insert に渡す
       estimated_minutes: 30,
       task_category: "research", // ADR 0022: decompose プロンプトが同時推論
       stack_order: 5, // baseStackOrder = parent.stack_order
@@ -160,6 +166,7 @@ describe("decomposeTask", () => {
     });
     expect(inserted[1]).toMatchObject({
       title: "子B",
+      body: "", // body が無い子は空文字で insert される
       task_category: "doc",
       stack_order: 6, // baseStackOrder + 1
     });

--- a/src/entities/task/decompose-server.ts
+++ b/src/entities/task/decompose-server.ts
@@ -133,7 +133,7 @@ async function runDecompose(
     user_id: userId,
     project_id: parent.project_id,
     title: child.title,
-    body: "",
+    body: child.body,
     estimated_minutes: child.estimatedMinutes,
     task_category: child.taskCategory,
     parent_task_id: parent.id,

--- a/src/shared/ai/prompts/decompose.test.ts
+++ b/src/shared/ai/prompts/decompose.test.ts
@@ -56,34 +56,58 @@ describe("buildDecomposePrompt", () => {
     // 出力例に task_category フィールドが含まれる
     expect(prompt).toContain('"task_category"');
   });
+
+  test("各子タスクの body 生成指示と出力例が prompt に含まれる (#120)", () => {
+    const prompt = buildDecomposePrompt({
+      title: "x",
+      body: "",
+      estimatedMinutes: null,
+    });
+
+    // 子の body 生成方針
+    expect(prompt).toContain("body は markdown");
+    expect(prompt).toContain("200 文字程度");
+    // 出力例に body フィールドが含まれる
+    expect(prompt).toContain('"body"');
+  });
 });
 
 describe("parseDecomposeResponse", () => {
   test("正常な JSON 配列をパースする (estimated_minutes / task_category とも値域内なら採用)", () => {
     const input = JSON.stringify([
-      { title: "下準備をする", estimated_minutes: 30, task_category: "research" },
-      { title: "本作業を進める", estimated_minutes: null, task_category: "coding" },
-      { title: "振り返り", estimated_minutes: 15, task_category: "doc" },
+      {
+        title: "下準備をする",
+        body: "- 必要な資料を集める\n- 環境を整える",
+        estimated_minutes: 30,
+        task_category: "research",
+      },
+      { title: "本作業を進める", body: "", estimated_minutes: null, task_category: "coding" },
+      { title: "振り返り", body: "学びを箇条書き", estimated_minutes: 15, task_category: "doc" },
     ]);
 
     const result = parseDecomposeResponse(input);
 
     expect(result).toEqual([
-      { title: "下準備をする", estimatedMinutes: 30, taskCategory: "research" },
-      { title: "本作業を進める", estimatedMinutes: null, taskCategory: "coding" },
-      { title: "振り返り", estimatedMinutes: 15, taskCategory: "doc" },
+      {
+        title: "下準備をする",
+        body: "- 必要な資料を集める\n- 環境を整える",
+        estimatedMinutes: 30,
+        taskCategory: "research",
+      },
+      { title: "本作業を進める", body: "", estimatedMinutes: null, taskCategory: "coding" },
+      { title: "振り返り", body: "学びを箇条書き", estimatedMinutes: 15, taskCategory: "doc" },
     ]);
   });
 
   test("markdown fence (```json ... ```) を剥がす", () => {
     const input =
-      '```json\n[{"title":"a","estimated_minutes":15,"task_category":"coding"},{"title":"b","estimated_minutes":15,"task_category":"doc"}]\n```';
+      '```json\n[{"title":"a","body":"","estimated_minutes":15,"task_category":"coding"},{"title":"b","body":"","estimated_minutes":15,"task_category":"doc"}]\n```';
 
     const result = parseDecomposeResponse(input);
 
     expect(result).toEqual([
-      { title: "a", estimatedMinutes: 15, taskCategory: "coding" },
-      { title: "b", estimatedMinutes: 15, taskCategory: "doc" },
+      { title: "a", body: "", estimatedMinutes: 15, taskCategory: "coding" },
+      { title: "b", body: "", estimatedMinutes: 15, taskCategory: "doc" },
     ]);
   });
 
@@ -94,7 +118,7 @@ describe("parseDecomposeResponse", () => {
 
   test("1 件のみは「実質分解されていない」ので [] (skipped 扱い) に倒す", () => {
     const input = JSON.stringify([
-      { title: "ひとつだけ", estimated_minutes: 10, task_category: "coding" },
+      { title: "ひとつだけ", body: "", estimated_minutes: 10, task_category: "coding" },
     ]);
 
     const result = parseDecomposeResponse(input);
@@ -105,6 +129,7 @@ describe("parseDecomposeResponse", () => {
   test("8 件以上は先頭 7 件で切る (AI 暴走時の安全弁)", () => {
     const items = Array.from({ length: 12 }, (_, i) => ({
       title: `子${i + 1}`,
+      body: "",
       estimated_minutes: 15,
       task_category: "coding",
     }));
@@ -119,81 +144,81 @@ describe("parseDecomposeResponse", () => {
   test("title が空 / 80 文字超過のエントリは捨て、残りを採用する", () => {
     const longTitle = "あ".repeat(81);
     const items = [
-      { title: "", estimated_minutes: 15, task_category: "coding" }, // 空 → 捨てる
-      { title: longTitle, estimated_minutes: 15, task_category: "coding" }, // 80 文字超過 → 捨てる
-      { title: "ok-1", estimated_minutes: 15, task_category: "coding" },
-      { title: "ok-2", estimated_minutes: 15, task_category: "doc" },
+      { title: "", body: "", estimated_minutes: 15, task_category: "coding" }, // 空 → 捨てる
+      { title: longTitle, body: "", estimated_minutes: 15, task_category: "coding" }, // 80 文字超過 → 捨てる
+      { title: "ok-1", body: "", estimated_minutes: 15, task_category: "coding" },
+      { title: "ok-2", body: "", estimated_minutes: 15, task_category: "doc" },
     ];
 
     const result = parseDecomposeResponse(JSON.stringify(items));
 
     expect(result).toEqual([
-      { title: "ok-1", estimatedMinutes: 15, taskCategory: "coding" },
-      { title: "ok-2", estimatedMinutes: 15, taskCategory: "doc" },
+      { title: "ok-1", body: "", estimatedMinutes: 15, taskCategory: "coding" },
+      { title: "ok-2", body: "", estimatedMinutes: 15, taskCategory: "doc" },
     ]);
   });
 
   test("estimated_minutes が許容バケット外 / 文字列 / 小数 → null に倒す (entry は採用)", () => {
     const items = [
-      { title: "a", estimated_minutes: 7, task_category: "coding" }, // バケット外
-      { title: "b", estimated_minutes: "30", task_category: "coding" }, // 文字列
-      { title: "c", estimated_minutes: 15.5, task_category: "coding" }, // 小数
-      { title: "d", estimated_minutes: 30, task_category: "coding" }, // 許容
+      { title: "a", body: "", estimated_minutes: 7, task_category: "coding" }, // バケット外
+      { title: "b", body: "", estimated_minutes: "30", task_category: "coding" }, // 文字列
+      { title: "c", body: "", estimated_minutes: 15.5, task_category: "coding" }, // 小数
+      { title: "d", body: "", estimated_minutes: 30, task_category: "coding" }, // 許容
     ];
 
     const result = parseDecomposeResponse(JSON.stringify(items));
 
     expect(result).toEqual([
-      { title: "a", estimatedMinutes: null, taskCategory: "coding" },
-      { title: "b", estimatedMinutes: null, taskCategory: "coding" },
-      { title: "c", estimatedMinutes: null, taskCategory: "coding" },
-      { title: "d", estimatedMinutes: 30, taskCategory: "coding" },
+      { title: "a", body: "", estimatedMinutes: null, taskCategory: "coding" },
+      { title: "b", body: "", estimatedMinutes: null, taskCategory: "coding" },
+      { title: "c", body: "", estimatedMinutes: null, taskCategory: "coding" },
+      { title: "d", body: "", estimatedMinutes: 30, taskCategory: "coding" },
     ]);
   });
 
   test("task_category が値域外 / 欠損 / 型違い → null に倒す (entry は採用、ADR 0022 フェイルソフト)", () => {
     const items = [
-      { title: "a", estimated_minutes: 15, task_category: "general" }, // 値域外
-      { title: "b", estimated_minutes: 15, task_category: "" }, // 空文字
-      { title: "c", estimated_minutes: 15 }, // 欠損
-      { title: "d", estimated_minutes: 15, task_category: 1 }, // 型違い (数値)
-      { title: "e", estimated_minutes: 15, task_category: null }, // 明示 null
-      { title: "f", estimated_minutes: 15, task_category: "doc" }, // 値域内
+      { title: "a", body: "", estimated_minutes: 15, task_category: "general" }, // 値域外
+      { title: "b", body: "", estimated_minutes: 15, task_category: "" }, // 空文字
+      { title: "c", body: "", estimated_minutes: 15 }, // 欠損
+      { title: "d", body: "", estimated_minutes: 15, task_category: 1 }, // 型違い (数値)
+      { title: "e", body: "", estimated_minutes: 15, task_category: null }, // 明示 null
+      { title: "f", body: "", estimated_minutes: 15, task_category: "doc" }, // 値域内
     ];
 
     const result = parseDecomposeResponse(JSON.stringify(items));
 
     expect(result).toEqual([
-      { title: "a", estimatedMinutes: 15, taskCategory: null },
-      { title: "b", estimatedMinutes: 15, taskCategory: null },
-      { title: "c", estimatedMinutes: 15, taskCategory: null },
-      { title: "d", estimatedMinutes: 15, taskCategory: null },
-      { title: "e", estimatedMinutes: 15, taskCategory: null },
-      { title: "f", estimatedMinutes: 15, taskCategory: "doc" },
+      { title: "a", body: "", estimatedMinutes: 15, taskCategory: null },
+      { title: "b", body: "", estimatedMinutes: 15, taskCategory: null },
+      { title: "c", body: "", estimatedMinutes: 15, taskCategory: null },
+      { title: "d", body: "", estimatedMinutes: 15, taskCategory: null },
+      { title: "e", body: "", estimatedMinutes: 15, taskCategory: null },
+      { title: "f", body: "", estimatedMinutes: 15, taskCategory: "doc" },
     ]);
   });
 
   test("task_category は大文字 / 前後空白を許容して値域に合わせる (Coding → coding)", () => {
     const items = [
-      { title: "a", estimated_minutes: 15, task_category: "Coding" },
-      { title: "b", estimated_minutes: 15, task_category: " admin " },
+      { title: "a", body: "", estimated_minutes: 15, task_category: "Coding" },
+      { title: "b", body: "", estimated_minutes: 15, task_category: " admin " },
     ];
 
     const result = parseDecomposeResponse(JSON.stringify(items));
 
     expect(result).toEqual([
-      { title: "a", estimatedMinutes: 15, taskCategory: "coding" },
-      { title: "b", estimatedMinutes: 15, taskCategory: "admin" },
+      { title: "a", body: "", estimatedMinutes: 15, taskCategory: "coding" },
+      { title: "b", body: "", estimatedMinutes: 15, taskCategory: "admin" },
     ]);
   });
 
   test("category 値域内すべて (coding/doc/research/admin/other) を受理する", () => {
     const items = [
-      { title: "a", estimated_minutes: 15, task_category: "coding" },
-      { title: "b", estimated_minutes: 15, task_category: "doc" },
-      { title: "c", estimated_minutes: 15, task_category: "research" },
-      { title: "d", estimated_minutes: 15, task_category: "admin" },
-      { title: "e", estimated_minutes: 15, task_category: "other" },
+      { title: "a", body: "", estimated_minutes: 15, task_category: "coding" },
+      { title: "b", body: "", estimated_minutes: 15, task_category: "doc" },
+      { title: "c", body: "", estimated_minutes: 15, task_category: "research" },
+      { title: "d", body: "", estimated_minutes: 15, task_category: "admin" },
+      { title: "e", body: "", estimated_minutes: 15, task_category: "other" },
     ];
 
     const result = parseDecomposeResponse(JSON.stringify(items));
@@ -204,6 +229,67 @@ describe("parseDecomposeResponse", () => {
       "research",
       "admin",
       "other",
+    ]);
+  });
+
+  test("body が欠損 / 型違い (number / null) → 空文字に倒す (entry は採用、フェイルソフト)", () => {
+    const items = [
+      { title: "a", estimated_minutes: 15, task_category: "coding" }, // 欠損
+      { title: "b", body: 123, estimated_minutes: 15, task_category: "coding" }, // 数値
+      { title: "c", body: null, estimated_minutes: 15, task_category: "coding" }, // null
+      { title: "d", body: "メモ", estimated_minutes: 15, task_category: "coding" }, // 文字列
+    ];
+
+    const result = parseDecomposeResponse(JSON.stringify(items));
+
+    expect(result?.map((c) => c.body)).toEqual(["", "", "", "メモ"]);
+  });
+
+  test("body が 600 文字を超える → 600 文字で truncate (AI 暴走時の hard cap)", () => {
+    const longBody = "あ".repeat(800);
+    const items = [
+      { title: "a", body: longBody, estimated_minutes: 15, task_category: "coding" },
+      { title: "b", body: "短い", estimated_minutes: 15, task_category: "coding" },
+    ];
+
+    const result = parseDecomposeResponse(JSON.stringify(items));
+
+    expect(result?.[0].body.length).toBe(600);
+    expect(result?.[1].body).toBe("短い");
+  });
+
+  test("8 件以上 / title 採用後の body 採用も含めて、parser は entry を全フィールド埋めて返す", () => {
+    // body 1 件目に markdown が入る現実的なケース
+    const items = [
+      {
+        title: "API 仕様を確認する",
+        body: "- README を読む\n- 認証フローを把握する\n- レート制限を確認する",
+        estimated_minutes: 15,
+        task_category: "research",
+      },
+      {
+        title: "クライアント実装をする",
+        body: "fetch ラッパーを作る",
+        estimated_minutes: 30,
+        task_category: "coding",
+      },
+    ];
+
+    const result = parseDecomposeResponse(JSON.stringify(items));
+
+    expect(result).toEqual([
+      {
+        title: "API 仕様を確認する",
+        body: "- README を読む\n- 認証フローを把握する\n- レート制限を確認する",
+        estimatedMinutes: 15,
+        taskCategory: "research",
+      },
+      {
+        title: "クライアント実装をする",
+        body: "fetch ラッパーを作る",
+        estimatedMinutes: 30,
+        taskCategory: "coding",
+      },
     ]);
   });
 

--- a/src/shared/ai/prompts/decompose.ts
+++ b/src/shared/ai/prompts/decompose.ts
@@ -25,6 +25,7 @@ export type DecomposeInput = {
 
 export type DecomposedChild = {
   title: string;
+  body: string;
   estimatedMinutes: number | null;
   taskCategory: TaskCategoryValue | null;
 };
@@ -32,6 +33,10 @@ export type DecomposedChild = {
 const MIN_CHILDREN = 2;
 const MAX_CHILDREN = 7;
 const MAX_TITLE_LEN = 80;
+// 子 body は markdown で 200 文字程度を目標に prompt で誘導する。AI が暴走しても
+// task body 全体が肥大化しないよう 600 文字で hard cap する (truncate)。
+const TARGET_BODY_LEN = 200;
+const MAX_BODY_LEN = 600;
 
 const ALLOWED_ESTIMATE_BUCKETS = [5, 10, 15, 20, 30, 45, 60, 90, 120] as const;
 
@@ -57,6 +62,10 @@ export function buildDecomposePrompt(parent: DecomposeInput): string {
     "  例 (悪): 「志望動機を書く」 / 例 (良): 「Dirbato 最終面接 志望動機 (パターン A) を書く」",
     `- title は ${MAX_TITLE_LEN} 文字以内。装飾的なプレフィックス (Step 1: 等) は付けない。`,
     `- estimated_minutes は ${ALLOWED_ESTIMATE_BUCKETS.join("/")} のいずれかの整数か、自信が無ければ null。`,
+    `- body は markdown で ${TARGET_BODY_LEN} 文字程度の実行メモ。実行手順 / 注意点 / 参照リンクなど、`,
+    "  着手時に「何を / どうやって」を思い出さなくて済むようにする。",
+    "  親 body の内容をそのまま貼らず、その子タスク固有の文脈に絞る。",
+    '  特に書くことが無い (title だけで十分) 場合は空文字 "" を返す。',
     "",
     "# task_category の値域 (各子タスクの作業種類)",
     "- coding   : 実装 / バグ修正 / リファクタ / レビュー / セットアップなどコードを書く作業",
@@ -73,8 +82,8 @@ export function buildDecomposePrompt(parent: DecomposeInput): string {
     "",
     "# 出力形式",
     "JSON 配列のみを返す。前後に説明文や markdown fence を付けない。",
-    "各要素は title / estimated_minutes / task_category の 3 フィールドを持つ。",
-    '例: [{"title":"...","estimated_minutes":30,"task_category":"coding"},{"title":"...","estimated_minutes":null,"task_category":"research"}]',
+    "各要素は title / body / estimated_minutes / task_category の 4 フィールドを持つ。",
+    '例: [{"title":"...","body":"- 手順1\\n- 手順2","estimated_minutes":30,"task_category":"coding"},{"title":"...","body":"","estimated_minutes":null,"task_category":"research"}]',
   ].join("\n");
 }
 
@@ -139,7 +148,16 @@ function normalizeChild(raw: unknown): DecomposedChild | null {
   // task_category だけの parse 失敗 (値域外 / 型違い / 欠損) では子の生成自体を止めない。
   // null で埋めて子は作る (ADR 0022 §否定的影響: フェイルソフト)。
   const taskCategory = normalizeCategory(obj.task_category);
-  return { title, estimatedMinutes: estimate, taskCategory };
+  // body は欠損 / 型違い → 空文字。長すぎ → 末尾 truncate。空文字を許容する
+  // (title だけで十分な子の場合に AI が "" を返す)。
+  const body = normalizeBody(obj.body);
+  return { title, body, estimatedMinutes: estimate, taskCategory };
+}
+
+function normalizeBody(raw: unknown): string {
+  if (typeof raw !== "string") return "";
+  if (raw.length <= MAX_BODY_LEN) return raw;
+  return raw.slice(0, MAX_BODY_LEN);
 }
 
 function normalizeEstimate(raw: unknown): number | null {


### PR DESCRIPTION
## 概要 (What)

AI 分解時に各子タスクの `body` (markdown の実行メモ) も同じ Gemini 呼び出しで生成し、子 insert 時に空文字で固定していたフィールドに反映する。

## 関連 Issue

Closes #120

## 背景 (Why)

これまで `DecomposedChild = { title, estimatedMinutes, taskCategory }` で、`decompose-server.ts` の子 insert は `body: ""` 固定だった。結果、分解された子の詳細パネルは常に「詳細を追加...」プレースホルダで、Top カードの body preview スロット (P3-7) も子では空。

着手時に「何を / どうやって」を都度思い出す認知負荷を下げ、vision「気づいたら準備が整っている」体験を表層レイヤで強化する。親 body を機械的に継承する代案より、AI が「親文脈 × 子粒度」に合わせて書いたメモのほうが価値が高い。

ADR 0017 / 0018 / 0022 の不変条件には影響しない (体験を厚くするだけ)。

## Before → After (概念・フロー・メンタルモデル)

**Before:** 子タスクは title / estimated / category だけが AI 由来で、body は常に空。詳細を埋めるのはユーザー手動。

**After:** 子タスクは title / body / estimated / category がワンショットで揃う。「分解したらメモも付いてくる」前提に変わる。

## 追加したテスト (How verified)

- [x] `decompose.test.ts`: prompt に body 生成指示が入る / parser が body を取り込む / 欠損 / 型違い / null は空文字 / 600 文字超は truncate / markdown 含む realistic ケース
- [x] `decompose-server.test.ts`: happy path で `body` が insert payload に伝搬する (markdown 入り + 空文字の両ケース)
- [x] `npm test` (412 passed) / `npm run typecheck` / `npm run lint` / `npm run format:check` すべて green
- [ ] 実 Gemini で生成 body の品質 / latency / token 増を手動確認 (詳細パネルから raw response が見られる #118 のおかげで踏みやすい)

## このPRの範囲外 (Out of scope)

- 既存の分解済み子に対する遡及的な body 補完 (今回の変更以降に分解された子だけが対象)
- 親 body 継承 / 要約の代替パス (AI 生成で十分という判断)


---
_Generated by [Claude Code](https://claude.ai/code/session_013uviJFRcpAHXJcPsVQsrj2)_