### PR TITLE
feat(ci): PR ごとに DB migration の schema diff を自動コメントする (ADR-0023)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,21 @@ jobs:
       # ===== ADR 0023: PR migration diff comment =====
       # 以下のステップは pull_request イベントのみで動かす (main への push では diff 元がない)。
 
+      # Supabase local stack は PG 17 を使うので、pg_dump も 17 を入れる。
+      # Ubuntu runner default の 16 だと server version mismatch で aborting。
+      # db-migrate.yml と同じパターン (pgdg apt repo から install + PATH 先頭に追加)。
+      - name: Install PostgreSQL 17 client tools
+        if: github.event_name == 'pull_request'
+        run: |
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+            -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+          sudo sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client-17
+          test -x /usr/lib/postgresql/17/bin/pg_dump
+          echo "/usr/lib/postgresql/17/bin" >> "$GITHUB_PATH"
+
       - name: Resolve local DB URL
         if: github.event_name == 'pull_request'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,12 +129,24 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   supabase:
+    # ADR 0023: PR の場合は本 job 内で main / PR それぞれの schema snapshot を取り、
+    # 構造化 diff + 規約検査を sticky comment として投稿する。
+    # 別 workflow に切り出すと `supabase start` (2 分強) を二重に払うので、
+    # ここに集約することで追加コストは `db reset` 1 回 + snapshot + 投稿で +20 秒程度。
     name: Supabase migrations
     needs: changes
     if: needs.changes.outputs.supabase == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # sticky-pull-request-comment が PR にコメントを投稿するために必要。
+      # fork PR では GitHub 側で read に降格されるので、その場合は投稿が skip される (job 自体は通る)。
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          # base SHA から `supabase/migrations/` をチェックアウトし直すために full history が要る
+          fetch-depth: 0
       - uses: supabase/setup-cli@v1
         with:
           version: latest
@@ -146,6 +158,98 @@ jobs:
         run: supabase db lint
       - name: Reset DB (re-apply all migrations from scratch)
         run: supabase db reset --no-seed
+
+      # ===== ADR 0023: PR migration diff comment =====
+      # 以下のステップは pull_request イベントのみで動かす (main への push では diff 元がない)。
+
+      - name: Resolve local DB URL
+        if: github.event_name == 'pull_request'
+        run: |
+          supabase status -o env > /tmp/sb.env
+          db_url=$(grep '^DB_URL=' /tmp/sb.env | cut -d= -f2- | tr -d '"')
+          echo "DATABASE_URL=$db_url" >> "$GITHUB_ENV"
+
+      - name: Snapshot PR-state (HEAD migrations applied)
+        if: github.event_name == 'pull_request'
+        run: |
+          mkdir -p /tmp/migration-diff
+          bash scripts/db-migration-diff/snapshot.sh \
+            "$DATABASE_URL" /tmp/migration-diff/pr.json
+          pg_dump --schema-only --schema=public --no-owner --no-privileges \
+            --dbname="$DATABASE_URL" > /tmp/migration-diff/pr.sql
+
+      - name: List new migration files in this PR
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git diff --name-only --diff-filter=A "$BASE_SHA"...HEAD -- supabase/migrations/ \
+            > /tmp/migration-diff/new_migrations.txt || true
+          echo "new migrations:"
+          cat /tmp/migration-diff/new_migrations.txt || true
+
+      - name: Checkout base migrations and reset DB
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          # PR で追加 / 変更された migration ファイルを base 状態に巻き戻す
+          git checkout "$BASE_SHA" -- supabase/migrations/
+          supabase db reset --no-seed
+
+      - name: Snapshot base-state
+        if: github.event_name == 'pull_request'
+        run: |
+          bash scripts/db-migration-diff/snapshot.sh \
+            "$DATABASE_URL" /tmp/migration-diff/base.json
+          pg_dump --schema-only --schema=public --no-owner --no-privileges \
+            --dbname="$DATABASE_URL" > /tmp/migration-diff/base.sql
+
+      - name: Restore HEAD migrations
+        if: github.event_name == 'pull_request'
+        run: |
+          git checkout HEAD -- supabase/migrations/
+
+      - name: Compute schema diff
+        if: github.event_name == 'pull_request'
+        run: |
+          # diff は差分があれば exit 1。`|| true` で workflow を落とさない
+          diff -u /tmp/migration-diff/base.sql /tmp/migration-diff/pr.sql \
+            > /tmp/migration-diff/schema.diff || true
+
+      - name: Render comment markdown
+        if: github.event_name == 'pull_request'
+        id: render
+        run: |
+          # compare.mjs は規約違反があると exit 1。コメント投稿後に fail させたいので
+          # ここではいったん exit code を握りつぶし、output に保存する。
+          set +e
+          node scripts/db-migration-diff/compare.mjs \
+            /tmp/migration-diff/base.json \
+            /tmp/migration-diff/pr.json \
+            /tmp/migration-diff/schema.diff \
+            /tmp/migration-diff/new_migrations.txt \
+            > /tmp/migration-diff/comment.md
+          rc=$?
+          set -e
+          echo "exit_code=$rc" >> "$GITHUB_OUTPUT"
+          echo "::group::Rendered comment"
+          cat /tmp/migration-diff/comment.md
+          echo "::endgroup::"
+
+      - name: Post sticky comment to PR
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: db-migration-diff
+          path: /tmp/migration-diff/comment.md
+
+      - name: Fail if migration assertions raised errors
+        if: github.event_name == 'pull_request' && steps.render.outputs.exit_code != '0'
+        run: |
+          echo "::error::Migration diff の規約チェックで ❌ が検出されました。投稿された PR コメントを確認してください"
+          exit 1
+
       - name: Stop Supabase
         if: always()
         run: supabase stop --no-backup || true

