### PR TITLE
fix(ci): migration diff CI が新規 migration の差分を取りこぼす不具合と view 未対応を修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,23 +193,34 @@ jobs:
           pg_dump --schema-only --schema=public --no-owner --no-privileges \
             --dbname="$DATABASE_URL" > /tmp/migration-diff/pr.sql
 
-      - name: List new migration files in this PR
+      - name: List new / missing migration files vs base
         if: github.event_name == 'pull_request'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
+          # 3-dot 構文 = fork point (merge base) からの差分。「PR ブランチで追加された」分。
           git diff --name-only --diff-filter=A "$BASE_SHA"...HEAD -- supabase/migrations/ \
             > /tmp/migration-diff/new_migrations.txt || true
+          # 逆向き: HEAD には無いが base (= main 現 HEAD) にあるファイル = rebase 必要 signal。
+          # 3-dot ではなく 2-dot で `git diff HEAD..BASE_SHA --diff-filter=A` を取ると
+          # 「HEAD に対して BASE_SHA で追加された」= HEAD に欠けている main の migration が出る。
+          git diff --name-only --diff-filter=A HEAD.."$BASE_SHA" -- supabase/migrations/ \
+            > /tmp/migration-diff/missing_migrations.txt || true
           echo "new migrations:"
           cat /tmp/migration-diff/new_migrations.txt || true
+          echo "missing (need rebase) migrations:"
+          cat /tmp/migration-diff/missing_migrations.txt || true
 
-      - name: Checkout base migrations and reset DB
+      - name: Restore base migrations and reset DB
         if: github.event_name == 'pull_request'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          # PR で追加 / 変更された migration ファイルを base 状態に巻き戻す
-          git checkout "$BASE_SHA" -- supabase/migrations/
+          # `git checkout <ref> -- <path>` は overlay モードで動くので、HEAD で新規追加された
+          # ファイルを working tree から消してくれない。`git restore` のデフォルトは
+          # no-overlay モードなので、`supabase/migrations/` を BASE_SHA と完全一致させ
+          # (= PR で追加した migration を物理削除) てから db reset できる。
+          git restore --source="$BASE_SHA" --worktree --staged -- supabase/migrations/
           supabase db reset --no-seed
 
       - name: Snapshot base-state
@@ -228,8 +239,16 @@ jobs:
       - name: Compute schema diff
         if: github.event_name == 'pull_request'
         run: |
+          # PostgreSQL 17 の pg_dump は出力先頭 / 末尾に `\restrict <ランダムトークン>` と
+          # `\unrestrict <ランダムトークン>` を吐く。トークンは dump のたびに変わるので、
+          # 残しておくと「実差分なし」のときも 2 行偽の diff が出てノイズになる。
+          # diff を取る前に両方の dump から落として比較する。
+          sed -E '/^\\(restrict|unrestrict)[[:space:]]/d' \
+            /tmp/migration-diff/base.sql > /tmp/migration-diff/base.normalized.sql
+          sed -E '/^\\(restrict|unrestrict)[[:space:]]/d' \
+            /tmp/migration-diff/pr.sql > /tmp/migration-diff/pr.normalized.sql
           # diff は差分があれば exit 1。`|| true` で workflow を落とさない
-          diff -u /tmp/migration-diff/base.sql /tmp/migration-diff/pr.sql \
+          diff -u /tmp/migration-diff/base.normalized.sql /tmp/migration-diff/pr.normalized.sql \
             > /tmp/migration-diff/schema.diff || true
 
       - name: Render comment markdown
@@ -244,6 +263,7 @@ jobs:
             /tmp/migration-diff/pr.json \
             /tmp/migration-diff/schema.diff \
             /tmp/migration-diff/new_migrations.txt \
+            /tmp/migration-diff/missing_migrations.txt \
             > /tmp/migration-diff/comment.md
           rc=$?
           set -e

--- a/docs/adr/0023-pr-migration-diff-auto-comment.md
+++ b/docs/adr/0023-pr-migration-diff-auto-comment.md
@@ -35,13 +35,28 @@ sticky コメントとして PR に投稿する。
 - Trigger: 既存 `supabase` job と同じ (`pull_request` で `supabase/**` が変更された時)
 - 差分の出し方: `pg_dump --schema-only` の生 diff + `information_schema` / `pg_catalog` から
   取った構造化スナップショットの diff の両方を出す
+- 構造化スナップショットの対象: tables (relkind in `r`/`v`/`m` を `kind` で識別) /
+  columns / constraints / foreign_keys / indexes / policies / enums / views
+  (definition + `security_invoker` / `security_barrier` reloptions)
 - 規約チェック (`❌` / `⚠️` / `✅`):
   - `❌` `public` の新テーブルに RLS が有効化されていない
   - `❌` カラム追加で NOT NULL かつ default なし（既存行で fail）
   - `❌` enum 値の削除（互換性破壊）
