### PR TITLE
fix(ai): failed 親の「再実行」ボタンを実際に再分解に倒す (#133)

### DIFF
--- a/src/entities/task/decompose-server.test.ts
+++ b/src/entities/task/decompose-server.test.ts
@@ -255,14 +255,30 @@ describe("decomposeTask", () => {
     expect(generate).not.toHaveBeenCalled();
   });
 
-  test("既に failed → 再分解しない (再実行は詳細パネルから明示的に行う想定 / ADR 0021)", async () => {
-    const { client } = makeSupabase(defaultPlan(makeParentRow({ decompose_status: "failed" })));
-    const generate = vi.fn();
+  test("既に failed → 詳細パネル「再実行」で再分解できる (ADR 0021 §1: failed → decomposing を許容)", async () => {
+    const { client, calls } = makeSupabase(
+      defaultPlan(makeParentRow({ decompose_status: "failed" })),
+    );
+    const rawResponse = JSON.stringify([
+      { title: "子A", estimated_minutes: 30 },
+      { title: "子B", estimated_minutes: 15 },
+    ]);
+    const generate = vi.fn(async () => rawResponse);
 
     const result = await decomposeTask(makeDeps({ client, generate }));
 
-    expect(result).toEqual({ kind: "skipped", reason: "already_resolved" });
-    expect(generate).not.toHaveBeenCalled();
+    expect(result).toEqual({ kind: "decomposed", childIds: ["child-1", "child-2"] });
+    expect(generate).toHaveBeenCalledOnce();
+    expect(calls.statusUpdates).toEqual([
+      { id: "parent-1", decompose_status: "decomposing" },
+      { id: "parent-1", decompose_status: "decomposed" },
+    ]);
+    // 再実行の試行履歴が action_logs に残る (#133 / ADR 0021)
+    expect(calls.actionLogs).toHaveLength(1);
+    expect(calls.actionLogs[0]).toMatchObject({
+      action_type: "task_decomposed",
+      task_id: "parent-1",
+    });
   });
 
   test("AI が parse 不能なテキストを返す → failed に倒し task_decompose_failed を記録 (ADR 0021)", async () => {

--- a/src/entities/task/decompose-server.ts
+++ b/src/entities/task/decompose-server.ts
@@ -46,8 +46,9 @@ export type DecomposeTaskDeps = {
 };
 
 const SKIP_STATUSES = new Set(["active", "paused", "done"]);
-// `failed` も「終端」なので二重分解させない。再実行は詳細パネルから明示的に none → decomposing で行う (ADR 0021)。
-const ALREADY_RESOLVED = new Set(["decomposed", "skipped", "failed"]);
+// 終端のうち「再分解しない」ものだけ。`failed` は ADR 0021 §1 で `failed → decomposing` を
+// 明示的に許容しているので含めない（詳細パネルの「再実行」ボタンが直接ここを通る）。
+const ALREADY_RESOLVED = new Set(["decomposed", "skipped"]);
 
 export async function decomposeTask(deps: DecomposeTaskDeps): Promise<DecomposeTaskOutcome> {
   const { supabase, userId, taskId, generate } = deps;


### PR DESCRIPTION
## 概要 (What)

`decompose_status='failed'` の親で詳細パネルから「再実行」を押しても no-op で終わり `action_logs` も増えない問題を修正する。`failed → decomposing` を許容することで、リトライ履歴が正しく `action_logs` に積まれるようになる。

## 関連 Issue

Closes #133

## 背景 (Why)

ADR 0021 §1 の状態遷移表は `failed → decomposing` を明示的に許容しているが、実装側 (`decompose-server.ts`) は `ALREADY_RESOLVED` に `failed` を含めており、`decomposeTask` 冒頭で短絡して `{ kind: "skipped", reason: "already_resolved" }` を返していた。

結果として:

- `setDecomposeStatus("decomposing")` も `runDecompose` も走らない
- `task_decomposed` / `task_decompose_failed` / `task_decompose_skipped` のいずれも `action_logs` に積まれない
- ユーザーから見ると押せるボタンが無反応に見える

ADR 0021 は「失敗が user に見える / recovery が押せる / 履歴が残る」を不変条件として置いているので、実装と ADR が矛盾している状態だった。既存テストもバグ寄りに固定されており、ADR と整合する側に逆転する必要があった。

- 関連 ADR: [ADR 0021 §1](../blob/main/docs/adr/0021-ai-decomposition-failure-visibility.md) (状態遷移表)

## Before → After (概念・フロー・メンタルモデル)

**Before:** `failed` は `decomposed` / `skipped` と同列の「再分解しない終端」扱い。再実行ボタンを押しても何も起きず、復帰には DB 直叩き (`update tasks set decompose_status='none'`) が必要だった。

**After:** `failed` は ADR 0021 §1 のとおり「終端だが再入口を持つ」状態。再実行ボタンが直接 `decomposing` への遷移をトリガし、結果は `action_logs` に積まれて履歴として残る。`decomposed` / `skipped` は引き続き再分解不可（本 PR の scope 外）。

## 追加したテスト (How verified)

- [x] 既存テスト「既に failed → 再分解しない」を「failed → 再実行で `decomposing → decomposed` に倒れて `task_decomposed` が action_logs に積まれる」に逆転
- [x] `decomposed` / `skipped` は引き続き短絡で `skipped/already_resolved` を返す既存テストが通ることを確認
- [x] `npm test` 全 415 件 passed / `lint` / `typecheck` / `format:check` clean
- [ ] 手動: failed 親に対する詳細パネルからの再実行で実際に再分解が走ることは未検証 (要 dev 環境確認)

## このPRの範囲外 (Out of scope)

- `decomposing` 状態に対する race guard 強化 (issue #133 §修正方針 4 のとおり別 issue 化候補)
- `decomposed` / `skipped` からの再分解 (ADR 0021 Notes / Alternatives で別判断と整理済み)
- 再実行ボタンの enable 条件 / UI 側の検証 (本 PR は server 側のロジック修正のみ)


---
_Generated by [Claude Code](https://claude.ai/code/session_01M2hcjfkYLzLkFe5rYHfkCN)_