--- a/docs/adr/0023-pr-migration-diff-auto-comment.md
+++ b/docs/adr/0023-pr-migration-diff-auto-comment.md
@@ -1,0 +1,113 @@
+# ADR 0023: PR ごとに DB migration の schema diff を自動コメントする
+
+- **Status**: Accepted
+- **Date**: 2026-04-29
+- **Related**: [ADR-0019](./0019-db-migration-via-manual-github-actions.md) / [ADR-0020](./0020-db-migration-credential-as-db-connection-string.md)
+
+## Context
+
+ADR-0019 で本番 migration は `workflow_dispatch` の手動 trigger + approval で適用すると決めた。
+approval gate の目的は **「破壊的 migration の事故防止」** であり、approve するためには
+**migration を読んで安全か判断できる** 必要がある。
+
+しかし `supabase/migrations/*.sql` を読むだけでは以下が見えにくい:
+
+- 既存行への影響（NOT NULL カラムを default なしで追加していないか / enum 値削除がないか）
+- RLS 規約（`public` の新テーブルに RLS が有効化されているか / owner-only ポリシー 4 種が揃っているか）
+- 外部キーの ON DELETE policy（`CASCADE` / `SET NULL` / `RESTRICT` / 未指定）
+- 「migration を全部当てた後の最終的なスキーマ」と main のスキーマの差分
+
+スマホで approve する運用（ADR-0019）では、SQL ファイルを開いて読むコストがさらに高い。
+PR の段階で **最終スキーマの差分とプロジェクト規約違反の自動検査** をコメントとして出せば、
+approve 判断が「コメントを読む」だけで完結する。
+
+## Decision
+
+`supabase/migrations/**` を変更する PR に対し、**既存 `.github/workflows/ci.yml` の
+`supabase` job を拡張**して、main / PR それぞれに migration を適用したスキーマの
+スナップショットを取り、構造化された差分とプロジェクト規約違反のチェック結果を
+sticky コメントとして PR に投稿する。
+
+- 別 workflow に切り出さない。既存 `supabase` job が既に `supabase start` +
+  `supabase db reset --no-seed` でフル migration 適用状態を作っているため、
+  その状態を再利用すれば追加コストは **`db reset` 1 回 + snapshot + 投稿で +20 秒程度**
+  で済む。別 workflow にすると `supabase start` (2 分強) を二重に払うことになる
+- Trigger: 既存 `supabase` job と同じ (`pull_request` で `supabase/**` が変更された時)
+- 差分の出し方: `pg_dump --schema-only` の生 diff + `information_schema` / `pg_catalog` から
+  取った構造化スナップショットの diff の両方を出す
+- 規約チェック (`❌` / `⚠️` / `✅`):
+  - `❌` `public` の新テーブルに RLS が有効化されていない
+  - `❌` カラム追加で NOT NULL かつ default なし（既存行で fail）
+  - `❌` enum 値の削除（互換性破壊）
+  - `⚠️` `public` の新テーブルで owner-only ポリシー 4 種（select / insert / update / delete）が揃っていない
+  - `⚠️` 外部キーの ON DELETE policy が未指定（`NO ACTION` のまま）
+- `❌` が一つでもあれば workflow は fail（job exit code 非ゼロ）。`⚠️` は警告のみ
+- コメントは [marocchino/sticky-pull-request-comment](https://github.com/marocchino/sticky-pull-request-comment) で
+  push のたびに同じコメントを上書き更新する
+- workflow から本番 DB へは一切接続しない。ephemeral Supabase local stack のみ使う
+
+## Consequences
+
+### 肯定的影響
+
+- **ADR-0019 の approval gate が実効的になる**。スマホで approve する時に「この PR を当てると
+  既存行が NULL violation で落ちる」「RLS が外れている」が一目で分かる
+- **kozutsumi 規約の自動検査ができる**。RLS / owner-only policy の付け忘れ、ON DELETE の指定漏れを
+  人間レビュー前に弾ける
+- **生 diff も併載する**ので、構造化サマリで取りこぼしたケース（COMMENT 追加・関数追加 etc）も
+  reviewer が拾える
+- **本番 DB に触らない**。ADR-0020 の DB credential を使わない（fork PR 等の経路でも安全）
+
+### 否定的影響・トレードオフ
+
+- **CI 時間が +2〜3 分**。`supabase start` が支配的（2 分強）。`supabase/migrations/**` を
+  変更する PR でしか走らないので、頻度は低い
+- **構造化スナップショットのカバレッジは限定的**。本 ADR では columns / tables / constraints /
+  foreign_keys / indexes / policies / enums のみ対象。functions / triggers / sequences は
+  生 diff のみ（必要になったら別 ADR で拡張）
+- **規約チェックは false positive を起こしうる**。例外的に RLS を意図的に外したい場合の
+  override 機構は持たない（必要になったら別 ADR で扱う）
+- **fork PR からの実行**は制限される。`pull_request` トリガーで `pull-requests: write` 権限を
+  与えるため、`pull_request` イベントの fork PR では権限が read に降格する。kozutsumi は
+  個人開発で fork PR の想定はないので許容
+
+### 規約チェックの失敗を fail にする線引き
+
+`❌` (fail) と `⚠️` (warn) の線引きは **「migration を main に merge した時点で本番に
+既知の問題が混入するか」** で判定する:
+
+- `❌`: merge → workflow 手動 trigger で本番に流すと **必ず壊れる / セキュリティ違反になる**
+  （NOT NULL violation / RLS なし / enum 値削除）
+- `⚠️`: 規約上望ましくないが、merge しても直ちに壊れない（owner policy 不足は他のクライアントが
+  ないため即時の漏洩にはならない / ON DELETE 未指定は意図的なケースもありうる）
+
+`⚠️` を fail に格上げするかどうかは運用しながら判断する（本 ADR では含めない）。
+
+## Alternatives considered
+
+- **生 `pg_dump` diff のみコメント**: 実装は簡単だが、レビュアーが diff を読んで規約違反を
+  目視で拾う必要がある。スマホでの approve コストが下がらないため不採用
+- **専用 workflow ファイルとして新規作成**: 責務が明確になるが、`supabase start` を二重に
+  払う (CI 時間 +2 分強)。既存 `supabase` job も migration 適用がメインの仕事なので、
+  「migration を当ててみる + 差分を出す」を 1 job に集約する方が責務として綺麗
+- **`supabase db diff` ベース**: Supabase CLI 提供の diff 機能。生成 SQL の質は
+  pg_dump diff より読みやすいが、構造化サマリ（カラム単位の Nullable / Default や RLS 検査）には
+  使えない。生 diff としては選択肢になりうるが、本 ADR では `pg_dump --schema-only` の diff に
+  揃える（migration workflow 側の `pg_dump` (ADR-0020) と道具を統一する）
+- **PR ブランチへの自動コミット (生成スキーマを `supabase/schema.sql` として commit)**:
+  push 権限の管理（PAT / GitHub App）と fork PR の扱いが複雑になる。人間がレビューするのは
+  「結果がどう変わるか」であり、ファイルとして commit する必要はない。コメントで足りる
+- **規約違反は警告のみで fail させない**: 規約違反が混入した PR が approve されると
+  本番に流れる。approval gate は規約違反まで弾く設計ではない（破壊的変更の事故防止が主目的）ため、
+  ここは CI 側で fail させる方が役割分担として明確
+
+## Notes
+
+- 構造化スナップショットの収集対象は `public` schema のみ。`auth` / `storage` 等の
+  Supabase 管理スキーマは触らない
+- 本 ADR は **migration の可視化と自動レビュー** が目的。本番への適用フローは ADR-0019 の
+  手動 workflow に従う（自動適用に寄せる ADR ではない）
+- 将来見直す条件:
+  - 構造化スナップショットの対象を functions / triggers に広げたくなった
+  - `⚠️` レベルの違反も fail にしたくなった（例: RLS policy 不足を厳格化）
+  - Supabase CLI の `db diff` が pg_dump diff を超える品質になった

--- a/scripts/db-migration-diff/compare.mjs
+++ b/scripts/db-migration-diff/compare.mjs
@@ -1,0 +1,508 @@
+#!/usr/bin/env node
+// public schema の snapshot JSON 2 つを比較して、PR コメント用 markdown を stdout に出す。
+//
+// 使い方:
+//   node scripts/db-migration-diff/compare.mjs \
+//     <base.json> <pr.json> <schema_diff.txt> <new_migrations.txt> > comment.md
+//
+// 引数:
+//   base.json            : main 適用後の snapshot (snapshot.sql の出力)
+//   pr.json              : PR 適用後の snapshot
+//   schema_diff.txt      : pg_dump --schema-only の生 diff (diff -u 出力)
+//   new_migrations.txt   : PR で新規追加された migration ファイル名 (1 行 1 ファイル)
+//
+// 終了コード:
+//   0 - 規約違反 (`❌`) なし
+//   1 - 規約違反あり (CI で fail させる)
+//
+// ADR 0023 を参照。
+
+import { readFile } from "node:fs/promises";
+import { argv, exit, stdout } from "node:process";
+
+const [, , basePath, prPath, schemaDiffPath, newMigrationsPath] = argv;
+
+if (!basePath || !prPath || !schemaDiffPath || !newMigrationsPath) {
+  console.error("usage: compare.mjs <base.json> <pr.json> <schema_diff.txt> <new_migrations.txt>");
+  exit(2);
+}
+
+const [base, pr, schemaDiff, newMigrationsRaw] = await Promise.all([
+  readJson(basePath),
+  readJson(prPath),
+  readFile(schemaDiffPath, "utf8").catch(() => ""),
+  readFile(newMigrationsPath, "utf8").catch(() => ""),
+]);
+
+const newMigrations = newMigrationsRaw
+  .split("\n")
+  .map((line) => line.trim())
+  .filter(Boolean);
+
+const report = buildReport(base, pr);
+const assertions = runAssertions(report, pr);
+const md = renderMarkdown({ report, assertions, schemaDiff, newMigrations });
+
+stdout.write(md);
+exit(assertions.failed ? 1 : 0);
+
+// ---- IO ----
+
+async function readJson(path) {
+  const raw = await readFile(path, "utf8");
+  return JSON.parse(raw);
+}
+
+// ---- Diff ----
+
+function buildReport(before, after) {
+  return {
+    tables: diffByKey(before.tables, after.tables, (t) => `${t.schema}.${t.table}`),
+    columns: diffByKey(before.columns, after.columns, (c) => `${c.schema}.${c.table}.${c.column}`),
+    constraints: diffByKey(
+      before.constraints,
+      after.constraints,
+      (k) => `${k.schema}.${k.table}.${k.name}`,
+    ),
+    foreignKeys: diffByKey(
+      before.foreign_keys,
+      after.foreign_keys,
+      (f) => `${f.schema}.${f.table}.${f.name}`,
+    ),
+    indexes: diffByKey(before.indexes, after.indexes, (i) => `${i.schema}.${i.table}.${i.name}`),
+    policies: diffByKey(before.policies, after.policies, (p) => `${p.schema}.${p.table}.${p.name}`),
+    enums: diffEnums(before.enums, after.enums),
+  };
+}
+
+// 共通 diff: key で揃えて added / removed / modified に分類する
+function diffByKey(beforeArr, afterArr, keyFn) {
+  const before = new Map();
+  for (const item of beforeArr ?? []) before.set(keyFn(item), item);
+  const after = new Map();
+  for (const item of afterArr ?? []) after.set(keyFn(item), item);
+
+  const added = [];
+  const removed = [];
+  const modified = [];
+
+  for (const [key, item] of after) {
+    if (!before.has(key)) {
+      added.push(item);
+    } else if (!shallowEqual(before.get(key), item)) {
+      modified.push({ before: before.get(key), after: item });
+    }
+  }
+  for (const [key, item] of before) {
+    if (!after.has(key)) removed.push(item);
+  }
+  return { added, removed, modified };
+}
+
+// enum は values 配列まで含めた値追加 / 削除を出すので個別処理
+function diffEnums(beforeArr, afterArr) {
+  const before = new Map();
+  for (const e of beforeArr ?? []) before.set(`${e.schema}.${e.name}`, e);
+  const after = new Map();
+  for (const e of afterArr ?? []) after.set(`${e.schema}.${e.name}`, e);
+
+  const added = [];
+  const removed = [];
+  const modified = [];
+
+  for (const [key, e] of after) {
+    if (!before.has(key)) {
+      added.push(e);
+    } else {
+      const prev = before.get(key);
+      const prevValues = prev.values ?? [];
+      const nextValues = e.values ?? [];
+      const valuesAdded = nextValues.filter((v) => !prevValues.includes(v));
+      const valuesRemoved = prevValues.filter((v) => !nextValues.includes(v));
+      if (valuesAdded.length || valuesRemoved.length) {
+        modified.push({ before: prev, after: e, valuesAdded, valuesRemoved });
+      }
+    }
+  }
+  for (const [key, e] of before) {
+    if (!after.has(key)) removed.push(e);
+  }
+  return { added, removed, modified };
+}
+
+function shallowEqual(a, b) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+// ---- Assertions (kozutsumi 規約チェック) ----
+
+function runAssertions(report, prSnapshot) {
+  const errors = [];
+  const warnings = [];
+  const oks = [];
+
+  // ❌ public の新テーブルに RLS が有効化されていない
+  for (const t of report.tables.added) {
+    if (t.schema !== "public") continue;
+    if (!t.rls_enabled) {
+      errors.push({
+        kind: "rls-missing",
+        message: `\`${t.schema}.${t.table}\` に RLS が有効化されていません`,
+        fix: `\`ALTER TABLE ${t.schema}.${t.table} ENABLE ROW LEVEL SECURITY;\` を追記`,
+      });
+    } else {
+      oks.push(`\`${t.schema}.${t.table}\` で RLS が有効化されている`);
+    }
+  }
+
+  // ❌ NOT NULL かつ default なしのカラム追加 (既存行で fail)
+  for (const c of report.columns.added) {
+    if (c.schema !== "public") continue;
+    // 既存テーブルへのカラム追加だけが対象 (新規テーブルは初期データなしなので問題ない)
+    const isNewTable = report.tables.added.some(
+      (t) => t.schema === c.schema && t.table === c.table,
+    );
+    if (isNewTable) continue;
+    if (c.nullable === "NO" && c.default === null) {
+      errors.push({
+        kind: "not-null-no-default",
+        message: `\`${c.schema}.${c.table}.${c.column}\` を NOT NULL かつ default なしで追加 (既存行で違反)`,
+        fix: "default 値を付けるか、まず NULL 可で追加 → backfill → NOT NULL 化に分割",
+      });
+    }
+  }
+
+  // ❌ enum 値の削除 (互換性破壊)
+  for (const e of report.enums.modified) {
+    if (e.valuesRemoved.length > 0) {
+      errors.push({
+        kind: "enum-value-removed",
+        message: `\`${e.before.schema}.${e.before.name}\` から enum 値を削除: ${e.valuesRemoved.map((v) => `\`${v}\``).join(", ")}`,
+        fix: "enum 値の削除は互換性破壊。値を残したまま使用箇所を移行する設計にする",
+      });
+    }
+  }
+
+  // ⚠️ 新規 public テーブルに owner-only ポリシー 4 種が揃っていない
+  const policiesByTable = new Map();
+  for (const p of prSnapshot.policies ?? []) {
+    const key = `${p.schema}.${p.table}`;
+    if (!policiesByTable.has(key)) policiesByTable.set(key, []);
+    policiesByTable.get(key).push(p);
+  }
+  for (const t of report.tables.added) {
+    if (t.schema !== "public") continue;
+    const key = `${t.schema}.${t.table}`;
+    const policies = policiesByTable.get(key) ?? [];
+    const cmds = new Set(policies.map((p) => p.command));
+    const need = ["SELECT", "INSERT", "UPDATE", "DELETE"];
+    const missing = need.filter((c) => !cmds.has(c) && !cmds.has("ALL"));
+    if (missing.length > 0 && t.rls_enabled) {
+      warnings.push({
+        kind: "policy-incomplete",
+        message: `\`${key}\` の policy 不足: ${missing.join(" / ")} が未定義`,
+        fix: "4 種すべてに policy を貼るか、ALL command で 1 本にまとめる",
+      });
+    } else if (missing.length === 0 && t.rls_enabled) {
+      oks.push(`\`${key}\` に owner policy 4 種が揃っている`);
+    }
+  }
+
+  // ⚠️ FK の ON DELETE policy が未指定 (NO ACTION のまま) かつ新規 FK
+  for (const f of report.foreignKeys.added) {
+    if (f.schema !== "public") continue;
+    if (f.delete_rule === "NO ACTION") {
+      warnings.push({
+        kind: "fk-no-on-delete",
+        message: `\`${f.schema}.${f.table}.${f.name}\` の ON DELETE が未指定 (NO ACTION)`,
+        fix: "`ON DELETE CASCADE / SET NULL / RESTRICT` のいずれかを明示する",
+      });
+    } else {
+      oks.push(
+        `\`${f.schema}.${f.table}.${f.name}\` の ON DELETE が明示されている (\`${f.delete_rule}\`)`,
+      );
+    }
+  }
+
+  return { errors, warnings, oks, failed: errors.length > 0 };
+}
+
+// ---- Markdown rendering ----
+
+function renderMarkdown({ report, assertions, schemaDiff, newMigrations }) {
+  const lines = [];
+  lines.push("## 🗄️ Migration diff");
+  lines.push("");
+
+  // ---- 新規 migration 一覧 ----
+  lines.push("**このPRで追加された migration**");
+  if (newMigrations.length === 0) {
+    lines.push("- _なし_ (`supabase/migrations/**` に新規ファイルなし)");
+  } else {
+    for (const m of newMigrations) lines.push(`- \`${m}\``);
+  }
+  lines.push("");
+  lines.push(
+    "**適用チェック**: ✅ main の上にクリーンに適用できました（ephemeral Supabase local stack）",
+  );
+  lines.push("");
+
+  // ---- サマリ ----
+  lines.push("### サマリ");
+  lines.push("");
+  lines.push("| カテゴリ | 変更 |");
+  lines.push("|---|---|");
+  lines.push(`| テーブル | ${summarizeTables(report.tables)} |`);
+  lines.push(`| 型 (enum) | ${summarizeEnums(report.enums)} |`);
+  lines.push(`| インデックス | ${summarizeSimple(report.indexes, "インデックス")} |`);
+  lines.push(`| RLS / ポリシー | ${summarizePolicies(report.tables, report.policies)} |`);
+  lines.push(`| 制約 | ${summarizeConstraints(report.constraints, report.foreignKeys)} |`);
+  lines.push("");
+
+  // ---- 新規テーブル詳細 ----
+  if (report.tables.added.length > 0) {
+    lines.push("### 新規テーブルの詳細");
+    lines.push("");
+    for (const t of report.tables.added) {
+      lines.push(...renderNewTableSection(t, report));
+      lines.push("");
+    }
+  }
+
+  // ---- 既存テーブルへのカラム追加詳細 ----
+  const addedColumnsOnExistingTables = report.columns.added.filter((c) => {
+    return !report.tables.added.some((t) => t.schema === c.schema && t.table === c.table);
+  });
+  if (addedColumnsOnExistingTables.length > 0) {
+    lines.push("### カラムの詳細");
+    lines.push("");
+    lines.push("| テーブル | 列 | 型 | NULL | デフォルト | 既存行への影響 |");
+    lines.push("|---|---|---|---|---|---|");
+    for (const c of addedColumnsOnExistingTables) {
+      lines.push(
+        `| \`${c.schema}.${c.table}\` | \`${c.column}\` | \`${formatType(c)}\` | ${c.nullable === "YES" ? "✅ NULL 可" : "NOT NULL"} | ${formatDefault(c.default)} | ${describeBackfillImpact(c)} |`,
+      );
+    }
+    lines.push("");
+  }
+
+  // ---- enum 値の追加 / 削除 ----
+  if (report.enums.modified.length > 0) {
+    lines.push("### Enum の変更");
+    lines.push("");
+    for (const e of report.enums.modified) {
+      const parts = [];
+      if (e.valuesAdded.length) parts.push(`+ ${e.valuesAdded.map((v) => `\`${v}\``).join(", ")}`);
+      if (e.valuesRemoved.length)
+        parts.push(`- ${e.valuesRemoved.map((v) => `\`${v}\``).join(", ")}`);
+      lines.push(`- \`${e.before.schema}.${e.before.name}\`: ${parts.join(" / ")}`);
+    }
+    lines.push("");
+  }
+
+  // ---- 検査 ----
+  lines.push("### 検査");
+  lines.push("");
+  for (const e of assertions.errors) {
+    lines.push(`- ❌ **${e.message}**`);
+    if (e.fix) lines.push(`  - 修正: ${e.fix}`);
+  }
+  for (const w of assertions.warnings) {
+    lines.push(`- ⚠️ ${w.message}`);
+    if (w.fix) lines.push(`  - 修正: ${w.fix}`);
+  }
+  for (const ok of assertions.oks) {
+    lines.push(`- ✅ ${ok}`);
+  }
+  if (
+    assertions.errors.length === 0 &&
+    assertions.warnings.length === 0 &&
+    assertions.oks.length === 0
+  ) {
+    lines.push("- ℹ️ 検査対象なし (テーブル / カラム / enum / FK の追加変更がない)");
+  }
+  lines.push("");
+
+  // ---- 生 diff ----
+  lines.push("<details>");
+  lines.push(
+    "<summary>生スキーマ diff (<code>pg_dump --schema-only</code>) — クリックで展開</summary>",
+  );
+  lines.push("");
+  if (schemaDiff.trim() === "") {
+    lines.push("_スキーマ差分なし (migration が no-op か、コメントのみ)_");
+  } else {
+    lines.push("```diff");
+    // GitHub のコメントは 65,536 文字まで。長すぎたら切る
+    const truncated = truncateForComment(schemaDiff, 50000);
+    lines.push(truncated);
+    lines.push("```");
+  }
+  lines.push("");
+  lines.push("</details>");
+  lines.push("");
+  lines.push(
+    "<sub>`.github/workflows/ci.yml` の <code>supabase</code> job が生成 / push のたびに更新</sub>",
+  );
+
+  return lines.join("\n") + "\n";
+}
+
+// ---- Summary helpers ----
+
+function summarizeTables({ added, removed, modified }) {
+  const parts = [];
+  if (added.length)
+    parts.push(`${added.length} 件追加 (${added.map((t) => `\`${t.table}\``).join(", ")})`);
+  if (removed.length)
+    parts.push(`⚠️ ${removed.length} 件削除 (${removed.map((t) => `\`${t.table}\``).join(", ")})`);
+  if (modified.length)
+    parts.push(
+      `${modified.length} 件変更 (${modified.map((m) => `\`${m.after.table}\``).join(", ")})`,
+    );
+  return parts.length ? parts.join(" / ") : "変更なし";
+}
+
+function summarizeSimple({ added, removed, modified }, label) {
+  const parts = [];
+  if (added.length) parts.push(`${added.length} 件追加`);
+  if (removed.length) parts.push(`⚠️ ${removed.length} 件削除`);
+  if (modified.length) parts.push(`${modified.length} 件変更`);
+  return parts.length ? parts.join(" / ") : "変更なし";
+}
+
+function summarizeEnums({ added, removed, modified }) {
+  const parts = [];
+  if (added.length)
+    parts.push(`${added.length} 件追加 (${added.map((e) => `\`${e.name}\``).join(", ")})`);
+  if (removed.length)
+    parts.push(`⚠️ ${removed.length} 件削除 (${removed.map((e) => `\`${e.name}\``).join(", ")})`);
+  if (modified.length) {
+    const summaries = modified.map((m) => {
+      const a = m.valuesAdded.length ? `+${m.valuesAdded.length}` : "";
+      const r = m.valuesRemoved.length ? `-${m.valuesRemoved.length}` : "";
+      return `\`${m.before.name}\` (${[a, r].filter(Boolean).join(" / ")})`;
+    });
+    parts.push(`値変更: ${summaries.join(", ")}`);
+  }
+  return parts.length ? parts.join(" / ") : "変更なし";
+}
+
+function summarizePolicies(tables, policies) {
+  const parts = [];
+  const newTablesWithRls = tables.added.filter((t) => t.rls_enabled);
+  if (newTablesWithRls.length) {
+    parts.push(`新規テーブル ${newTablesWithRls.length} 件で RLS 有効化`);
+  }
+  if (policies.added.length) parts.push(`policy ${policies.added.length} 件追加`);
+  if (policies.removed.length) parts.push(`⚠️ policy ${policies.removed.length} 件削除`);
+  if (policies.modified.length) parts.push(`policy ${policies.modified.length} 件変更`);
+  return parts.length ? parts.join(" / ") : "変更なし";
+}
+
+function summarizeConstraints(constraints, foreignKeys) {
+  const parts = [];
+  const fkAdded = foreignKeys.added.length;
+  const fkRemoved = foreignKeys.removed.length;
+  const otherAdded = constraints.added.length - fkAdded;
+  const otherRemoved = constraints.removed.length - fkRemoved;
+  if (otherAdded > 0) parts.push(`制約 ${otherAdded} 件追加`);
+  if (fkAdded > 0) parts.push(`FK ${fkAdded} 件追加`);
+  if (otherRemoved > 0) parts.push(`⚠️ 制約 ${otherRemoved} 件削除`);
+  if (fkRemoved > 0) parts.push(`⚠️ FK ${fkRemoved} 件削除`);
+  return parts.length ? parts.join(" / ") : "変更なし";
+}
+
+// ---- New table detail ----
+
+function renderNewTableSection(t, report) {
+  const lines = [];
+  lines.push(`#### \`${t.schema}.${t.table}\``);
+  lines.push("");
+
+  // Columns
+  const columns = report.columns.added.filter((c) => c.schema === t.schema && c.table === t.table);
+  if (columns.length) {
+    lines.push("| 列 | 型 | NULL | デフォルト |");
+    lines.push("|---|---|---|---|");
+    for (const c of columns) {
+      lines.push(
+        `| \`${c.column}\` | \`${formatType(c)}\` | ${c.nullable === "YES" ? "NULL 可" : "NOT NULL"} | ${formatDefault(c.default)} |`,
+      );
+    }
+    lines.push("");
+  }
+
+  // FKs
+  const fks = report.foreignKeys.added.filter((f) => f.schema === t.schema && f.table === t.table);
+  if (fks.length) {
+    lines.push("**外部キー**:");
+    for (const f of fks) {
+      const cols = (f.columns ?? []).map((c) => `\`${c}\``).join(", ");
+      const refCols = (f.ref_columns ?? []).map((c) => `\`${c}\``).join(", ");
+      lines.push(
+        `- ${cols} → \`${f.ref_schema}.${f.ref_table}\`(${refCols}) / **ON DELETE ${f.delete_rule}**`,
+      );
+    }
+    lines.push("");
+  }
+
+  // Policies
+  const policies = report.policies.added.filter(
+    (p) => p.schema === t.schema && p.table === t.table,
+  );
+  if (policies.length) {
+    lines.push("**RLS ポリシー**:");
+    lines.push("");
+    lines.push("| 種別 | 名前 | 条件 |");
+    lines.push("|---|---|---|");
+    for (const p of policies) {
+      const cond = [];
+      if (p.using) cond.push(`USING: \`${truncateInline(p.using)}\``);
+      if (p.with_check) cond.push(`WITH CHECK: \`${truncateInline(p.with_check)}\``);
+      lines.push(`| ${p.command} | \`${p.name}\` | ${cond.join("<br>")} |`);
+    }
+    lines.push("");
+  }
+
+  if (!t.rls_enabled) {
+    lines.push("> ⚠️ このテーブルは RLS が有効化されていません");
+    lines.push("");
+  }
+
+  return lines;
+}
+
+function describeBackfillImpact(c) {
+  if (c.nullable === "YES") {
+    return `既存行は ${c.default !== null ? `\`${formatDefault(c.default)}\`` : "`NULL`"} のまま（バックフィル不要）`;
+  }
+  // NOT NULL
+  if (c.default !== null) {
+    return `既存行は default \`${formatDefault(c.default)}\` でバックフィル`;
+  }
+  return "❌ 既存行で NOT NULL 違反 (default なし)";
+}
+
+function formatType(c) {
+  // information_schema.columns は USER-DEFINED の時 udt_name に enum 名が入る
+  if (c.type === "USER-DEFINED" && c.udt) return c.udt;
+  return c.type;
+}
+
+function formatDefault(d) {
+  if (d === null || d === undefined) return "なし";
+  return d;
+}
+
+function truncateInline(s) {
+  if (!s) return "";
+  if (s.length <= 80) return s;
+  return s.slice(0, 77) + "...";
+}
+
+function truncateForComment(s, max) {
+  if (s.length <= max) return s;
+  const head = s.slice(0, max);
+  return head + `\n... (truncated, ${s.length - max} more characters; full diff in workflow logs)`;
+}

