### PR TITLE
feat(estimation): 見積もり補正エンジンの算出ロジックと UI 表示 (P3-9, #93)

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -10,6 +10,8 @@ import type { Event } from "@/entities/event/types";
 import type { CreateProjectInput, UpdateProjectInput } from "@/entities/project/gateway";
 import { ProjectsProvider } from "@/entities/project/ProjectsContext";
 import type { Project } from "@/entities/project/types";
+import { CorrectionFactorsProvider } from "@/entities/task/CorrectionFactorsContext";
+import type { CorrectionFactor } from "@/entities/task/correction";
 import type { CreateTaskInput } from "@/entities/task/gateway";
 import type { Task, TaskCategory } from "@/entities/task/types";
 import { AddButton } from "@/features/add-forms/AddButton";
@@ -69,6 +71,8 @@ const keys = {
   events: ["events"] as const,
   /** 詳細パネル (P3-15) で fetch する AI 分解の最新試行ログ。タスク id 単位で分離する。 */
   decomposeLog: (taskId: string) => ["actionLog", "decompose", taskId] as const,
+  /** 見積もり補正倍率 (P3-9 / #93、ADR 0025): user-scoped、view 経由で取る。 */
+  correctionFactors: ["correctionFactors"] as const,
 };
 
 export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
@@ -99,6 +103,19 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
   const projects = useMemo(() => projectsQuery.data ?? [], [projectsQuery.data]);
   const tasks = useMemo(() => tasksQuery.data ?? [], [tasksQuery.data]);
   const events = useMemo(() => eventsQuery.data ?? [], [eventsQuery.data]);
+
+  // P3-9 / #93: 見積もり補正倍率 (ADR 0024 / 0025)。
+  // 補正は augmentation (ADR 0013) なので未取得 / fetch 失敗は空配列扱い (= 全タスク補正なし)。
+  // staleTime を長めにして、タスク完了のたびに再取得しない (補正値の鋭敏な更新は不要)。
+  const correctionFactorsQuery = useQuery({
+    queryKey: keys.correctionFactors,
+    queryFn: () => taskGateway.listCorrectionFactors(),
+    staleTime: 5 * 60_000,
+  });
+  const correctionFactors = useMemo<readonly CorrectionFactor[]>(
+    () => correctionFactorsQuery.data ?? [],
+    [correctionFactorsQuery.data],
+  );
 
   const [detailId, setDetailId] = useState<string | null>(null);
   const [eventDetailId, setEventDetailId] = useState<string | null>(null);
@@ -582,177 +599,182 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
 
   return (
     <ProjectsProvider projects={mergeTreeProjects(projects, historyData)}>
-      <div className="relative select-none">
-        {/* Header */}
-        <div className="sticky top-0 z-50 flex items-center gap-3 border-b border-bg-elevated bg-bg-primary px-5 pb-3 pt-4">
-          <div className="font-jp text-[16px] font-bold -tracking-[0.02em]">
-            <span className="text-accent-blue">kozu</span>
-            <span className="text-fg-faint">tsumi</span>
+      <CorrectionFactorsProvider factors={correctionFactors}>
+        <div className="relative select-none">
+          {/* Header */}
+          <div className="sticky top-0 z-50 flex items-center gap-3 border-b border-bg-elevated bg-bg-primary px-5 pb-3 pt-4">
+            <div className="font-jp text-[16px] font-bold -tracking-[0.02em]">
+              <span className="text-accent-blue">kozu</span>
+              <span className="text-fg-faint">tsumi</span>
+            </div>
+            <div className="flex-1" />
+            <div className="flex rounded-md bg-bg-elevated p-0.5">
+              {tabs.map((tab) => {
+                const active = view === tab.key;
+                return (
+                  <Link
+                    key={tab.key}
+                    href={tab.href}
+                    className={`cursor-pointer rounded-[4px] px-3.5 py-1 text-[11px] font-medium no-underline ${
+                      active ? "bg-bg-divider text-fg-emphasized" : "bg-transparent text-fg-weak"
+                    }`}
+                  >
+                    {tab.label}
+                  </Link>
+                );
+              })}
+            </div>
+            <CalendarSyncButton
+              isPending={calendarSync.isPending}
+              lastSyncedAt={calendarSync.lastSyncedAt}
+              onClick={() => calendarSync.triggerSync("manual")}
+            />
+            <UserMenu
+              email={user.email}
+              avatarUrl={user.avatarUrl}
+              onResetSample={resetSample}
+              onClearAll={clearAll}
+            />
           </div>
-          <div className="flex-1" />
-          <div className="flex rounded-md bg-bg-elevated p-0.5">
-            {tabs.map((tab) => {
-              const active = view === tab.key;
-              return (
-                <Link
-                  key={tab.key}
-                  href={tab.href}
-                  className={`cursor-pointer rounded-[4px] px-3.5 py-1 text-[11px] font-medium no-underline ${
-                    active ? "bg-bg-divider text-fg-emphasized" : "bg-transparent text-fg-weak"
-                  }`}
-                >
-                  {tab.label}
-                </Link>
-              );
-            })}
-          </div>
-          <CalendarSyncButton
-            isPending={calendarSync.isPending}
-            lastSyncedAt={calendarSync.lastSyncedAt}
-            onClick={() => calendarSync.triggerSync("manual")}
-          />
-          <UserMenu
-            email={user.email}
-            avatarUrl={user.avatarUrl}
-            onResetSample={resetSample}
-            onClearAll={clearAll}
-          />
+
+          <ReauthBanner visible={calendarSync.needsReauth} onDismiss={calendarSync.dismissReauth} />
+
+          {view === "stack" ? (
+            <StackView
+              events={events}
+              pendingTasks={pendingTasks}
+              doneTasks={doneTasks}
+              topTimer={topTimer}
+              toggleDone={toggleDone}
+              reorder={reorder}
+              nowMin={nowMin}
+              now={nowMs}
+              today={today}
+              onOpenDetail={setDetailId}
+              onOpenEvent={setEventDetailId}
+            />
+          ) : (
+            <TreeView historyData={historyData} projectOrder={projectOrderForTree} />
+          )}
+
+          {detailTask && (
+            <TaskDetailPanel
+              task={detailTask}
+              events={events}
+              now={nowMs}
+              onClose={() => setDetailId(null)}
+              onUpdate={updateBody}
+              onToggleDone={toggleDone}
+              onDelete={(id) => deleteTaskMutation.mutate(id)}
+              onChangeDependency={(id, dependsOnEventId) =>
+                updateDependencyMutation.mutate({ id, dependsOnEventId })
+              }
+              onChangeCategory={(id, taskCategory) =>
+                updateCategoryMutation.mutate({ id, taskCategory })
+              }
+              aiEnabled={aiEnabled}
+              latestDecomposeLog={decomposeLogQuery.data ?? null}
+              isDecomposeLogLoading={decomposeLogQuery.isPending}
+              onTriggerDecompose={(id) => {
+                // P3-15 / ADR 0021 §4: optimistic に decomposing pill を出しつつ fire-and-forget。
+                // server 側でも `decompose_status='decomposing'` に倒す (重複設定は無害)。
+                queryClient.setQueryData<Task[]>(keys.tasks, (prev) =>
+                  (prev ?? []).map((t) =>
+                    t.id === id ? { ...t, decomposeStatus: "decomposing" } : t,
+                  ),
+                );
+                // 既存 log は陳腐化するので invalidate (新たな試行が完了したら再 fetch される)
+                queryClient.invalidateQueries({ queryKey: keys.decomposeLog(id) });
+                triggerDecompose(id);
+              }}
+            />
+          )}
+
+          {eventDetailId &&
+            (() => {
+              const ev = events.find((e) => e.id === eventDetailId);
+              return ev ? (
+                <EventDetailPanel
+                  event={ev}
+                  onClose={() => setEventDetailId(null)}
+                  onChangeProject={(id, projectId) =>
+                    updateEventProjectMutation.mutate({ id, projectId })
+                  }
+                  onUpdate={async (id, patch) => {
+                    await updateEventMutation.mutateAsync({ id, patch });
+                  }}
+                  onDelete={async (id) => {
+                    await deleteEventMutation.mutateAsync(id);
+                  }}
+                />
+              ) : null;
+            })()}
+
+          <AddButton onClick={() => setAddOpen(true)} />
+
+          {addOpen ? (
+            <AddPanel
+              projects={projects}
+              events={events}
+              onClose={() => setAddOpen(false)}
+              onCreateTask={async (input) => {
+                // stackOrder は末尾に割り当て (pending 件数)
+                const stackOrder = pendingTasks.length;
+                const created = await createTaskMutation.mutateAsync({ ...input, stackOrder });
+                // P3-6 / ADR 0017: タスク作成成功後に AI 分解を fire-and-forget で投げる。
+                // server 側でも `decompose_status='decomposing'` に倒すが、UI に分解中 pill を
+                // 即時出すため optimistic に cache を書き換える。AI_ENABLED=false / 失敗時は
+                // server が `none` に戻す (decompose-server の guard 経路)。
+                // 既に invalidateQueries で refetch 中の cache に対しては map で上書き、
+                // refetch 前で entry が無ければ末尾に append する。
+                queryClient.setQueryData<Task[]>(keys.tasks, (prev) => {
+                  const list = prev ?? [];
+                  const found = list.some((t) => t.id === created.id);
+                  const updated = { ...created, decomposeStatus: "decomposing" as const };
+                  return found
+                    ? list.map((t) =>
+                        t.id === created.id ? { ...t, decomposeStatus: "decomposing" } : t,
+                      )
+                    : [...list, updated];
+                });
+                triggerDecompose(created.id);
+                // P3-4 / ADR 0015: AI 初期ラベリングも同経路で fire-and-forget。
+                // 失敗 / AI_ENABLED=false は server が `task_category=null` のまま残す
+                // (ADR 0013 augmentation only)。client 側の optimistic 反映はしない —
+                // category は UX 上「気づいたら埋まっている」体験で良い。
+                triggerCategorize(created.id);
+              }}
+              onCreateEvent={async (input) => {
+                await createEventMutation.mutateAsync(input);
+              }}
+              onCreateProject={async (input) => {
+                await createProjectMutation.mutateAsync(input);
+              }}
+              onOpenProject={setProjectDetailId}
+            />
+          ) : null}
+
+          {projectDetail && (
+            <ProjectDetailPanel
+              project={projectDetail}
+              onClose={() => setProjectDetailId(null)}
+              onUpdate={async (id, patch) => {
+                await updateProjectMutation.mutateAsync({ id, patch });
+              }}
+              onDelete={async (id) => {
+                await deleteProjectMutation.mutateAsync(id);
+              }}
+            />
+          )}
+
+          {pauseModalOpen ? (
+            <PauseReasonModal
+              onSelect={handlePauseSelect}
+              onClose={() => setPauseModalOpen(false)}
+            />
+          ) : null}
         </div>
-
-        <ReauthBanner visible={calendarSync.needsReauth} onDismiss={calendarSync.dismissReauth} />
-
-        {view === "stack" ? (
-          <StackView
-            events={events}
-            pendingTasks={pendingTasks}
-            doneTasks={doneTasks}
-            topTimer={topTimer}
-            toggleDone={toggleDone}
-            reorder={reorder}
-            nowMin={nowMin}
-            now={nowMs}
-            today={today}
-            onOpenDetail={setDetailId}
-            onOpenEvent={setEventDetailId}
-          />
-        ) : (
-          <TreeView historyData={historyData} projectOrder={projectOrderForTree} />
-        )}
-
-        {detailTask && (
-          <TaskDetailPanel
-            task={detailTask}
-            events={events}
-            now={nowMs}
-            onClose={() => setDetailId(null)}
-            onUpdate={updateBody}
-            onToggleDone={toggleDone}
-            onDelete={(id) => deleteTaskMutation.mutate(id)}
-            onChangeDependency={(id, dependsOnEventId) =>
-              updateDependencyMutation.mutate({ id, dependsOnEventId })
-            }
-            onChangeCategory={(id, taskCategory) =>
-              updateCategoryMutation.mutate({ id, taskCategory })
-            }
-            aiEnabled={aiEnabled}
-            latestDecomposeLog={decomposeLogQuery.data ?? null}
-            isDecomposeLogLoading={decomposeLogQuery.isPending}
-            onTriggerDecompose={(id) => {
-              // P3-15 / ADR 0021 §4: optimistic に decomposing pill を出しつつ fire-and-forget。
-              // server 側でも `decompose_status='decomposing'` に倒す (重複設定は無害)。
-              queryClient.setQueryData<Task[]>(keys.tasks, (prev) =>
-                (prev ?? []).map((t) =>
-                  t.id === id ? { ...t, decomposeStatus: "decomposing" } : t,
-                ),
-              );
-              // 既存 log は陳腐化するので invalidate (新たな試行が完了したら再 fetch される)
-              queryClient.invalidateQueries({ queryKey: keys.decomposeLog(id) });
-              triggerDecompose(id);
-            }}
-          />
-        )}
-
-        {eventDetailId &&
-          (() => {
-            const ev = events.find((e) => e.id === eventDetailId);
-            return ev ? (
-              <EventDetailPanel
-                event={ev}
-                onClose={() => setEventDetailId(null)}
-                onChangeProject={(id, projectId) =>
-                  updateEventProjectMutation.mutate({ id, projectId })
-                }
-                onUpdate={async (id, patch) => {
-                  await updateEventMutation.mutateAsync({ id, patch });
-                }}
-                onDelete={async (id) => {
-                  await deleteEventMutation.mutateAsync(id);
-                }}
-              />
-            ) : null;
-          })()}
-
-        <AddButton onClick={() => setAddOpen(true)} />
-
-        {addOpen ? (
-          <AddPanel
-            projects={projects}
-            events={events}
-            onClose={() => setAddOpen(false)}
-            onCreateTask={async (input) => {
-              // stackOrder は末尾に割り当て (pending 件数)
-              const stackOrder = pendingTasks.length;
-              const created = await createTaskMutation.mutateAsync({ ...input, stackOrder });
-              // P3-6 / ADR 0017: タスク作成成功後に AI 分解を fire-and-forget で投げる。
-              // server 側でも `decompose_status='decomposing'` に倒すが、UI に分解中 pill を
-              // 即時出すため optimistic に cache を書き換える。AI_ENABLED=false / 失敗時は
-              // server が `none` に戻す (decompose-server の guard 経路)。
-              // 既に invalidateQueries で refetch 中の cache に対しては map で上書き、
-              // refetch 前で entry が無ければ末尾に append する。
-              queryClient.setQueryData<Task[]>(keys.tasks, (prev) => {
-                const list = prev ?? [];
-                const found = list.some((t) => t.id === created.id);
-                const updated = { ...created, decomposeStatus: "decomposing" as const };
-                return found
-                  ? list.map((t) =>
-                      t.id === created.id ? { ...t, decomposeStatus: "decomposing" } : t,
-                    )
-                  : [...list, updated];
-              });
-              triggerDecompose(created.id);
-              // P3-4 / ADR 0015: AI 初期ラベリングも同経路で fire-and-forget。
-              // 失敗 / AI_ENABLED=false は server が `task_category=null` のまま残す
-              // (ADR 0013 augmentation only)。client 側の optimistic 反映はしない —
-              // category は UX 上「気づいたら埋まっている」体験で良い。
-              triggerCategorize(created.id);
-            }}
-            onCreateEvent={async (input) => {
-              await createEventMutation.mutateAsync(input);
-            }}
-            onCreateProject={async (input) => {
-              await createProjectMutation.mutateAsync(input);
-            }}
-            onOpenProject={setProjectDetailId}
-          />
-        ) : null}
-
-        {projectDetail && (
-          <ProjectDetailPanel
-            project={projectDetail}
-            onClose={() => setProjectDetailId(null)}
-            onUpdate={async (id, patch) => {
-              await updateProjectMutation.mutateAsync({ id, patch });
-            }}
-            onDelete={async (id) => {
-              await deleteProjectMutation.mutateAsync(id);
-            }}
-          />
-        )}
-
-        {pauseModalOpen ? (
-          <PauseReasonModal onSelect={handlePauseSelect} onClose={() => setPauseModalOpen(false)} />
-        ) : null}
-      </div>
+      </CorrectionFactorsProvider>
     </ProjectsProvider>
   );
 }