+  - `❌` 新規 view / matview に `security_invoker = true` が指定されていない（postgres の view は
+    未指定だと **definer 権限で評価され RLS をバイパス**するため、kozutsumi では原則必須）
+  - `❌` 既存 view の `security_invoker` が `true → false` に変更された（RLS 迂回経路ができる）
   - `⚠️` `public` の新テーブルで owner-only ポリシー 4 種（select / insert / update / delete）が揃っていない
   - `⚠️` 外部キーの ON DELETE policy が未指定（`NO ACTION` のまま）
 - `❌` が一つでもあれば workflow は fail（job exit code 非ゼロ）。`⚠️` は警告のみ
+- 比較は **PR の HEAD vs main の現 HEAD (`github.event.pull_request.base.sha`)** で行う。
+  fork point ではなく現 HEAD と比較するのは **「今この PR を merge した時の最終スキーマ」を
+  示すため**。副次効果として、main にあって HEAD に無い migration があれば
+  「rebase が必要」シグナルとしてコメント冒頭に warning を出す（PR ブランチが古いことを検知できる）
+- main 状態への巻き戻しは `git restore --source="$BASE_SHA" --worktree --staged --
+  supabase/migrations/` で行う（`git checkout <ref> --` は overlay モードで PR が追加した
+  新規ファイルを消せないため、base 状態が再現できない）
+- 生 diff 比較前に pg_dump 17 が出力する `\restrict` / `\unrestrict` のランダムトークン行を
+  両 dump から削除する（毎 dump で値が変わるため、実差分なしでも 2 行偽の diff が出るのを防ぐ）
 - コメントは [marocchino/sticky-pull-request-comment](https://github.com/marocchino/sticky-pull-request-comment) で
   push のたびに同じコメントを上書き更新する
 - workflow から本番 DB へは一切接続しない。ephemeral Supabase local stack のみ使う
@@ -63,8 +78,8 @@ sticky コメントとして PR に投稿する。
 - **CI 時間が +2〜3 分**。`supabase start` が支配的（2 分強）。`supabase/migrations/**` を
   変更する PR でしか走らないので、頻度は低い
 - **構造化スナップショットのカバレッジは限定的**。本 ADR では columns / tables / constraints /
-  foreign_keys / indexes / policies / enums のみ対象。functions / triggers / sequences は
-  生 diff のみ（必要になったら別 ADR で拡張）
+  foreign_keys / indexes / policies / enums / views(definition + reloptions) のみ対象。
+  functions / triggers / sequences は生 diff のみ（必要になったら別 ADR で拡張）
 - **規約チェックは false positive を起こしうる**。例外的に RLS を意図的に外したい場合の
   override 機構は持たない（必要になったら別 ADR で扱う）
 - **fork PR からの実行**は制限される。`pull_request` トリガーで `pull-requests: write` 権限を
@@ -111,3 +126,21 @@ sticky コメントとして PR に投稿する。
   - 構造化スナップショットの対象を functions / triggers に広げたくなった
   - `⚠️` レベルの違反も fail にしたくなった（例: RLS policy 不足を厳格化）
   - Supabase CLI の `db diff` が pg_dump diff を超える品質になった
+- 改訂履歴:
+  - 2026-04-29: 初版（PR #136）
+  - **2026-04-29 改訂**:
+    - **base 状態巻き戻しの不具合修正**: 旧実装は `git checkout <BASE_SHA> --
+      supabase/migrations/` で base に戻していたが、これは overlay モードのため PR が
+      新規追加した migration ファイルを working tree から消せず、`supabase db reset`
+      で **PR の migration が base 側にも適用される** バグがあった。結果、構造化サマリ /
+      生 diff いずれも「変更なし」になり、新規 migration が事実上スキップされていた
+      （PR #135 のコメントが該当例）。`git restore --no-overlay` 相当に置換して修正
+    - 構造化スナップショットに **view / matview** を追加。columns 側にも `kind` を付け、
+      view 由来の列が「既存テーブルへのカラム追加」として誤検出されないようにした
+    - **`security_invoker = true`** を新規 view の必須要件として追加（未指定 view は
+      definer 権限で評価され RLS を迂回するため）。既存 view からの `security_invoker`
+      除去も `❌` 扱い
+    - main 現 HEAD 比較の副次効果として **rebase 必要シグナル** をコメント冒頭に表示
+      （main にあって HEAD に無い migration を検出してリスト表示）
+    - 生 diff 比較前に pg_dump 17 の `\restrict` / `\unrestrict` ランダムトークンを除去
+      （差分ゼロでも 2 行ノイズが出る問題の解消）

--- a/scripts/db-migration-diff/compare.mjs
+++ b/scripts/db-migration-diff/compare.mjs
@@ -3,13 +3,15 @@
 //
 // 使い方:
 //   node scripts/db-migration-diff/compare.mjs \
-//     <base.json> <pr.json> <schema_diff.txt> <new_migrations.txt> > comment.md
+//     <base.json> <pr.json> <schema_diff.txt> <new_migrations.txt> <missing_migrations.txt> \
+//     > comment.md
 //
 // 引数:
-//   base.json            : main 適用後の snapshot (snapshot.sql の出力)
-//   pr.json              : PR 適用後の snapshot
-//   schema_diff.txt      : pg_dump --schema-only の生 diff (diff -u 出力)
-//   new_migrations.txt   : PR で新規追加された migration ファイル名 (1 行 1 ファイル)
+//   base.json              : main 適用後の snapshot (snapshot.sql の出力)
+//   pr.json                : PR 適用後の snapshot
+//   schema_diff.txt        : pg_dump --schema-only の生 diff (diff -u 出力)
+//   new_migrations.txt     : PR で新規追加された migration ファイル名 (1 行 1 ファイル)
+//   missing_migrations.txt : main にあって HEAD に無い migration ファイル名 (rebase 必要 signal)
 //
 // 終了コード:
 //   0 - 規約違反 (`❌`) なし
@@ -20,28 +22,39 @@
 import { readFile } from "node:fs/promises";
 import { argv, exit, stdout } from "node:process";
 
-const [, , basePath, prPath, schemaDiffPath, newMigrationsPath] = argv;
+const [, , basePath, prPath, schemaDiffPath, newMigrationsPath, missingMigrationsPath] = argv;
 
-if (!basePath || !prPath || !schemaDiffPath || !newMigrationsPath) {
-  console.error("usage: compare.mjs <base.json> <pr.json> <schema_diff.txt> <new_migrations.txt>");
+if (!basePath || !prPath || !schemaDiffPath || !newMigrationsPath || !missingMigrationsPath) {
+  console.error(
+    "usage: compare.mjs <base.json> <pr.json> <schema_diff.txt> <new_migrations.txt> <missing_migrations.txt>",
+  );
   exit(2);
 }
 
-const [base, pr, schemaDiff, newMigrationsRaw] = await Promise.all([
+const [base, pr, schemaDiff, newMigrationsRaw, missingMigrationsRaw] = await Promise.all([
   readJson(basePath),
   readJson(prPath),
   readFile(schemaDiffPath, "utf8").catch(() => ""),
   readFile(newMigrationsPath, "utf8").catch(() => ""),
+  readFile(missingMigrationsPath, "utf8").catch(() => ""),
 ]);
 
-const newMigrations = newMigrationsRaw
-  .split("\n")
-  .map((line) => line.trim())
-  .filter(Boolean);
+const newMigrations = splitLines(newMigrationsRaw);
+const missingMigrations = splitLines(missingMigrationsRaw);
+
+// kind フィルタ。tables (relkind in r/v/m) から table 行だけ抽出する用途。
+// 古い snapshot 互換のため kind 未指定は table とみなす。
+const isTable = (t) => (t.kind ?? "table") === "table";
 
 const report = buildReport(base, pr);
 const assertions = runAssertions(report, pr);
-const md = renderMarkdown({ report, assertions, schemaDiff, newMigrations });
+const md = renderMarkdown({
+  report,
+  assertions,
+  schemaDiff,
+  newMigrations,
+  missingMigrations,
+});
 
 stdout.write(md);
 exit(assertions.failed ? 1 : 0);
@@ -53,10 +66,18 @@ async function readJson(path) {
   return JSON.parse(raw);
 }
 
+function splitLines(raw) {
+  return raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
 // ---- Diff ----
 
 function buildReport(before, after) {
   return {
+    // tables は relkind in ('r','v','m') を含む。kind フィールドで table / view / matview を判別する
     tables: diffByKey(before.tables, after.tables, (t) => `${t.schema}.${t.table}`),
     columns: diffByKey(before.columns, after.columns, (c) => `${c.schema}.${c.table}.${c.column}`),
     constraints: diffByKey(
@@ -72,6 +93,8 @@ function buildReport(before, after) {
     indexes: diffByKey(before.indexes, after.indexes, (i) => `${i.schema}.${i.table}.${i.name}`),
     policies: diffByKey(before.policies, after.policies, (p) => `${p.schema}.${p.table}.${p.name}`),
     enums: diffEnums(before.enums, after.enums),
+    // views は view / matview 専用 (definition / security_invoker / security_barrier を含む)
+    views: diffByKey(before.views ?? [], after.views ?? [], (v) => `${v.schema}.${v.name}`),
   };
 }
 
@@ -141,9 +164,10 @@ function runAssertions(report, prSnapshot) {
   const warnings = [];
   const oks = [];
 
-  // ❌ public の新テーブルに RLS が有効化されていない
+  // ❌ public の新テーブルに RLS が有効化されていない (view / matview は対象外)
   for (const t of report.tables.added) {
     if (t.schema !== "public") continue;
+    if (!isTable(t)) continue;
     if (!t.rls_enabled) {
       errors.push({
         kind: "rls-missing",
@@ -155,9 +179,10 @@ function runAssertions(report, prSnapshot) {
     }
   }
 
-  // ❌ NOT NULL かつ default なしのカラム追加 (既存行で fail)
+  // ❌ NOT NULL かつ default なしのカラム追加 (既存行で fail) — 通常 table のみ対象
   for (const c of report.columns.added) {
     if (c.schema !== "public") continue;
+    if ((c.kind ?? "table") !== "table") continue; // view / matview の列は対象外
     // 既存テーブルへのカラム追加だけが対象 (新規テーブルは初期データなしなので問題ない)
     const isNewTable = report.tables.added.some(
       (t) => t.schema === c.schema && t.table === c.table,
@@ -183,7 +208,35 @@ function runAssertions(report, prSnapshot) {
     }
   }
 
-  // ⚠️ 新規 public テーブルに owner-only ポリシー 4 種が揃っていない
+  // ❌ 新規 view / matview に security_invoker = true が指定されていない
+  // 未指定だと definer (= 所有者 = postgres) 権限で評価され、呼び出し元の RLS をバイパスする。
+  for (const v of report.views.added) {
+    if (v.schema !== "public") continue;
+    if (!v.security_invoker) {
+      errors.push({
+        kind: "view-not-security-invoker",
+        message: `\`${v.schema}.${v.name}\` (${v.kind}) に \`security_invoker = true\` が指定されていません`,
+        fix: `\`CREATE VIEW ... WITH (security_invoker = true) AS ...\` で作成。未指定だと所有者権限で評価され RLS を迂回する`,
+      });
+    } else {
+      oks.push(
+        `\`${v.schema}.${v.name}\` (${v.kind}) で \`security_invoker = true\` が指定されている`,
+      );
+    }
+  }
+
+  // ⚠️ 既存 view の security_invoker が外された (true → false)
+  for (const m of report.views.modified) {
+    if (m.before.security_invoker && !m.after.security_invoker) {
+      errors.push({
+        kind: "view-security-invoker-removed",
+        message: `\`${m.after.schema}.${m.after.name}\` で \`security_invoker\` が外されました (true → false)`,
+        fix: "RLS 迂回経路ができるため原則維持する。意図的に外す場合は ADR で根拠を残す",
+      });
+    }
+  }
+
+  // ⚠️ 新規 public テーブルに owner-only ポリシー 4 種が揃っていない (table のみ対象)
   const policiesByTable = new Map();
   for (const p of prSnapshot.policies ?? []) {
     const key = `${p.schema}.${p.table}`;
@@ -192,6 +245,7 @@ function runAssertions(report, prSnapshot) {
   }
   for (const t of report.tables.added) {
     if (t.schema !== "public") continue;
+    if (!isTable(t)) continue;
     const key = `${t.schema}.${t.table}`;
     const policies = policiesByTable.get(key) ?? [];
     const cmds = new Set(policies.map((p) => p.command));
@@ -229,10 +283,28 @@ function runAssertions(report, prSnapshot) {
 
 // ---- Markdown rendering ----
 
-function renderMarkdown({ report, assertions, schemaDiff, newMigrations }) {
+function renderMarkdown({ report, assertions, schemaDiff, newMigrations, missingMigrations }) {
   const lines = [];
   lines.push("## 🗄️ Migration diff");
   lines.push("");
+
+  // ---- rebase 警告 (main にあって HEAD に無い migration を検出) ----
+  if (missingMigrations.length > 0) {
+    lines.push(
+      `> ⚠️ **main に ${missingMigrations.length} 件の migration があり、このブランチに含まれていません**。`,
+    );
+    lines.push(">");
+    lines.push(
+      "> 以下のファイルが main 側で追加されています。rebase / merge して取り込んでください:",
+    );
+    lines.push(">");
+    for (const m of missingMigrations) lines.push(`> - \`${m}\``);
+    lines.push(">");
+    lines.push(
+      "> （以下の diff は **main 現 HEAD vs このブランチ** のため、欠けている migration が「削除」として表示されることがあります）",
+    );
+    lines.push("");
+  }
 
   // ---- 新規 migration 一覧 ----
   lines.push("**このPRで追加された migration**");
@@ -248,29 +320,78 @@ function renderMarkdown({ report, assertions, schemaDiff, newMigrations }) {
   lines.push("");
 
   // ---- サマリ ----
+  const tablesOnly = filterAddedRemovedModified(report.tables, isTable);
+  const viewsOnly = report.views;
   lines.push("### サマリ");
   lines.push("");
   lines.push("| カテゴリ | 変更 |");
   lines.push("|---|---|");
-  lines.push(`| テーブル | ${summarizeTables(report.tables)} |`);
+  lines.push(`| テーブル | ${summarizeTables(tablesOnly)} |`);
+  lines.push(`| ビュー | ${summarizeViews(viewsOnly)} |`);
   lines.push(`| 型 (enum) | ${summarizeEnums(report.enums)} |`);
-  lines.push(`| インデックス | ${summarizeSimple(report.indexes, "インデックス")} |`);
-  lines.push(`| RLS / ポリシー | ${summarizePolicies(report.tables, report.policies)} |`);
+  lines.push(`| インデックス | ${summarizeSimple(report.indexes)} |`);
+  lines.push(`| RLS / ポリシー | ${summarizePolicies(tablesOnly, report.policies)} |`);
   lines.push(`| 制約 | ${summarizeConstraints(report.constraints, report.foreignKeys)} |`);
   lines.push("");
 
-  // ---- 新規テーブル詳細 ----
-  if (report.tables.added.length > 0) {
+  // ---- 新規テーブル詳細 (view は除外) ----
+  const newTables = report.tables.added.filter(isTable);
+  if (newTables.length > 0) {
     lines.push("### 新規テーブルの詳細");
     lines.push("");
-    for (const t of report.tables.added) {
+    for (const t of newTables) {
       lines.push(...renderNewTableSection(t, report));
       lines.push("");
     }
   }
 
-  // ---- 既存テーブルへのカラム追加詳細 ----
+  // ---- 新規 view / matview 詳細 ----
+  if (report.views.added.length > 0) {
+    lines.push("### 新規 view / matview の詳細");
+    lines.push("");
+    for (const v of report.views.added) {
+      lines.push(...renderNewViewSection(v, report));
+      lines.push("");
+    }
+  }
+
+  // ---- 既存 view の definition 変更 ----
+  if (report.views.modified.length > 0) {
+    lines.push("### View の変更");
+    lines.push("");
+    for (const m of report.views.modified) {
+      lines.push(`#### \`${m.after.schema}.${m.after.name}\` (${m.after.kind})`);
+      lines.push("");
+      const flagDiff = [];
+      if (m.before.security_invoker !== m.after.security_invoker) {
+        flagDiff.push(
+          `- \`security_invoker\`: \`${m.before.security_invoker}\` → \`${m.after.security_invoker}\``,
+        );
+      }
+      if (m.before.security_barrier !== m.after.security_barrier) {
+        flagDiff.push(
+          `- \`security_barrier\`: \`${m.before.security_barrier}\` → \`${m.after.security_barrier}\``,
+        );
+      }
+      if (flagDiff.length) {
+        lines.push("**オプション変更**:");
+        lines.push(...flagDiff);
+        lines.push("");
+      }
+      if (m.before.definition !== m.after.definition) {
+        lines.push("**定義変更** (CREATE OR REPLACE):");
+        lines.push("");
+        lines.push("```sql");
+        lines.push(truncateForComment(m.after.definition ?? "", 4000));
+        lines.push("```");
+        lines.push("");
+      }
+    }
+  }
+
+  // ---- 既存テーブルへのカラム追加詳細 (view 由来は除外) ----
   const addedColumnsOnExistingTables = report.columns.added.filter((c) => {
+    if ((c.kind ?? "table") !== "table") return false;
     return !report.tables.added.some((t) => t.schema === c.schema && t.table === c.table);
   });
   if (addedColumnsOnExistingTables.length > 0) {
@@ -319,7 +440,7 @@ function renderMarkdown({ report, assertions, schemaDiff, newMigrations }) {
     assertions.warnings.length === 0 &&
     assertions.oks.length === 0
   ) {
-    lines.push("- ℹ️ 検査対象なし (テーブル / カラム / enum / FK の追加変更がない)");
+    lines.push("- ℹ️ 検査対象なし (テーブル / カラム / enum / FK / view の追加変更がない)");
   }
   lines.push("");
 
@@ -350,6 +471,14 @@ function renderMarkdown({ report, assertions, schemaDiff, newMigrations }) {
 
 // ---- Summary helpers ----
 
+function filterAddedRemovedModified(diff, predicate) {
+  return {
+    added: diff.added.filter(predicate),
+    removed: diff.removed.filter(predicate),
+    modified: diff.modified.filter((m) => predicate(m.after)),
+  };
+}
+
 function summarizeTables({ added, removed, modified }) {
   const parts = [];
   if (added.length)
@@ -363,7 +492,22 @@ function summarizeTables({ added, removed, modified }) {
   return parts.length ? parts.join(" / ") : "変更なし";
 }
 
-function summarizeSimple({ added, removed, modified }, label) {
+function summarizeViews({ added, removed, modified }) {
+  const parts = [];
+  if (added.length)
+    parts.push(
+      `${added.length} 件追加 (${added.map((v) => `\`${v.name}\` (${v.kind})`).join(", ")})`,
+    );
+  if (removed.length)
+    parts.push(`⚠️ ${removed.length} 件削除 (${removed.map((v) => `\`${v.name}\``).join(", ")})`);
+  if (modified.length)
+    parts.push(
+      `${modified.length} 件変更 (${modified.map((m) => `\`${m.after.name}\``).join(", ")})`,
+    );
+  return parts.length ? parts.join(" / ") : "変更なし";
+}
+
+function summarizeSimple({ added, removed, modified }) {
   const parts = [];
   if (added.length) parts.push(`${added.length} 件追加`);
   if (removed.length) parts.push(`⚠️ ${removed.length} 件削除`);
@@ -388,9 +532,9 @@ function summarizeEnums({ added, removed, modified }) {
   return parts.length ? parts.join(" / ") : "変更なし";
 }
 
-function summarizePolicies(tables, policies) {
+function summarizePolicies(tablesOnly, policies) {
   const parts = [];
-  const newTablesWithRls = tables.added.filter((t) => t.rls_enabled);
+  const newTablesWithRls = tablesOnly.added.filter((t) => t.rls_enabled);
   if (newTablesWithRls.length) {
     parts.push(`新規テーブル ${newTablesWithRls.length} 件で RLS 有効化`);
   }
@@ -421,7 +565,9 @@ function renderNewTableSection(t, report) {
   lines.push("");
 
   // Columns
-  const columns = report.columns.added.filter((c) => c.schema === t.schema && c.table === t.table);
+  const columns = report.columns.added.filter(
+    (c) => c.schema === t.schema && c.table === t.table && (c.kind ?? "table") === "table",
+  );
   if (columns.length) {
     lines.push("| 列 | 型 | NULL | デフォルト |");
     lines.push("|---|---|---|---|");
@@ -467,6 +613,52 @@ function renderNewTableSection(t, report) {
 
   if (!t.rls_enabled) {
     lines.push("> ⚠️ このテーブルは RLS が有効化されていません");
+    lines.push("");
+  }
+
+  return lines;
+}
+
+// ---- New view detail ----
+
+function renderNewViewSection(v, report) {
+  const lines = [];
+  lines.push(`#### \`${v.schema}.${v.name}\` (${v.kind})`);
+  lines.push("");
+
+  // セキュリティオプション
+  const flags = [];
+  flags.push(`- \`security_invoker\`: ${v.security_invoker ? "✅ true" : "❌ false (RLS 迂回)"}`);
+  flags.push(`- \`security_barrier\`: \`${v.security_barrier}\``);
+  lines.push("**オプション**:");
+  lines.push(...flags);
+  lines.push("");
+
+  // Columns (information_schema 経由で view 列も取れる)
+  const columns = report.columns.added.filter(
+    (c) =>
+      c.schema === v.schema && c.table === v.name && (c.kind === "view" || c.kind === "matview"),
+  );
+  if (columns.length) {
+    lines.push("**列**:");
+    lines.push("");
+    lines.push("| 列 | 型 | NULL |");
+    lines.push("|---|---|---|");
+    for (const c of columns) {
+      lines.push(
+        `| \`${c.column}\` | \`${formatType(c)}\` | ${c.nullable === "YES" ? "NULL 可" : "NOT NULL"} |`,
+      );
+    }
+    lines.push("");
+  }
+
+  // 定義
+  if (v.definition) {
+    lines.push("**定義**:");
+    lines.push("");
+    lines.push("```sql");
+    lines.push(truncateForComment(v.definition, 4000));
+    lines.push("```");
     lines.push("");
   }
 

--- a/scripts/db-migration-diff/snapshot.sql
+++ b/scripts/db-migration-diff/snapshot.sql
@@ -6,14 +6,18 @@
 --
 -- 構造はおおよそ:
 --   {
---     "tables":      [{ schema, table, rls_enabled, rls_forced }],
---     "columns":     [{ schema, table, column, type, udt, nullable, default, ordinal }],
+--     "tables":      [{ schema, table, kind, rls_enabled, rls_forced }],
+--     "columns":     [{ schema, table, kind, column, type, udt, nullable, default, ordinal }],
 --     "constraints": [{ schema, table, name, type, definition }],
 --     "foreign_keys":[{ schema, table, name, columns, ref_schema, ref_table, ref_columns, delete_rule, update_rule }],
 --     "indexes":     [{ schema, table, name, definition }],
 --     "policies":    [{ schema, table, name, permissive, roles, command, using, with_check }],
---     "enums":       [{ schema, name, values }]
+--     "enums":       [{ schema, name, values }],
+--     "views":       [{ schema, name, kind, definition, security_invoker, security_barrier }]
 --   }
+--
+-- `tables` は relkind in ('r','v','m') を含むので「table / view / matview を一律
+-- 列挙したい」用途には tables を、view 専用の検査 (security_invoker 等) には views を使う。
 
 with
   tables as (
@@ -22,29 +26,73 @@ with
       select json_build_object(
         'schema', n.nspname,
         'table', c.relname,
+        'kind', case c.relkind
+          when 'r' then 'table'
+          when 'v' then 'view'
+          when 'm' then 'matview'
+        end,
         'rls_enabled', c.relrowsecurity,
         'rls_forced', c.relforcerowsecurity
       ) as t
       from pg_class c
       join pg_namespace n on n.oid = c.relnamespace
-      where n.nspname = 'public' and c.relkind = 'r'
+      where n.nspname = 'public' and c.relkind in ('r', 'v', 'm')
+    ) sub
+  ),
+  views as (
+    -- view / matview の定義 + 主要 reloptions を抜く。security_invoker は PG 15+ の
+    -- view option で、未指定だと definer (= view 所有者) 権限で評価され RLS をバイパスする。
+    -- kozutsumi では原則 security_invoker = true を要求する。
+    select coalesce(json_agg(v order by v->>'schema', v->>'name'), '[]'::json) as data
+    from (
+      select json_build_object(
+        'schema', n.nspname,
+        'name', c.relname,
+        'kind', case c.relkind when 'v' then 'view' when 'm' then 'matview' end,
+        'definition', pg_get_viewdef(c.oid, true),
+        'security_invoker', coalesce(
+          (select option_value::boolean
+           from pg_options_to_table(c.reloptions)
+           where option_name = 'security_invoker'),
+          false
+        ),
+        'security_barrier', coalesce(
+          (select option_value::boolean
+           from pg_options_to_table(c.reloptions)
+           where option_name = 'security_barrier'),
+          false
+        )
+      ) as v
+      from pg_class c
+      join pg_namespace n on n.oid = c.relnamespace
+      where n.nspname = 'public' and c.relkind in ('v', 'm')
     ) sub
   ),
   columns as (
+    -- information_schema.columns は view / matview の列も含む。compare.mjs 側で
+    -- 「既存テーブルへのカラム追加」判定をする時に view 由来を除外できるよう、
+    -- pg_class から relkind を join して kind ('table' / 'view' / 'matview') を付与する。
     select coalesce(json_agg(c order by c->>'schema', c->>'table', (c->>'ordinal')::int), '[]'::json) as data
     from (
       select json_build_object(
-        'schema', table_schema,
-        'table', table_name,
-        'column', column_name,
-        'type', data_type,
-        'udt', udt_name,
-        'nullable', is_nullable,
-        'default', column_default,
-        'ordinal', ordinal_position
+        'schema', col.table_schema,
+        'table', col.table_name,
+        'kind', case cls.relkind
+          when 'r' then 'table'
+          when 'v' then 'view'
+          when 'm' then 'matview'
+        end,
+        'column', col.column_name,
+        'type', col.data_type,
+        'udt', col.udt_name,
+        'nullable', col.is_nullable,
+        'default', col.column_default,
+        'ordinal', col.ordinal_position
       ) as c
-      from information_schema.columns
-      where table_schema = 'public'
+      from information_schema.columns col
+      join pg_namespace ns on ns.nspname = col.table_schema
+      join pg_class cls on cls.relname = col.table_name and cls.relnamespace = ns.oid
+      where col.table_schema = 'public' and cls.relkind in ('r', 'v', 'm')
     ) sub
   ),
   constraints as (
@@ -157,5 +205,6 @@ select json_build_object(
   'foreign_keys', (select data from foreign_keys),
   'indexes', (select data from indexes),
   'policies', (select data from policies),
-  'enums', (select data from enums)
+  'enums', (select data from enums),
+  'views', (select data from views)
 );


### PR DESCRIPTION
## 概要 (What)

ADR-0023 の migration diff CI が **新規 migration の差分を実質取りこぼしていた** 不具合を修正し、ついでに view / matview を構造化スナップショットの対象に加えて `security_invoker` 検査と rebase 必要シグナルを追加する。

## 関連 Issue

Refs #135

(該当 PR のコメント `https://github.com/y-oga-819/kozutsumi/pull/135#issuecomment-4347154242` に発症した。issue は未起票。)

## 背景 (Why)

ADR-0023 ([docs/adr/0023-pr-migration-diff-auto-comment.md](../blob/main/docs/adr/0023-pr-migration-diff-auto-comment.md)) で導入した migration diff CI が、PR #135 (新規 view 追加) のコメントで「テーブル: 変更なし」「生 diff も `\restrict` ランダムトークンの 2 行だけ」になっていた。

調査の結果、**base 状態への巻き戻しが機能していない** のが根本原因と判明:

```yaml
# 旧実装 (.github/workflows/ci.yml)
- name: Checkout base migrations and reset DB
  run: |
    git checkout "$BASE_SHA" -- supabase/migrations/
    supabase db reset --no-seed
```

`git checkout <ref> -- <path>` は **overlay モード** で、`<ref>` に存在しないファイル（= PR が新規追加した migration）を working tree から削除しない。結果、base のつもりで `supabase db reset` した DB にも **PR の migration が適用されてしまい**、base.sql ≒ pr.sql になって diff が消える。

ついでに、構造化スナップショット (`scripts/db-migration-diff/snapshot.sql`) が `pg_class.relkind = 'r'` で絞っていたため view / matview を取りこぼしており、view 専用の規約 (`security_invoker = true` の必須化) も未検査だった。

## Before → After (概念・フロー・メンタルモデル)

**Before:**

```
PR HEAD migrations 適用 → snapshot (pr)
git checkout BASE_SHA -- supabase/migrations/   ← overlay モード: 新規ファイル残存
supabase db reset --no-seed                      ← 残ったままの新規 migration も適用される
snapshot (base)                                  ← 実は pr と同じ内容
diff = 空 (or random token のみ)                ← 新規 migration が見えない
```

view を加えても、構造化スナップショットの対象に含まれないので「変更なし」表示。`security_invoker` の付け忘れも検知できない。main から遅れている PR にも気づけない。

**After:**

```
PR HEAD migrations 適用 → snapshot (pr)
git restore --source=BASE_SHA --no-overlay --   ← 新規ファイルを物理削除
supabase db reset --no-seed                      ← 純粋な main 状態が再現
snapshot (base)                                  ← 本当の base
diff = PR が増やした分だけ                       ← 正しく見える
```

- view / matview も `kind` 付きで構造化される (`tables`) + view 専用セクション (`views`: definition + reloptions)
- 新規 view に `security_invoker = true` が無ければ `❌` で workflow を fail
- 既存 view の `security_invoker` を true→false に下げる変更も `❌`
- main にあって HEAD に無い migration があればコメント冒頭に **rebase 必要警告** を出す（main 現 HEAD 比較の副次効果）
- pg_dump 17 の `\restrict` / `\unrestrict` ランダムトークンを生 diff から除去（差分ゼロでも 2 行ノイズが出る問題を解消）

## 追加したテスト (How verified)

- [x] `compare.mjs` に対する手動 smoke test 3 ケース
  - view + `security_invoker=true` → exit 0 / ✅ 表示
  - view + `security_invoker=false` + missing migrations → exit 1 / ❌ + rebase 警告
  - 既存テーブルへの NOT NULL 列追加 + RLS 新テーブル → 既存 assertion (NOT NULL / policy 不足 / RLS) が引き続き発火
- [x] `npm run format:check` / `npm run lint` / `npm run typecheck` / `npm test` (415 passed)
- [ ] **本 PR の CI 自体が新しい migration の diff を正しく出すか** は、本 PR には migration が含まれないため別途 follow-up PR で確認が要る（または manual に supabase/migrations/ をいじった検証 PR を立てる）

## リリース前チェックリスト (When / Before merge)

- [x] ドキュメント (ADR-0023) を更新した（改訂履歴セクション追加）
- [ ] マージ後、次の migration を含む PR で CI コメントが「変更なし」ではなく実差分を出すことを確認する

## このPRの範囲外 (Out of scope)

- **構造化スナップショットを functions / triggers / sequences まで広げる** — 旧 ADR の Notes と同じく「必要になったら別 ADR で拡張」のまま据え置き
- **view 由来の columns 表示の改善** — 現状 view の列は新規 view の詳細セクションに表示されるのみで、変更検知は view definition 全体の比較に任せている。列単位の追加 / 削除をきめ細かく出すのは過剰
- **`⚠️` レベルの違反を fail に格上げ** — ADR-0023 の方針通り別判断
- **fork point 比較への切り替え** — main 現 HEAD 比較を維持（ADR-0023 の意図通り、merge 後の最終状態を見せる）。fork point の方が「ブランチが何を増やしたか」だけは綺麗に出るが、main の進行に気づけない欠点がある


---
_Generated by [Claude Code](https://claude.ai/code/session_01FMy6Hr2U98bnQWhpPsYfKR)_