--- a/scripts/db-migration-diff/snapshot.sh
+++ b/scripts/db-migration-diff/snapshot.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# public schema の構造化スナップショットを 1 行 JSON で出力する。
+#
+# 使い方:
+#   scripts/db-migration-diff/snapshot.sh "$DATABASE_URL" path/to/output.json
+#
+# scripts/db-migration-diff/snapshot.sql を psql に流すだけのラッパ。
+# ADR 0023 を参照。
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 DATABASE_URL OUTPUT_JSON_PATH" >&2
+  exit 2
+fi
+
+database_url="$1"
+output="$2"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# -At: aligned tuple-only。JSON 1 行が裸で出る (ヘッダ / 区切り / 末尾改行は psql 標準のまま)
+# --no-psqlrc: ローカル環境の psqlrc に左右されない
+psql "$database_url" --no-psqlrc -At -f "$script_dir/snapshot.sql" > "$output"

--- a/scripts/db-migration-diff/snapshot.sql
+++ b/scripts/db-migration-diff/snapshot.sql
@@ -1,0 +1,161 @@
+-- public schema の構造化スナップショットを 1 行 JSON で出力する。
+-- 出力先: stdout (psql -At で囲わずに JSON 1 行が出る)
+--
+-- 対象は public schema のみ (auth / storage / supabase_* は触らない)。
+-- 本ファイルは scripts/db-migration-diff/snapshot.sh から呼ばれる。
+--
+-- 構造はおおよそ:
+--   {
+--     "tables":      [{ schema, table, rls_enabled, rls_forced }],
+--     "columns":     [{ schema, table, column, type, udt, nullable, default, ordinal }],
+--     "constraints": [{ schema, table, name, type, definition }],
+--     "foreign_keys":[{ schema, table, name, columns, ref_schema, ref_table, ref_columns, delete_rule, update_rule }],
+--     "indexes":     [{ schema, table, name, definition }],
+--     "policies":    [{ schema, table, name, permissive, roles, command, using, with_check }],
+--     "enums":       [{ schema, name, values }]
+--   }
+
+with
+  tables as (
+    select coalesce(json_agg(t order by t->>'schema', t->>'table'), '[]'::json) as data
+    from (
+      select json_build_object(
+        'schema', n.nspname,
+        'table', c.relname,
+        'rls_enabled', c.relrowsecurity,
+        'rls_forced', c.relforcerowsecurity
+      ) as t
+      from pg_class c
+      join pg_namespace n on n.oid = c.relnamespace
+      where n.nspname = 'public' and c.relkind = 'r'
+    ) sub
+  ),
+  columns as (
+    select coalesce(json_agg(c order by c->>'schema', c->>'table', (c->>'ordinal')::int), '[]'::json) as data
+    from (
+      select json_build_object(
+        'schema', table_schema,
+        'table', table_name,
+        'column', column_name,
+        'type', data_type,
+        'udt', udt_name,
+        'nullable', is_nullable,
+        'default', column_default,
+        'ordinal', ordinal_position
+      ) as c
+      from information_schema.columns
+      where table_schema = 'public'
+    ) sub
+  ),
+  constraints as (
+    select coalesce(json_agg(k order by k->>'schema', k->>'table', k->>'name'), '[]'::json) as data
+    from (
+      select json_build_object(
+        'schema', n.nspname,
+        'table', cl.relname,
+        'name', con.conname,
+        'type', con.contype::text,
+        'definition', pg_get_constraintdef(con.oid)
+      ) as k
+      from pg_constraint con
+      join pg_class cl on cl.oid = con.conrelid
+      join pg_namespace n on n.oid = cl.relnamespace
+      where n.nspname = 'public'
+    ) sub
+  ),
+  foreign_keys as (
+    select coalesce(json_agg(f order by f->>'schema', f->>'table', f->>'name'), '[]'::json) as data
+    from (
+      select json_build_object(
+        'schema', n.nspname,
+        'table', cl.relname,
+        'name', con.conname,
+        'columns', (
+          select json_agg(att.attname order by u.ord)
+          from unnest(con.conkey) with ordinality as u(attnum, ord)
+          join pg_attribute att on att.attrelid = con.conrelid and att.attnum = u.attnum
+        ),
+        'ref_schema', rn.nspname,
+        'ref_table', rcl.relname,
+        'ref_columns', (
+          select json_agg(att.attname order by u.ord)
+          from unnest(con.confkey) with ordinality as u(attnum, ord)
+          join pg_attribute att on att.attrelid = con.confrelid and att.attnum = u.attnum
+        ),
+        'delete_rule', case con.confdeltype
+          when 'a' then 'NO ACTION'
+          when 'r' then 'RESTRICT'
+          when 'c' then 'CASCADE'
+          when 'n' then 'SET NULL'
+          when 'd' then 'SET DEFAULT'
+        end,
+        'update_rule', case con.confupdtype
+          when 'a' then 'NO ACTION'
+          when 'r' then 'RESTRICT'
+          when 'c' then 'CASCADE'
+          when 'n' then 'SET NULL'
+          when 'd' then 'SET DEFAULT'
+        end
+      ) as f
+      from pg_constraint con
+      join pg_class cl on cl.oid = con.conrelid
+      join pg_namespace n on n.oid = cl.relnamespace
+      join pg_class rcl on rcl.oid = con.confrelid
+      join pg_namespace rn on rn.oid = rcl.relnamespace
+      where n.nspname = 'public' and con.contype = 'f'
+    ) sub
+  ),
+  indexes as (
+    select coalesce(json_agg(i order by i->>'schema', i->>'table', i->>'name'), '[]'::json) as data
+    from (
+      select json_build_object(
+        'schema', schemaname,
+        'table', tablename,
+        'name', indexname,
+        'definition', indexdef
+      ) as i
+      from pg_indexes
+      where schemaname = 'public'
+    ) sub
+  ),
+  policies as (
+    select coalesce(json_agg(p order by p->>'schema', p->>'table', p->>'name'), '[]'::json) as data
+    from (
+      select json_build_object(
+        'schema', schemaname,
+        'table', tablename,
+        'name', policyname,
+        'permissive', permissive,
+        'roles', to_json(roles),
+        'command', cmd,
+        'using', qual,
+        'with_check', with_check
+      ) as p
+      from pg_policies
+      where schemaname = 'public'
+    ) sub
+  ),
+  enums as (
+    select coalesce(json_agg(e order by e->>'schema', e->>'name'), '[]'::json) as data
+    from (
+      select json_build_object(
+        'schema', n.nspname,
+        'name', t.typname,
+        'values', json_agg(e.enumlabel order by e.enumsortorder)
+      ) as e
+      from pg_type t
+      join pg_enum e on t.oid = e.enumtypid
+      join pg_namespace n on n.oid = t.typnamespace
+      where n.nspname = 'public'
+      group by n.nspname, t.typname
+    ) sub
+  )
+select json_build_object(
+  'tables', (select data from tables),
+  'columns', (select data from columns),
+  'constraints', (select data from constraints),
+  'foreign_keys', (select data from foreign_keys),
+  'indexes', (select data from indexes),
+  'policies', (select data from policies),
+  'enums', (select data from enums)
+);