--- a/src/entities/task/CorrectionFactorsContext.tsx
+++ b/src/entities/task/CorrectionFactorsContext.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+
+import {
+  type CorrectionFactor,
+  type CorrectionFactorMap,
+  indexFactorsByCategory,
+} from "./correction";
+
+/**
+ * 見積もり補正倍率 (P3-9 / #93、ADR 0024 / 0025) を tree 全体で共有するための context。
+ *
+ * AppShell で view (`task_category_correction_factors`) を fetch してマップに整形し、
+ * 子の Stack View / 詳細パネルから `useCorrectionFactors()` で参照する。
+ * 値が未取得 / fetch 失敗時は空マップ (= 全タスク補正なし扱い) を返す。
+ *
+ * 補正は augmentation (ADR 0013) なので、view が読めなくても core path は成立する。
+ * Provider が tree に無い場合も throw せず空マップを返す方針 (テストで都度 wrap する
+ * 手間を増やさないため)。
+ */
+const CorrectionFactorsContext = createContext<CorrectionFactorMap>({});
+
+export function CorrectionFactorsProvider({
+  factors,
+  children,
+}: {
+  factors: readonly CorrectionFactor[];
+  children: ReactNode;
+}) {
+  const map = useMemo(() => indexFactorsByCategory(factors), [factors]);
+  return (
+    <CorrectionFactorsContext.Provider value={map}>{children}</CorrectionFactorsContext.Provider>
+  );
+}
+
+export function useCorrectionFactors(): CorrectionFactorMap {
+  return useContext(CorrectionFactorsContext);
+}