### PR DESCRIPTION
## 概要 (What)

`supabase/migrations/**` を変更する PR に対し、main / PR それぞれに migration を適用したスキーマのスナップショットを取り、構造化差分 + kozutsumi 規約の自動検査結果を sticky コメントとして PR に投稿する。`❌` 検出時は CI を fail させる。

## 背景 (Why)

[ADR-0023](docs/adr/0023-pr-migration-diff-auto-comment.md) を参照。

ADR-0019 で本番 migration は手動 trigger + approval で適用すると決めたが、approval gate が機能するには **「migration を読んで安全か判断できる」** 必要がある。SQL ファイルだけでは:

- 既存行への影響（NOT NULL カラム追加で violation しないか）
- RLS 規約（新テーブルに RLS が有効化されているか / owner-only ポリシー 4 種が揃っているか）
- 外部キーの ON DELETE policy

が見えにくい。スマホで approve する運用ではさらにコストが高い。PR 段階で **最終スキーマの差分と規約違反の自動検査** をコメントで出せば、approve 判断が「コメントを読む」だけで完結する。

## Before → After (概念・フロー・メンタルモデル)

**Before:**
- migration 含む PR が来たら、レビュアーは `supabase/migrations/*.sql` を開いて目視で読む
- 「この migration を当てたらスキーマがどう変わるか」「既存行への影響」「規約違反」は人間が頭の中で再構成する
- スマホで approve する時、SQL を全部読むのが現実的に難しい