--- a/src/entities/task/correction.test.ts
+++ b/src/entities/task/correction.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  CORRECTION_CONSTANTS,
+  computeCorrectionFactor,
+  correctEstimate,
+  indexFactorsByCategory,
+  isWithinOutlierRange,
+  median,
+  type CorrectionFactor,
+} from "./correction";
+
+describe("median", () => {
+  test("奇数件は中央値そのもの", () => {
+    expect(median([3, 1, 2])).toBe(2);
+  });
+
+  test("偶数件は中央 2 件の平均 (Supabase percentile_cont(0.5) と一致)", () => {
+    expect(median([1, 2, 3, 4])).toBe(2.5);
+  });
+
+  test("空配列は NaN", () => {
+    expect(Number.isNaN(median([]))).toBe(true);
+  });
+
+  test("元配列を変更しない (不変性)", () => {
+    const xs = [3, 1, 2];
+    const original = [...xs];
+    median(xs);
+    expect(xs).toEqual(original);
+  });
+});
+
+describe("isWithinOutlierRange", () => {
+  test("[0.1, 10] の範囲内は true (境界 inclusive)", () => {
+    expect(isWithinOutlierRange(0.1)).toBe(true);
+    expect(isWithinOutlierRange(1)).toBe(true);
+    expect(isWithinOutlierRange(10)).toBe(true);
+  });
+
+  test("範囲外は false", () => {
+    expect(isWithinOutlierRange(0.05)).toBe(false);
+    expect(isWithinOutlierRange(11)).toBe(false);
+  });
+
+  test("NaN / Infinity は false", () => {
+    expect(isWithinOutlierRange(Number.NaN)).toBe(false);
+    expect(isWithinOutlierRange(Number.POSITIVE_INFINITY)).toBe(false);
+  });
+});
+
+describe("computeCorrectionFactor", () => {
+  test("中央値 + サンプル数を返す", () => {
+    const samples = [
+      { estimatedMinutes: 30, actualMinutes: 30 }, // 1.0
+      { estimatedMinutes: 30, actualMinutes: 45 }, // 1.5
+      { estimatedMinutes: 30, actualMinutes: 60 }, // 2.0
+    ];
+    expect(computeCorrectionFactor(samples)).toEqual({ factor: 1.5, sampleCount: 3 });
+  });
+
+  test("estimated <= 0 / actual <= 0 のサンプルは除外", () => {
+    const samples = [
+      { estimatedMinutes: 30, actualMinutes: 45 }, // 1.5
+      { estimatedMinutes: 0, actualMinutes: 30 }, // 除算不能
+      { estimatedMinutes: 30, actualMinutes: 0 }, // 未消化
+    ];
+    expect(computeCorrectionFactor(samples)).toEqual({ factor: 1.5, sampleCount: 1 });
+  });
+
+  test("外れ値クリップ ([0.1, 10] 範囲外) のサンプルは除外", () => {
+    const samples = [
+      { estimatedMinutes: 30, actualMinutes: 45 }, // 1.5 OK
+      { estimatedMinutes: 1, actualMinutes: 100 }, // 100x → 除外
+      { estimatedMinutes: 100, actualMinutes: 1 }, // 0.01x → 除外
+    ];
+    expect(computeCorrectionFactor(samples)).toEqual({ factor: 1.5, sampleCount: 1 });
+  });
+
+  test("全サンプル除外なら null", () => {
+    const samples = [
+      { estimatedMinutes: 0, actualMinutes: 30 },
+      { estimatedMinutes: 1, actualMinutes: 100 },
+    ];
+    expect(computeCorrectionFactor(samples)).toBeNull();
+  });
+
+  test("空配列なら null", () => {
+    expect(computeCorrectionFactor([])).toBeNull();
+  });
+
+  test("偶数件の中央値は中央 2 件の平均", () => {
+    const samples = [
+      { estimatedMinutes: 10, actualMinutes: 8 }, // 0.8
+      { estimatedMinutes: 10, actualMinutes: 12 }, // 1.2
+      { estimatedMinutes: 10, actualMinutes: 14 }, // 1.4
+      { estimatedMinutes: 10, actualMinutes: 16 }, // 1.6
+    ];
+    const result = computeCorrectionFactor(samples);
+    expect(result?.factor).toBeCloseTo(1.3, 5);
+    expect(result?.sampleCount).toBe(4);
+  });
+});
+
+describe("indexFactorsByCategory", () => {
+  test("category キーで引けるマップに整形する", () => {
+    const factors: CorrectionFactor[] = [
+      { taskCategory: "coding", factor: 0.8, sampleCount: 10 },
+      { taskCategory: "doc", factor: 2.2, sampleCount: 7 },
+    ];
+    const map = indexFactorsByCategory(factors);
+    expect(map.coding).toEqual({ taskCategory: "coding", factor: 0.8, sampleCount: 10 });
+    expect(map.doc).toEqual({ taskCategory: "doc", factor: 2.2, sampleCount: 7 });
+    expect(map.research).toBeUndefined();
+  });
+
+  test("空配列なら空マップ", () => {
+    expect(indexFactorsByCategory([])).toEqual({});
+  });
+});
+
+describe("correctEstimate", () => {
+  const factors = indexFactorsByCategory([
+    { taskCategory: "coding", factor: 0.8, sampleCount: 10 },
+    { taskCategory: "doc", factor: 2.2, sampleCount: 7 },
+    { taskCategory: "research", factor: 1.5, sampleCount: 2 }, // 閾値未満 (5)
+  ]);
+
+  test("補正適用: 倍率 × 元値を四捨五入で返す", () => {
+    expect(correctEstimate({ estimatedMinutes: 30, taskCategory: "doc", factors })).toEqual({
+      rawMinutes: 30,
+      correctedMinutes: 66, // 30 * 2.2
+      factor: 2.2,
+      sampleCount: 7,
+    });
+  });
+
+  test("倍率 < 1 (コーディング系) でも補正適用される (短く確保)", () => {
+    expect(correctEstimate({ estimatedMinutes: 30, taskCategory: "coding", factors })).toEqual({
+      rawMinutes: 30,
+      correctedMinutes: 24, // 30 * 0.8
+      factor: 0.8,
+      sampleCount: 10,
+    });
+  });
+
+  test("最小サンプル数閾値未満は補正なし (元値のみ)", () => {
+    expect(correctEstimate({ estimatedMinutes: 30, taskCategory: "research", factors })).toEqual({
+      rawMinutes: 30,
+      correctedMinutes: null,
+      factor: null,
+      sampleCount: null,
+    });
+  });
+
+  test("category にデータが無い場合は補正なし", () => {
+    expect(correctEstimate({ estimatedMinutes: 30, taskCategory: "admin", factors })).toEqual({
+      rawMinutes: 30,
+      correctedMinutes: null,
+      factor: null,
+      sampleCount: null,
+    });
+  });
+
+  test("task_category=null は補正対象外 (ADR 0015)", () => {
+    expect(correctEstimate({ estimatedMinutes: 30, taskCategory: null, factors })).toEqual({
+      rawMinutes: 30,
+      correctedMinutes: null,
+      factor: null,
+      sampleCount: null,
+    });
+  });
+
+  test("estimatedMinutes が null なら null (UI に出さない)", () => {
+    expect(correctEstimate({ estimatedMinutes: null, taskCategory: "doc", factors })).toBeNull();
+  });
+
+  test("estimatedMinutes が 0 以下なら null", () => {
+    expect(correctEstimate({ estimatedMinutes: 0, taskCategory: "doc", factors })).toBeNull();
+    expect(correctEstimate({ estimatedMinutes: -5, taskCategory: "doc", factors })).toBeNull();
+  });
+
+  test("補正後が 1 分未満になる場合は 1 分に底上げ (0min 表示を避ける)", () => {
+    const tinyFactors = indexFactorsByCategory([
+      { taskCategory: "coding", factor: 0.01, sampleCount: 10 },
+    ]);
+    const result = correctEstimate({
+      estimatedMinutes: 5,
+      taskCategory: "coding",
+      factors: tinyFactors,
+    });
+    expect(result?.correctedMinutes).toBe(1);
+  });
+
+  test("minSampleCount オプションで閾値を変えられる", () => {
+    const result = correctEstimate({
+      estimatedMinutes: 30,
+      taskCategory: "research",
+      factors,
+      minSampleCount: 1,
+    });
+    expect(result?.correctedMinutes).toBe(45); // 30 * 1.5
+  });
+});
+
+describe("CORRECTION_CONSTANTS", () => {
+  test("Supabase view の境界値と一致する (contract)", () => {
+    // ADR 0024 / supabase/migrations/..._p3_9_estimation_correction_views.sql
+    expect(CORRECTION_CONSTANTS.OUTLIER_LOW).toBe(0.1);
+    expect(CORRECTION_CONSTANTS.OUTLIER_HIGH).toBe(10);
+    expect(CORRECTION_CONSTANTS.MIN_SAMPLE_COUNT).toBe(5);
+  });
+});