**After:**
- PR を出すと CI が自動で「main 適用後 vs PR 適用後」のスキーマを比較し、表形式のサマリ + 生 diff + 規約検査結果を sticky コメントで投稿
- 規約違反（RLS なし / NOT NULL 違反 / enum 値削除）があれば CI が fail する
- approve 判断はコメントを読むだけで完結。スマホでも approve 可能なフローになる

## 追加したテスト (How verified)

- [x] `compare.mjs` をローカルで 3 シナリオ smoke test:
  - enum 値追加 (P3-12 相当): ✅ exit 0、サマリに `+1`
  - 新規テーブル + RLS + ポリシー 4 種 (P2-3 相当): ✅ exit 0、規約検査全部 `✅`
  - 違反まみれ (RLS なし / NOT NULL no default / enum 値削除 / FK NO ACTION): ✅ exit 1、3 件の `❌` + 1 件の `⚠️`
- [x] `node --check`、`bash -n`、`python3 yaml.safe_load`、`prettier --check .` 通過
- [ ] **本 PR 自体では migration 変更がないため、このコメントが投稿されないことが期待される**（CI で確認したい）
- [ ] 実 migration を含む後続 PR で実際の出力を確認する（フィードバックがあれば調整）

## リリース前チェックリスト (When / Before merge)

- [x] ADR-0023 を起票した
- [x] CI 既存 `supabase` job への変更が他 step を壊さないことを確認（`Lint SQL` / `Reset DB` / `Stop Supabase` は順序維持）
- [ ] 既存ユーザーへの影響: なし（CI のみ・本番接続なし）

## このPRの範囲外 (Out of scope)

- **構造化スナップショットの拡張**: 現状は tables / columns / constraints / FKs / indexes / policies / enums。functions / triggers / sequences は生 diff のみで拾う。必要になれば別 ADR で拡張
- **`⚠️` レベルの fail 化**: owner policy 不足 / FK NO ACTION は警告のみ。運用しながら判断
- **CI ファイル分割**: `ci.yml` 1 本に全 job 集約のままで OK か、Supabase 必要 / 不要で分けるかは別議論（混ぜると本 PR のスコープがブレる）
- **migration 変更を伴う本 CI ステップの実 PR での動作確認**: 本 PR では migration を変更していないため、後続 PR で実出力を見る

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEbKwHaou2YTcxThE3Hs8v)_