--- a/src/entities/task/correction.ts
+++ b/src/entities/task/correction.ts
@@ -1,0 +1,156 @@
+import type { TaskCategory } from "./types";
+
+/**
+ * 見積もり補正エンジン (Phase 3, P3-9 / #93) の純粋関数。
+ *
+ * - ADR 0024: task_category 別の中央値 + 外れ値クリップ + 最小サンプル数閾値
+ * - ADR 0025: Supabase view と同じロジックを TS でも持ち、両者を contract test で一致させる
+ *
+ * 値域 (外れ値の境界 / 最小サンプル数閾値) は code 側の constant で管理する。
+ * 実運用で「補正が暴れる」「効きが弱すぎる」が観測されたら issue で議論し、
+ * 本ファイルの constant を更新する (ADR 0024 の supersede ではない)。
+ */
+
+const OUTLIER_LOW = 0.1;
+const OUTLIER_HIGH = 10;
+const MIN_SAMPLE_COUNT = 5;
+
+export const CORRECTION_CONSTANTS = {
+  OUTLIER_LOW,
+  OUTLIER_HIGH,
+  MIN_SAMPLE_COUNT,
+} as const;
+
+/** 補正倍率の集計用サンプル (完了済みタスクの推定 / 実績ペア)。 */
+export type CorrectionSample = {
+  estimatedMinutes: number;
+  actualMinutes: number;
+};
+
+/** 補正倍率 1 件 (Supabase view `task_category_correction_factors` 1 行に対応)。 */
+export type CorrectionFactor = {
+  taskCategory: TaskCategory;
+  /** 中央値で算出された倍率 (`actual / estimated`)。 */
+  factor: number;
+  /** 外れ値クリップ後のサンプル数。閾値未満は補正適用しない。 */
+  sampleCount: number;
+};
+
+/** 補正倍率を category キーで引けるマップ (category 数は高々 5 件)。 */
+export type CorrectionFactorMap = Partial<Record<TaskCategory, CorrectionFactor>>;
+
+/** UI に渡す「補正後 + 元値」の組。 */
+export type CorrectedEstimate = {
+  /** 元の生 estimated_minutes (UI で副表示する元値)。 */
+  rawMinutes: number;
+  /** 補正後の分数。`task_category=null` / 閾値未満 / category にデータが無い時は null。 */
+  correctedMinutes: number | null;
+  /** 補正に使った倍率。補正適用時のみ。 */
+  factor: number | null;
+  /** 補正に使ったサンプル数。補正適用時のみ。 */
+  sampleCount: number | null;
+};
+
+/**
+ * 数値配列の中央値。空配列は NaN を返す (呼び出し側で件数チェック前提)。
+ *
+ * Supabase の `percentile_cont(0.5) WITHIN GROUP (ORDER BY ...)` は偶数件で
+ * 「中央 2 件の線形補間」を返す。本実装も同じ挙動 (平均) で揃える。
+ */
+export function median(values: readonly number[]): number {
+  if (values.length === 0) return Number.NaN;
+  const sorted = [...values].sort((a, b) => a - b);
+  const n = sorted.length;
+  const mid = Math.floor(n / 2);
+  return n % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+/**
+ * `actual / estimated` が外れ値クリップ範囲内かどうか。
+ * NaN / Infinity は false。境界値 (`0.1` / `10`) は inclusive (Supabase view の `between` と一致)。
+ */
+export function isWithinOutlierRange(ratio: number): boolean {
+  return Number.isFinite(ratio) && ratio >= OUTLIER_LOW && ratio <= OUTLIER_HIGH;
+}
+
+/**
+ * サンプル列から補正倍率と件数を算出する。Supabase view と同じ集計。
+ *
+ * - `estimated <= 0` / `actual <= 0` のサンプルは除外 (除算不能 / 未消化)
+ * - `actual / estimated` が `[0.1, 10]` 範囲外のサンプルは除外 (外れ値)
+ * - 残ったサンプルの ratio の中央値を返す
+ *
+ * 全サンプルが除外された場合は null。
+ */
+export function computeCorrectionFactor(
+  samples: readonly CorrectionSample[],
+): { factor: number; sampleCount: number } | null {
+  const ratios: number[] = [];
+  for (const s of samples) {
+    if (s.estimatedMinutes <= 0) continue;
+    if (s.actualMinutes <= 0) continue;
+    const ratio = s.actualMinutes / s.estimatedMinutes;
+    if (!isWithinOutlierRange(ratio)) continue;
+    ratios.push(ratio);
+  }
+  if (ratios.length === 0) return null;
+  return { factor: median(ratios), sampleCount: ratios.length };
+}
+
+/**
+ * Supabase view の出力 (`task_category_correction_factors`) を category キーマップに整形する。
+ * 同じ category が重複していたら **後勝ち** (view 側で UNIQUE が保証されているので通常は起きない)。
+ */
+export function indexFactorsByCategory(factors: readonly CorrectionFactor[]): CorrectionFactorMap {
+  const out: CorrectionFactorMap = {};
+  for (const f of factors) {
+    out[f.taskCategory] = f;
+  }
+  return out;
+}
+
+/**
+ * 1 タスクの見積もりに補正を適用する。
+ *
+ * 補正適用条件:
+ * - `estimatedMinutes` が正の数
+ * - `taskCategory` が non-null
+ * - factors に当該 category のエントリがある
+ * - そのエントリの `sampleCount >= minSampleCount`
+ *
+ * いずれか満たさない場合は `correctedMinutes = null` のまま元値だけ返す。
+ * `estimatedMinutes` が null / 0 以下なら `null` を返す (UI で出さない)。
+ */
+export function correctEstimate(args: {
+  estimatedMinutes: number | null;
+  taskCategory: TaskCategory | null;
+  factors: CorrectionFactorMap;
+  /** デフォルト 5 (CORRECTION_CONSTANTS.MIN_SAMPLE_COUNT)。 */
+  minSampleCount?: number;
+}): CorrectedEstimate | null {
+  const { estimatedMinutes, taskCategory, factors, minSampleCount = MIN_SAMPLE_COUNT } = args;
+  if (estimatedMinutes === null || estimatedMinutes <= 0) return null;
+
+  const base: CorrectedEstimate = {
+    rawMinutes: estimatedMinutes,
+    correctedMinutes: null,
+    factor: null,
+    sampleCount: null,
+  };
+  if (taskCategory === null) return base;
+
+  const f = factors[taskCategory];
+  if (!f || f.sampleCount < minSampleCount) return base;
+
+  // 表示単位は分。少数を切り上げ / 切り捨てではなく四捨五入で揃える
+  // (1.5x で 30 → 45 のような分かりやすい値が出やすいため)。
+  const rounded = Math.round(estimatedMinutes * f.factor);
+  // 倍率が極小で 0 分に丸まった場合は 1 分に底上げする (0 分表示は意味がない)。
+  const correctedMinutes = rounded < 1 ? 1 : rounded;
+  return {
+    rawMinutes: estimatedMinutes,
+    correctedMinutes,
+    factor: f.factor,
+    sampleCount: f.sampleCount,
+  };
+}

--- a/src/entities/task/gateway.ts
+++ b/src/entities/task/gateway.ts
@@ -1,3 +1,4 @@
+import type { CorrectionFactor } from "./correction";
 import type { DecomposeStatus, Task, TaskCategory } from "./types";
 
 export type CreateTaskInput = {
@@ -38,4 +39,11 @@ export interface TaskGateway {
   reorder(entries: readonly { id: string; stackOrder: number | null }[]): Promise<void>;
   delete(id: string): Promise<void>;
   deleteAllForCurrentUser(): Promise<void>;
+  /**
+   * 見積もり補正倍率の取得 (P3-9 / #93、ADR 0024 / 0025)。
+   * Supabase view `task_category_correction_factors` を読む薄ラッパー。
+   * 行が無い場合 (= 完了タスクが無い / 全 category が外れ値で除外された) は空配列。
+   * 最小サンプル数判定はここでは行わず、呼び出し側 (`correctEstimate`) で判定する。
+   */
+  listCorrectionFactors(): Promise<CorrectionFactor[]>;
 }

--- a/src/entities/task/supabase-gateway.test.ts
+++ b/src/entities/task/supabase-gateway.test.ts
@@ -152,3 +152,48 @@ describe("SupabaseTaskGateway: task_category mapping", () => {
     expect(tasks[0]!.taskCategory).toBe("admin");
   });
 });
+
+describe("SupabaseTaskGateway: listCorrectionFactors (P3-9 / #93)", () => {
+  function makeViewClient(
+    rows: { task_category: string; sample_count: number; factor: unknown }[],
+  ) {
+    const select = vi.fn(async () => ({ data: rows, error: null }));
+    const from = vi.fn(() => ({ select }));
+    const client = { from } as unknown as SupabaseClient<Database>;
+    return { client, from, select };
+  }
+
+  test("view 行を CorrectionFactor[] に写し、factor は Number で正規化する", async () => {
+    // PostgREST 経由だと numeric が string で来る場合がある (ADR 0024 / 0025)。
+    const { client, from } = makeViewClient([
+      { task_category: "coding", sample_count: 10, factor: "0.8" },
+      { task_category: "doc", sample_count: 7, factor: 2.2 },
+    ]);
+
+    const gateway = new SupabaseTaskGateway(client);
+    const factors = await gateway.listCorrectionFactors();
+
+    expect(from).toHaveBeenCalledWith("task_category_correction_factors");
+    expect(factors).toEqual([
+      { taskCategory: "coding", factor: 0.8, sampleCount: 10 },
+      { taskCategory: "doc", factor: 2.2, sampleCount: 7 },
+    ]);
+  });
+
+  test("view 行が無ければ空配列 (補正対象タスクが無い / 全 category が外れ値除外)", async () => {
+    const { client } = makeViewClient([]);
+    const gateway = new SupabaseTaskGateway(client);
+
+    expect(await gateway.listCorrectionFactors()).toEqual([]);
+  });
+
+  test("RLS は view 側 (security_invoker=true) なので user_id 絞り込みは書かない", async () => {
+    const { client, from, select } = makeViewClient([]);
+    const gateway = new SupabaseTaskGateway(client);
+
+    await gateway.listCorrectionFactors();
+    // from + select だけで eq() / filter() は呼ばれない
+    expect(from).toHaveBeenCalledTimes(1);
+    expect(select).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/entities/task/supabase-gateway.ts
+++ b/src/entities/task/supabase-gateway.ts
@@ -3,6 +3,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { ACTION_TYPES, log } from "@/entities/action-log/logger";
 import type { Database, Tables, TablesInsert, TablesUpdate } from "@/shared/types/database";
 
+import type { CorrectionFactor } from "./correction";
 import type { CreateTaskInput, TaskGateway, UpdateTaskInput } from "./gateway";
 import type { Task } from "./types";
 
@@ -116,5 +117,21 @@ export class SupabaseTaskGateway implements TaskGateway {
     const uid = await getUserId(this.supabase);
     const { error } = await this.supabase.from("tasks").delete().eq("user_id", uid);
     if (error) throw error;
+  }
+
+  async listCorrectionFactors(): Promise<CorrectionFactor[]> {
+    // RLS は view 側 (security_invoker=true) で auth.uid() ベースに効くので、
+    // user_id の絞り込みは明示的に書かない。
+    const { data, error } = await this.supabase
+      .from("task_category_correction_factors")
+      .select("task_category, sample_count, factor");
+    if (error) throw error;
+    return (data ?? []).map((row) => ({
+      taskCategory: row.task_category,
+      // PostgreSQL の `numeric` は PostgREST 経由で string に乗ることがあるので
+      // Number に揃えてから返す (Supabase JS の型は number だが防御的に統一)。
+      factor: Number(row.factor),
+      sampleCount: row.sample_count,
+    }));
   }
 }

--- a/src/features/task-detail/TaskDetailPanel.test.tsx
+++ b/src/features/task-detail/TaskDetailPanel.test.tsx
@@ -4,6 +4,8 @@ import type { LatestDecomposeLog } from "../../entities/action-log/gateway";
 import type { Event } from "../../entities/event/types";
 import type { Project } from "../../entities/project/types";
 import { ProjectsProvider } from "../../entities/project/ProjectsContext";
+import { CorrectionFactorsProvider } from "../../entities/task/CorrectionFactorsContext";
+import type { CorrectionFactor } from "../../entities/task/correction";
 import type { Task } from "../../entities/task/types";
 import { TaskDetailPanel, type TaskDetailPanelProps } from "./TaskDetailPanel";
 
@@ -20,8 +22,12 @@ afterEach(() => {
 const projects: Project[] = [
   { id: "slo", name: "SLO推進", color: "#2D9F45", isPrimary: true, createdAt: "" },
 ];
-const render = (ui: React.ReactElement) =>
-  rtlRender(<ProjectsProvider projects={projects}>{ui}</ProjectsProvider>);
+const render = (ui: React.ReactElement, options: { factors?: readonly CorrectionFactor[] } = {}) =>
+  rtlRender(
+    <ProjectsProvider projects={projects}>
+      <CorrectionFactorsProvider factors={options.factors ?? []}>{ui}</CorrectionFactorsProvider>
+    </ProjectsProvider>,
+  );
 
 const baseTask: Task = {
   id: "t1",
@@ -42,7 +48,10 @@ const baseTask: Task = {
 
 const noop = () => {};
 
-function renderPanel(overrides: Partial<TaskDetailPanelProps> = {}) {
+function renderPanel(
+  overrides: Partial<TaskDetailPanelProps> = {},
+  options: { factors?: readonly CorrectionFactor[] } = {},
+) {
   const props: TaskDetailPanelProps = {
     task: baseTask,
     events: [],
@@ -51,7 +60,7 @@ function renderPanel(overrides: Partial<TaskDetailPanelProps> = {}) {
     onToggleDone: noop,
     ...overrides,
   };
-  return render(<TaskDetailPanel {...props} />);
+  return render(<TaskDetailPanel {...props} />, options);
 }
 
 describe("TaskDetailPanel", () => {
@@ -592,5 +601,60 @@ describe("TaskDetailPanel - AI 分解情報エリア (P3-15)", () => {
     // <section aria-label="..."> は ARIA で region として扱われる
     const section = getByRole("region", { name: "AI 分解情報" });
     expect(section).toBeTruthy();
+  });
+});
+
+describe("TaskDetailPanel: 見積もり補正 (P3-9 / #93、ADR 0026)", () => {
+  test("補正なし (category null) は元値だけを faint で出し、自然文は出さない", () => {
+    const { getByText, queryByText } = renderPanel(
+      { task: { ...baseTask, estimatedMinutes: 30, taskCategory: null } },
+      {
+        factors: [{ taskCategory: "doc", factor: 2.2, sampleCount: 7 }],
+      },
+    );
+    expect(getByText("30m")).toBeTruthy();
+    expect(queryByText(/同じ種類のタスク/)).toBeNull();
+    expect(queryByText(/あなたの見積もり/)).toBeNull();
+  });
+
+  test("補正適用時はヘッダに補正後を出し、title 下の自然文に元値と倍率を添える", () => {
+    const { getByText, queryByText } = renderPanel(
+      {
+        task: { ...baseTask, estimatedMinutes: 30, taskCategory: "doc" },
+      },
+      {
+        factors: [{ taskCategory: "doc", factor: 2.2, sampleCount: 7 }],
+      },
+    );
+    // ヘッダに補正後の値 (30 * 2.2 = 66 → 1h06m)
+    expect(getByText("1h06m")).toBeTruthy();
+    // 自然文ライン (補正の存在は明言しない、ADR 0026)
+    expect(getByText(/あなたの見積もり 30m/)).toBeTruthy();
+    expect(getByText(/同じ種類のタスクは平均 2\.2 倍かかっています/)).toBeTruthy();
+    // ADR 0026: 「補正係数」「補正済み」「元」「確保」等のラベルは出さない
+    expect(queryByText(/補正/)).toBeNull();
+    expect(queryByText(/^元 /)).toBeNull();
+  });
+
+  test("最小サンプル数閾値未満は補正なし扱い (元値のみ + 自然文なし)", () => {
+    const { getByText, queryByText } = renderPanel(
+      {
+        task: { ...baseTask, estimatedMinutes: 30, taskCategory: "doc" },
+      },
+      {
+        factors: [{ taskCategory: "doc", factor: 2.2, sampleCount: 2 }],
+      },
+    );
+    expect(getByText("30m")).toBeTruthy();
+    expect(queryByText(/同じ種類のタスク/)).toBeNull();
+  });
+
+  test("estimatedMinutes が null なら見積もり関連の表示は一切出ない", () => {
+    const { queryByText } = renderPanel(
+      { task: { ...baseTask, estimatedMinutes: null, taskCategory: "doc" } },
+      { factors: [{ taskCategory: "doc", factor: 2.2, sampleCount: 7 }] },
+    );
+    expect(queryByText(/30m/)).toBeNull();
+    expect(queryByText(/あなたの見積もり/)).toBeNull();
   });
 });

--- a/src/features/task-detail/TaskDetailPanel.tsx
+++ b/src/features/task-detail/TaskDetailPanel.tsx
@@ -4,6 +4,8 @@ import type { DecomposeFailReason } from "../../entities/action-log/types";
 import type { Event } from "../../entities/event/types";
 import { getProject } from "../../entities/project/projects";
 import { useProjects } from "../../entities/project/ProjectsContext";
+import { useCorrectionFactors } from "../../entities/task/CorrectionFactorsContext";
+import { correctEstimate } from "../../entities/task/correction";
 import type { Task, TaskCategory } from "../../entities/task/types";
 import { renderMarkdown } from "../../shared/lib/markdown";
 import { isDone } from "../../shared/lib/task";
@@ -73,6 +75,13 @@ export function TaskDetailPanel({
   const proj = getProject(projectsById, task.projectId);
   const dep = task.dependsOnEventId ? events.find((e) => e.id === task.dependsOnEventId) : null;
   const done = isDone(task);
+  const factors = useCorrectionFactors();
+  // P3-9 / #93、ADR 0026: 補正後 + 元値の組。null ならヘッダの見積もり表示自体を出さない。
+  const estimate = correctEstimate({
+    estimatedMinutes: task.estimatedMinutes,
+    taskCategory: task.taskCategory,
+    factors,
+  });
 
   // 依存先候補は「未来のイベント + 現在選択中のイベント (過去でも保持表示)」。
   // 過去のイベントを新規依存先にしても意味がないが、既存の依存先を勝手に外すと混乱するため残す。
@@ -110,11 +119,19 @@ export function TaskDetailPanel({
           <div className="mb-2 flex items-center gap-2">
             <div className="h-2 w-2 rounded-full" style={{ background: proj.color }} />
             <span className="font-jp text-[10px] text-fg-subtle">{proj.name}</span>
-            {task.estimatedMinutes !== null && (
-              <span className="text-[9px] tabular-nums text-fg-faint">
-                {fmtDuration(task.estimatedMinutes)}
+            {estimate?.correctedMinutes !== null && estimate !== null ? (
+              // ADR 0026 詳細パネル: ヘッダは補正後だけを大きく出し、元値と倍率は title 下の自然文で添える。
+              <span
+                aria-label={`${fmtDuration(estimate.correctedMinutes)} を確保`}
+                className="text-[10px] tabular-nums text-fg-muted"
+              >
+                {fmtDuration(estimate.correctedMinutes)}
               </span>
-            )}
+            ) : estimate ? (
+              <span aria-label="見積もり" className="text-[9px] tabular-nums text-fg-faint">
+                {fmtDuration(estimate.rawMinutes)}
+              </span>
+            ) : null}
             {dep && (
               <span className="rounded-[3px] bg-[#E85D0415] px-1.5 py-px font-jp text-[9px] text-accent-amber">
                 ← {formatRelativeTime(dep.startTime, nowDate)} {dep.title}
@@ -138,6 +155,14 @@ export function TaskDetailPanel({
           <h2 className="m-0 font-jp text-[16px] font-bold leading-[1.4] text-fg-strong">
             {task.title}
           </h2>
+          {estimate?.correctedMinutes !== null && estimate !== null && (
+            // ADR 0026 詳細パネル: 元値を自然文で添え、補正の存在を明言しない文脈的な文言で倍率を示す。
+            // 「補正係数」「補正済み」等の言い回しは出さない。
+            <p className="mt-1 font-jp text-[10px] leading-[1.5] text-fg-subtle">
+              あなたの見積もり {fmtDuration(estimate.rawMinutes)} ・ 同じ種類のタスクは平均{" "}
+              {formatFactor(estimate.factor!)} 倍かかっています
+            </p>
+          )}
         </div>
 
         {onChangeDependency && (
@@ -441,6 +466,16 @@ function rawResponseFromLog(log: LatestDecomposeLog): string | null {
   if (log.action_type === "task_decompose_skipped") return log.metadata.raw_response;
   // task_decompose_failed: raw_response は generate が応答を返した後に失敗した場合のみ存在
   return log.metadata.raw_response ?? null;
+}
+
+/**
+ * 補正倍率を「同じ種類のタスクは平均 X.X 倍かかっています」形式で添えるための整形 (ADR 0026)。
+ * - 0.95〜1.05 のような微差は「1.0」では補正の存在を不自然に明示するので
+ *   小数 1 桁で四捨五入して文脈的に出す。
+ * - 0.1 以下や 10 以上は外れ値クリップで除外されているので来ない (correction.ts 側で担保)。
+ */
+function formatFactor(factor: number): string {
+  return factor.toFixed(1);
 }
 
 // ADR 0015 / #90: タスク種類 override の表示ラベル。値域 (TASK_CATEGORY_VALUES) は

--- a/src/features/task-stack/CorrectedEstimate.test.tsx
+++ b/src/features/task-stack/CorrectedEstimate.test.tsx
@@ -1,0 +1,90 @@
+import { render } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import type { CorrectedEstimate as CorrectedEstimateValue } from "@/entities/task/correction";
+
+import { CorrectedEstimate } from "./CorrectedEstimate";
+
+/**
+ * 補正後 + 元値の併記表示 (P3-9 / #93、ADR 0026) のレンダリング契約。
+ *
+ * ADR 0026 で禁止された表現 (取消線・矢印・「元」「補正後」「確保」等のラベル) が
+ * 出ないことを踏む。これは PR レビュー時の「安直な表現に戻る」防止網。
+ */
+
+describe("CorrectedEstimate", () => {
+  test("estimate=null のときは何も描画しない", () => {
+    const { container } = render(<CorrectedEstimate estimate={null} variant="top" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("補正なしは元値だけを faint で出す (現行 UI 後退無し)", () => {
+    const estimate: CorrectedEstimateValue = {
+      rawMinutes: 30,
+      correctedMinutes: null,
+      factor: null,
+      sampleCount: null,
+    };
+    const { getByText, queryByText } = render(
+      <CorrectedEstimate estimate={estimate} variant="top" />,
+    );
+    expect(getByText("30m")).toBeTruthy();
+    // 補正値が無いので併記しない
+    expect(queryByText("·")).toBeNull();
+  });
+
+  test("補正ありは『補正後 · 元値』の順で併記する", () => {
+    const estimate: CorrectedEstimateValue = {
+      rawMinutes: 30,
+      correctedMinutes: 45,
+      factor: 1.5,
+      sampleCount: 10,
+    };
+    const { getByText } = render(<CorrectedEstimate estimate={estimate} variant="top" />);
+    // 補正後と元値が両方表示される
+    expect(getByText("45m")).toBeTruthy();
+    expect(getByText("30m")).toBeTruthy();
+    // 区切りは middle dot (取消線・矢印・括弧は使わない; ADR 0026)
+    expect(getByText("·")).toBeTruthy();
+  });
+
+  test("ADR 0026: ラベル (元 / 補正後 / 確保 等) は表示しない", () => {
+    const estimate: CorrectedEstimateValue = {
+      rawMinutes: 30,
+      correctedMinutes: 45,
+      factor: 1.5,
+      sampleCount: 10,
+    };
+    const { queryByText, container } = render(
+      <CorrectedEstimate estimate={estimate} variant="top" />,
+    );
+    expect(queryByText(/補正/)).toBeNull();
+    expect(queryByText(/^元/)).toBeNull();
+    // 取消線 / 矢印が含まれていないことの軽い踏みつけ
+    const html = container.innerHTML;
+    expect(html).not.toMatch(/line-through/);
+    expect(html).not.toMatch(/→/);
+  });
+
+  test("variant=row はサイズ階層を一段小さく出す", () => {
+    const estimate: CorrectedEstimateValue = {
+      rawMinutes: 30,
+      correctedMinutes: null,
+      factor: null,
+      sampleCount: null,
+    };
+    const { container } = render(<CorrectedEstimate estimate={estimate} variant="row" />);
+    expect(container.innerHTML).toMatch(/text-\[9px\]/);
+  });
+
+  test("variant=top は一段大きい (Stack View Top カード上ゾーン)", () => {
+    const estimate: CorrectedEstimateValue = {
+      rawMinutes: 30,
+      correctedMinutes: null,
+      factor: null,
+      sampleCount: null,
+    };
+    const { container } = render(<CorrectedEstimate estimate={estimate} variant="top" />);
+    expect(container.innerHTML).toMatch(/text-\[10px\]/);
+  });
+});

--- a/src/features/task-stack/CorrectedEstimate.tsx
+++ b/src/features/task-stack/CorrectedEstimate.tsx
@@ -1,0 +1,53 @@
+import type { CorrectedEstimate as CorrectedEstimateValue } from "@/entities/task/correction";
+import { fmtDuration } from "@/shared/lib/time";
+
+/**
+ * 見積もり (補正後 + 元値) の併記表示 (P3-9 / #93、ADR 0026)。
+ *
+ * - 補正後を主表示 / 元値を muted で副表示。ラベル・取消線・矢印は使わない (ADR 0026)。
+ * - 補正なし (`correctedMinutes === null`) は元値だけを既存と同じ trim で出す。
+ * - `estimate === null` (元値も無い) は何も描画しない (caller は条件分岐不要)。
+ *
+ * 区切り記号は ADR 0026 の方針に従い middle dot `·` を採用。
+ *
+ * variant:
+ * - `top`   : Top カード上ゾーン (`text-[10px]`)。補正後を主色、元値を muted で sm。
+ * - `row`   : 行カード Row 1 / 詳細パネル ヘッダ (`text-[9px]`)。同じ階層をひと回り小さく。
+ */
+type Props = {
+  estimate: CorrectedEstimateValue | null;
+  variant: "top" | "row";
+};
+
+export function CorrectedEstimate({ estimate, variant }: Props) {
+  if (estimate === null) return null;
+
+  const mainSizeClass = variant === "top" ? "text-[10px]" : "text-[9px]";
+  // 元値は併記時に一段小さく出して階層を作る (ADR 0026: 大小コントラスト)。
+  const rawSizeClass = variant === "top" ? "text-[9px]" : "text-[8px]";
+
+  if (estimate.correctedMinutes === null) {
+    // 補正なし: 元値だけ、従来通り faint で表示する (UI 後退無し)。
+    return (
+      <span aria-label="見積もり" className={`${mainSizeClass} tabular-nums text-fg-faint`}>
+        {fmtDuration(estimate.rawMinutes)}
+      </span>
+    );
+  }
+
+  const correctedLabel = `${fmtDuration(estimate.correctedMinutes)} を確保`;
+  const rawLabel = `あなたの見積もり ${fmtDuration(estimate.rawMinutes)}`;
+  return (
+    <span aria-label="見積もり" className="inline-flex items-baseline gap-1">
+      <span aria-label={correctedLabel} className={`${mainSizeClass} tabular-nums text-fg-muted`}>
+        {fmtDuration(estimate.correctedMinutes)}
+      </span>
+      <span aria-hidden="true" className={`${rawSizeClass} text-fg-faint`}>
+        ·
+      </span>
+      <span aria-label={rawLabel} className={`${rawSizeClass} tabular-nums text-fg-faint`}>
+        {fmtDuration(estimate.rawMinutes)}
+      </span>
+    </span>
+  );
+}

--- a/src/features/task-stack/TaskRow.tsx
+++ b/src/features/task-stack/TaskRow.tsx
@@ -3,10 +3,13 @@ import type { PointerEvent as ReactPointerEvent } from "react";
 import { getProject } from "@/entities/project/projects";
 import { useProjects } from "@/entities/project/ProjectsContext";
 import type { Event } from "@/entities/event/types";
+import { useCorrectionFactors } from "@/entities/task/CorrectionFactorsContext";
+import { correctEstimate } from "@/entities/task/correction";
 import type { Task } from "@/entities/task/types";
 import { ParallelogramProgress } from "@/shared/ui/ParallelogramProgress";
-import { IMMINENT_THRESHOLD_MS, fmtDuration, formatRelativeTime } from "@/shared/lib/time";
+import { IMMINENT_THRESHOLD_MS, formatRelativeTime } from "@/shared/lib/time";
 
+import { CorrectedEstimate } from "./CorrectedEstimate";
 import { Grip } from "./Grip";
 import type { Progress } from "./stackItems";
 import { StatusPill } from "./StatusPill";
@@ -48,6 +51,12 @@ export function TaskRow({
 }: TaskRowProps) {
   const { projectsById } = useProjects();
   const proj = getProject(projectsById, task.projectId);
+  const factors = useCorrectionFactors();
+  const estimate = correctEstimate({
+    estimatedMinutes: task.estimatedMinutes,
+    taskCategory: task.taskCategory,
+    factors,
+  });
 
   // ADR 0016 §6: 子は親の dependsOnEventId を継承 (子自身の値がなければ親に fallback)。
   const effectiveDepId = task.dependsOnEventId ?? parent?.dependsOnEventId ?? null;
@@ -86,11 +95,7 @@ export function TaskRow({
           style={{ background: proj.color }}
         />
         <span className="flex-1 truncate font-jp text-[12px] text-fg-muted">{task.title}</span>
-        {task.estimatedMinutes !== null && (
-          <span className="text-[9px] tabular-nums text-fg-faint">
-            {fmtDuration(task.estimatedMinutes)}
-          </span>
-        )}
+        {estimate && <CorrectedEstimate estimate={estimate} variant="row" />}
       </div>
       {/* Row 2: dep event (右詰) */}
       {dep && (

--- a/src/features/task-stack/TopTaskCard.tsx
+++ b/src/features/task-stack/TopTaskCard.tsx
@@ -3,12 +3,15 @@ import type { PointerEvent as ReactPointerEvent } from "react";
 import type { Event } from "@/entities/event/types";
 import { getProject } from "@/entities/project/projects";
 import { useProjects } from "@/entities/project/ProjectsContext";
+import { useCorrectionFactors } from "@/entities/task/CorrectionFactorsContext";
+import { correctEstimate } from "@/entities/task/correction";
 import type { PauseReason } from "@/entities/task/time-entries";
 import type { Task } from "@/entities/task/types";
 import { bodyPreview } from "@/shared/lib/body-preview";
 import { IMMINENT_THRESHOLD_MS, fmtDuration, formatRelativeTime } from "@/shared/lib/time";
 import { ParallelogramProgress } from "@/shared/ui/ParallelogramProgress";
 
+import { CorrectedEstimate } from "./CorrectedEstimate";
 import { Grip } from "./Grip";
 import { pauseReasonLabel } from "./PauseReasonModal";
 import type { Progress } from "./stackItems";
@@ -69,6 +72,13 @@ export function TopTaskCard({
 }: TopTaskCardProps) {
   const { projectsById } = useProjects();
   const proj = getProject(projectsById, task.projectId);
+  const factors = useCorrectionFactors();
+  // P3-9 / #93、ADR 0024 / 0026: 補正後 + 元値の組。category null / サンプル不足は元値のみ。
+  const estimate = correctEstimate({
+    estimatedMinutes: task.estimatedMinutes,
+    taskCategory: task.taskCategory,
+    factors,
+  });
 
   // ADR 0016 §6: 子は親の dependsOnEventId を継承 (子自身の値がなければ親に fallback)。
   const effectiveDepId = task.dependsOnEventId ?? parent?.dependsOnEventId ?? null;
@@ -133,9 +143,9 @@ export function TopTaskCard({
                 中断: {pauseReasonLabel(pauseReason)}
               </span>
             )}
-            {task.estimatedMinutes !== null && (
-              <span className="ml-auto text-[10px] tabular-nums text-fg-faint">
-                {fmtDuration(task.estimatedMinutes)}
+            {estimate && (
+              <span className="ml-auto">
+                <CorrectedEstimate estimate={estimate} variant="top" />
               </span>
             )}
           </div>


### PR DESCRIPTION
## 概要 (What)

Phase 3 見積もり補正エンジン (#93) の **算出ロジック + UI 配線**。設計 ADR と view は別 PR (#135) で済んでおり、本 PR は TS 純粋関数 / gateway / Top カード・行カード・詳細パネルへの表示まで。

## 関連 Issue

Closes #93

## 背景 (Why)

差別化の核 ([vision.md](../blob/main/docs/design/vision.md)) は「行動データを蓄積して個人最適化する」ことで、補正エンジンは Phase 3 で立ち上げる **行動データの最初の output**。

設計判断は前 PR で確定済み:

- [ADR 0024](../blob/main/docs/adr/0024-estimation-correction-by-category-median.md): `task_category` 別の中央値 + 外れ値クリップ + 最小サンプル数閾値
- [ADR 0025](../blob/main/docs/adr/0025-estimation-correction-via-supabase-view-and-pure-fn.md): Supabase view + TS 純粋関数の二重実装 (contract test で同等性担保)
- [ADR 0026](../blob/main/docs/adr/0026-estimation-correction-display-style.md): 大小コントラストで併記、取消線・矢印・ラベルは使わない

本 PR で issue #93 の完了条件 5 項目すべてを踏む。

## Before → After (考え方の差分)

**Before:** Top カード / 行カード / 詳細パネルでは生 `estimated_minutes` を小さい faint で出すだけ。kozutsumi が「行動データを使って何かを返す」面が UI に存在しない。

**After:** 完了タスクが `task_category` 別に 5 件以上溜まると、補正後の値が主表示 / 元値が副表示で併記される。詳細パネルは「あなたの見積もり 30m · 同じ種類のタスクは平均 2.2 倍かかっています」の自然文で補正を明言せず添える (ADR 0026)。閾値未満 / category null / fetch 失敗 / view 不在は元値だけ表示で **現行 UI が後退しない**。

行動データを使った最初の output が UI に出る = Phase 4 の行動パターン分析・LLM 妥当性検証の入力源が動き始める。

## 追加したテスト (How verified)

unit / integration:

- `entities/task/correction.test.ts` (25 件): median / 外れ値クリップ / 最小サンプル数判定 / `correctEstimate` の全分岐 + Supabase view との contract 用定数の一致確認
- `entities/task/supabase-gateway.test.ts` (+3 件): `listCorrectionFactors` の view → `CorrectionFactor[]` mapping、PostgREST の numeric が string で来る場合の正規化、RLS 委譲 (security_invoker) で `eq` を呼ばないこと
- `features/task-stack/CorrectedEstimate.test.tsx` (6 件): ADR 0026 で **禁止** された表現 (取消線・矢印・「補正」「元」「確保」ラベル) が出ないことを踏みつけ — PR レビュー時に「安直に取消線で良いじゃん」が戻るのを防ぐ
- `features/task-detail/TaskDetailPanel.test.tsx` (+4 件): 補正適用 / 閾値未満 / category null / `estimatedMinutes=null` の各分岐で自然文と元値の表示有無を踏む

合計 +13 件 (440 → 453)。typecheck / eslint / prettier も clean。

カバーできていない領域:

- **e2e**: 補正値表示の semantic locator は `#96 (P3-11)` でまとめて踏む
- **SQL 実環境での contract test**: ADR 0025 が要求する「view と TS 関数が同じ入力で同じ出力を返す」の SQL 側確認は seed 整備が必要。Phase 4 の行動パターン分析で seed が要るタイミングで一緒に整備する想定

## リリース前チェックリスト

- [x] マイグレーション: 前 PR #135 で適用済み (本 PR では追加なし)
- [x] 環境変数 / シークレット: 追加なし
- [x] フィーチャーフラグ: なし (補正は augmentation only / fail-soft で動く、ADR 0013)
- [x] 既存ユーザーへの影響: 完了タスクが無い user / category null の user は **何も変わらない** (元値表示が継続)

## このPRの範囲外 (Out of scope)

- **e2e で AI バイパス + core path 不変条件を踏む** → issue #96 (P3-11) で別 PR
- **時間帯×タスク種類のクロス分析** → Phase 4 (architecture.md §1.5、ADR 0024 Notes に supersede しない理由を記載済み)
- **既存タスクの category backfill** → issue #93 非スコープ
- **補正値をスケジューラ計算に流す** → Phase 4 のスコアリング (#1.8) で別軸

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKM6QcDpFcuc49VKn72GRN)_