### PR TITLE
test(e2e): Phase 3 AI 経路バイパス + Variant E core path の不変条件 (P3-11)

### DIFF
--- a/e2e/db.ts
+++ b/e2e/db.ts
@@ -123,6 +123,8 @@ export type TimeEntryRow = {
   duration_seconds: number | null;
 };
 
+export type DecomposeStatus = "none" | "decomposing" | "decomposed" | "skipped" | "failed";
+
 export type TaskRow = {
   id: string;
   user_id: string;
@@ -134,6 +136,8 @@ export type TaskRow = {
   stack_order: number | null;
   depends_on_event_id: string | null;
   task_category: "coding" | "doc" | "research" | "admin" | "other" | null;
+  parent_task_id: string | null;
+  decompose_status: DecomposeStatus;
   completed_at: string | null;
 };
 
@@ -226,6 +230,78 @@ export async function getTimeEntries(
   return (data ?? []) as TimeEntryRow[];
 }
 
+/**
+ * UI を経由せずに tasks 行を 1 件 insert する (P3-11)。
+ *
+ * AddPanel 経路は AppShell の triggerDecompose / triggerCategorize を巻き込むため、
+ * `decompose_status` や `parent_task_id` を狙った状態で seed したいケース
+ * (例: `decomposed` 親 + 子、`none` の leaf-parent) ではこちらを使う。
+ *
+ * RLS は service_role でバイパスされる。
+ */
+export async function seedTask(
+  admin: SupabaseClient,
+  input: {
+    userId: string;
+    projectId: string;
+    title: string;
+    stackOrder: number;
+    parentTaskId?: string | null;
+    decomposeStatus?: DecomposeStatus;
+    estimatedMinutes?: number | null;
+    status?: TaskRow["status"];
+    taskCategory?: TaskRow["task_category"];
+    body?: string;
+    completedAt?: string | null;
+  },
+): Promise<TaskRow> {
+  const { data, error } = await admin
+    .from("tasks")
+    .insert({
+      user_id: input.userId,
+      project_id: input.projectId,
+      title: input.title,
+      body: input.body ?? "",
+      stack_order: input.stackOrder,
+      parent_task_id: input.parentTaskId ?? null,
+      decompose_status: input.decomposeStatus ?? "none",
+      estimated_minutes: input.estimatedMinutes ?? null,
+      status: input.status ?? "idle",
+      task_category: input.taskCategory ?? null,
+      completed_at: input.completedAt ?? null,
+    })
+    .select("*")
+    .single();
+  if (error || !data) {
+    throw new Error(`[e2e] seedTask(${input.title}) failed: ${error?.message ?? "no row"}`);
+  }
+  return data as TaskRow;
+}
+
+/**
+ * UI を経由せずに projects 行を 1 件 insert する (P3-11)。
+ * seedTask と組で使い、AddPanel を踏まずに DB を準備する。
+ */
+export async function seedProject(
+  admin: SupabaseClient,
+  input: { userId: string; name: string; color?: string; isPrimary?: boolean },
+): Promise<ProjectRow> {
+  const { data, error } = await admin
+    .from("projects")
+    .insert({
+      user_id: input.userId,
+      name: input.name,
+      color: input.color ?? "#5B8DEF",
+      is_primary: input.isPrimary ?? false,
+    })
+    .select("*")
+    .single();
+  if (error || !data) {
+    throw new Error(`[e2e] seedProject(${input.name}) failed: ${error?.message ?? "no row"}`);
+  }
+  return data as ProjectRow;
+}
+
 export async function getTaskByTitle(
   admin: SupabaseClient,
   userId: string,
@@ -241,6 +317,21 @@ export async function getTaskByTitle(
     throw new Error(`[e2e] getTaskByTitle(${title}) failed: ${error?.message ?? "not found"}`);
   }
   return data as TaskRow;
+}
+
+/**
+ * ユーザーの tasks を一括取得する (P3-11 で「子レコードが作られないこと」を踏むのに使う)。
+ */
+export async function getTasksForUser(admin: SupabaseClient, userId: string): Promise<TaskRow[]> {
+  const { data, error } = await admin
+    .from("tasks")
+    .select("*")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: true });
+  if (error) {
+    throw new Error(`[e2e] getTasksForUser failed: ${error.message}`);
+  }
+  return (data ?? []) as TaskRow[];
 }
 
 export async function getProjectByName(

--- a/e2e/phase3-ai-bypass-invariants.spec.ts
+++ b/e2e/phase3-ai-bypass-invariants.spec.ts
@@ -97,9 +97,9 @@ test.describe("Variant E core path 不変条件 (ADR 0016)", () => {
     await expect(top.getByText("未分解", { exact: true })).toBeVisible();
 
     // 補正後見積もり無しの fallback: aria-label="見積もり" の単独 span (CorrectedEstimate `correctedMinutes === null`)。
-    // raw は fmtDuration(25) → "25分"。これが表示されればタイマー / 状態遷移以前に
+    // raw は fmtDuration(25) → "25m"。これが表示されればタイマー / 状態遷移以前に
     // 描画段階でも raw 値で fallback できている (ADR 0013 縮退の UI 確認)。
-    await expect(top.getByLabel("見積もり")).toHaveText("25分");
+    await expect(top.getByLabel("見積もり")).toHaveText("25m");
 
     // 表示されているのは leaf-parent 1 件だけ (decomposed 親の子フラット化が起きない)。
     await expect(stack.getByRole("listitem")).toHaveCount(1);

--- a/e2e/phase3-ai-bypass-invariants.spec.ts
+++ b/e2e/phase3-ai-bypass-invariants.spec.ts
@@ -1,0 +1,218 @@
+import { createAdminClient, getTasksForUser, seedProject, seedTask } from "./db";
+import { expect, test } from "./fixtures";
+
+/**
+ * Issue #96 (P3-11) / ADR 0013 / 0014 / 0016:
+ *
+ * `AI_ENABLED=false` (e2e のデフォルト、playwright.config.ts) で
+ * Phase 3 の core path が AI 抜きで成立する不変条件を semantic locator で踏む。
+ *
+ * AI 失敗時の縮退コードパスは e2e と同じ (`/api/ai/*` が `withAiRoute` で
+ * 200 skipped を返す) なので、ここでの不変条件が augmentation only
+ * (ADR 0013) の自動安全網になる。
+ *
+ * AI 経路 (Route Handler 内ロジック) のカバレッジは src/shared/ai/route.test.ts /
+ * src/app/api/ai/{ping,decompose,categorize}/route.test.ts のユニットに任せる
+ * (ADR 0014: e2e でモックを抱えない)。
+ */
+
+test.describe("AI 経路バイパス (ADR 0014)", () => {
+  test("/api/ai/ping は AI_ENABLED=false で 200 { skipped: true, reason: 'ai_disabled' } を返す", async ({
+    signedInPage: page,
+  }) => {
+    // signedInPage 経由なら request は session cookie を引き継ぐ。
+    const res = await page.request.post("/api/ai/ping");
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as { skipped?: boolean; reason?: string };
+    // この shape が壊れたら withAiRoute の kill-switch が外れている (ADR 0013/0014)。
+    expect(body).toEqual({ skipped: true, reason: "ai_disabled" });
+  });
+
+  test("AddPanel からタスク追加 → 親 1 件だけ Stack に並び、DB に子レコードは作られない", async ({
+    signedInPageWithProject: page,
+    projectName,
+    testUserId: userId,
+  }) => {
+    const taskTitle = "AI バイパス: 親のみ残置";
+
+    await page.getByRole("button", { name: "新規追加" }).click();
+    const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+    await addDialog.getByRole("tab", { name: "タスク" }).click();
+    await addDialog.getByLabel("タイトル").fill(taskTitle);
+    await addDialog.getByLabel("プロジェクト").selectOption({ label: projectName });
+    await addDialog.getByRole("button", { name: "追加" }).click();
+    await expect(addDialog).toHaveCount(0);
+
+    const stack = page.getByRole("list", { name: "タスクスタック" });
+    await expect(stack.getByRole("listitem")).toHaveCount(1);
+    await expect(stack.getByRole("listitem").filter({ hasText: taskTitle })).toBeVisible();
+
+    // DB: 親 1 件だけ。AI が動いていれば triggerDecompose 経由で子が insert される
+    // が、`AI_ENABLED=false` なら withAiRoute が 200 skipped で返し DB は変わらない
+    // (decompose-server には到達しない)。
+    const admin = createAdminClient();
+    const tasks = await getTasksForUser(admin, userId);
+    expect(tasks).toHaveLength(1);
+    const parent = tasks[0];
+    expect(parent.title).toBe(taskTitle);
+    expect(parent.parent_task_id).toBeNull();
+    // server は AI 経路を踏まないので decompose_status の DB 値は default 'none' のまま。
+    // (client は optimistic に 'decomposing' をキャッシュに書くが永続化はされない)。
+    expect(parent.decompose_status).toBe("none");
+    // AI categorize も同様に走らないので task_category は null のまま (ADR 0013 augmentation only)。
+    expect(parent.task_category).toBeNull();
+  });
+});
+
+test.describe("Variant E core path 不変条件 (ADR 0016)", () => {
+  test("decompose_status='none' の親は『未分解』pill を出し、補正なしの見積もりも raw 値で表示する", async ({
+    signedInPage: page,
+    testUserId: userId,
+  }) => {
+    const admin = createAdminClient();
+    const project = await seedProject(admin, {
+      userId,
+      name: "未分解 pill 検証",
+      color: "#5B8DEF",
+    });
+    const task = await seedTask(admin, {
+      userId,
+      projectId: project.id,
+      title: "未分解の単独タスク",
+      stackOrder: 0,
+      decomposeStatus: "none",
+      // task_category=null + correction factors 無し → CorrectedEstimate は raw のみ表示。
+      estimatedMinutes: 25,
+    });
+
+    // 直接 seed したので reload して fetch を回す。
+    await page.reload();
+
+    const stack = page.getByRole("list", { name: "タスクスタック" });
+    const top = stack.getByRole("listitem").filter({ hasText: task.title });
+    await expect(top).toBeVisible();
+
+    // 「未分解」pill (StatusPill, status='none')。Top カード下ゾーン Row 3 右詰スロット。
+    await expect(top.getByText("未分解")).toBeVisible();
+
+    // 補正後見積もり無しの fallback: aria-label="見積もり" の単独 span (CorrectedEstimate `correctedMinutes === null`)。
+    // raw は fmtDuration(25) → "25分"。これが表示されればタイマー / 状態遷移以前に
+    // 描画段階でも raw 値で fallback できている (ADR 0013 縮退の UI 確認)。
+    await expect(top.getByLabel("見積もり")).toHaveText("25分");
+
+    // 表示されているのは leaf-parent 1 件だけ (decomposed 親の子フラット化が起きない)。
+    await expect(stack.getByRole("listitem")).toHaveCount(1);
+  });
+
+  test("decomposed 親 + 子 3 件: 親は Stack から消え、Top に role=progressbar が出る", async ({
+    signedInPage: page,
+    testUserId: userId,
+  }) => {
+    const admin = createAdminClient();
+    const project = await seedProject(admin, {
+      userId,
+      name: "progressbar 検証",
+      color: "#E85D04",
+    });
+
+    // 親: stack_order=null (Stack には出ない)。decomposed なので buildStackItems で除外される。
+    const parent = await seedTask(admin, {
+      userId,
+      projectId: project.id,
+      title: "面接対策をまとめる",
+      stackOrder: 0,
+      decomposeStatus: "decomposed",
+    });
+    const childTitles = ["志望動機を整理", "想定質問を 5 つ書く", "逆質問を準備"];
+    for (let i = 0; i < childTitles.length; i++) {
+      await seedTask(admin, {
+        userId,
+        projectId: project.id,
+        title: childTitles[i],
+        stackOrder: 1 + i,
+        parentTaskId: parent.id,
+        decomposeStatus: "none",
+      });
+    }
+
+    await page.reload();
+
+    const stack = page.getByRole("list", { name: "タスクスタック" });
+
+    // 親 (decomposed) は Stack から消え、子 3 件だけがフラットに並ぶ (ADR 0016 §1)。
+    await expect(stack.getByRole("listitem")).toHaveCount(3);
+    for (const t of childTitles) {
+      await expect(stack.getByRole("listitem").filter({ hasText: t })).toBeVisible();
+    }
+    await expect(stack.getByRole("listitem").filter({ hasText: parent.title })).toHaveCount(0);
+
+    // Top カードの平行四辺形プログレス (ADR 0016 §5)。
+    // doneCount=0、currentIndex = 0 + (1 番目) = 1、total = 3。
+    const topItem = stack.getByRole("listitem").first();
+    const progress = topItem.getByRole("progressbar");
+    await expect(progress).toBeVisible();
+    await expect(progress).toHaveAttribute("aria-valuenow", "0");
+    await expect(progress).toHaveAttribute("aria-valuemin", "0");
+    await expect(progress).toHaveAttribute("aria-valuemax", "3");
+    await expect(progress).toHaveAttribute("aria-label", "進捗 0/3、現在 1/3");
+
+    // ⤷ 親タスク名が下ゾーンに継承される (ADR 0016 §6 の親 dep 継承と並ぶ表示原則)。
+    await expect(topItem.getByText(`⤷ ${parent.title}`)).toBeVisible();
+  });
+
+  test("Top-only complete: 行カードに『完了』ボタンが無い / Top で完了すると Done リストに移る", async ({
+    signedInPage: page,
+    testUserId: userId,
+  }) => {
+    const admin = createAdminClient();
+    const project = await seedProject(admin, {
+      userId,
+      name: "Top-only complete 検証",
+      color: "#5B8DEF",
+    });
+    const topTitle = "Top で完了するタスク";
+    const rowTitle = "2 番目のタスク";
+    await seedTask(admin, {
+      userId,
+      projectId: project.id,
+      title: topTitle,
+      stackOrder: 0,
+      decomposeStatus: "none",
+    });
+    await seedTask(admin, {
+      userId,
+      projectId: project.id,
+      title: rowTitle,
+      stackOrder: 1,
+      decomposeStatus: "none",
+    });
+
+    await page.reload();
+
+    const stack = page.getByRole("list", { name: "タスクスタック" });
+    await expect(stack.getByRole("listitem")).toHaveCount(2);
+
+    const topItem = stack.getByRole("listitem").nth(0);
+    const rowItem = stack.getByRole("listitem").nth(1);
+
+    // Top カードには「完了」ボタンが常時 (idle/active/paused 全状態で) 出る (ADR 0016 §7)。
+    await expect(topItem.getByRole("button", { name: "完了" })).toBeVisible();
+    // 行カードには完了ボタンを置かない (ADR 0016 §7)。
+    await expect(rowItem.getByRole("button", { name: "完了" })).toHaveCount(0);
+    // 開始 / 中断 / 再開 等の Timer Controls も Top のみ。
+    await expect(rowItem.getByRole("button", { name: "開始" })).toHaveCount(0);
+
+    // Top で完了 → Stack から消えて Done リストに移る (ADR 0016 §8)。
+    await topItem.getByRole("button", { name: "完了" }).click();
+
+    await expect(stack.getByRole("listitem")).toHaveCount(1);
+    await expect(stack.getByRole("listitem").filter({ hasText: topTitle })).toHaveCount(0);
+
+    const doneList = page.getByRole("list", { name: "完了済みタスク" });
+    await expect(doneList.getByRole("listitem").filter({ hasText: topTitle })).toBeVisible();
+    // Done セクションには「戻す」ボタンが付く (aria-label にタイトル + 接尾辞)。
+    await expect(
+      doneList.getByRole("button", { name: `${topTitle} を未完了に戻す` }),
+    ).toBeVisible();
+  });
+});

--- a/e2e/phase3-ai-bypass-invariants.spec.ts
+++ b/e2e/phase3-ai-bypass-invariants.spec.ts
@@ -93,7 +93,8 @@ test.describe("Variant E core path 不変条件 (ADR 0016)", () => {
     await expect(top).toBeVisible();
 
     // 「未分解」pill (StatusPill, status='none')。Top カード下ゾーン Row 3 右詰スロット。
-    await expect(top.getByText("未分解")).toBeVisible();
+    // exact=true でプロジェクト名 / タイトルへの substring 衝突を避ける (StatusPill は raw "未分解" のみ)。
+    await expect(top.getByText("未分解", { exact: true })).toBeVisible();
 
     // 補正後見積もり無しの fallback: aria-label="見積もり" の単独 span (CorrectedEstimate `correctedMinutes === null`)。
     // raw は fmtDuration(25) → "25分"。これが表示されればタイマー / 状態遷移以前に
@@ -140,11 +141,12 @@ test.describe("Variant E core path 不変条件 (ADR 0016)", () => {
     const stack = page.getByRole("list", { name: "タスクスタック" });
 
     // 親 (decomposed) は Stack から消え、子 3 件だけがフラットに並ぶ (ADR 0016 §1)。
+    // listitem 数 = 3 と各子の可視性で「親が listitem として描画されていない」が担保される
+    // (子の下ゾーンには `⤷ ${parent.title}` が出るので親 title での filter は使えない)。
     await expect(stack.getByRole("listitem")).toHaveCount(3);
     for (const t of childTitles) {
       await expect(stack.getByRole("listitem").filter({ hasText: t })).toBeVisible();
     }
-    await expect(stack.getByRole("listitem").filter({ hasText: parent.title })).toHaveCount(0);
 
     // Top カードの平行四辺形プログレス (ADR 0016 §5)。
     // doneCount=0、currentIndex = 0 + (1 番目) = 1、total = 3。


### PR DESCRIPTION
## 概要 (What)

ADR 0014 の「e2e は `AI_ENABLED=false` で AI 経路をバイパス」と ADR 0016 (Variant E) の core 不変条件を **semantic locator で踏む e2e spec** を追加。AI 失敗時の縮退コードパスは e2e と同じ (`/api/ai/*` が `withAiRoute` で 200 skipped を返す) なので、ここでの不変条件が ADR 0013 augmentation only の自動安全網になる。

## 関連 Issue

Closes #96

## 背景 (Why)

Phase 3 で AI (Gemini) が core 機能 (タスク分解 / category labeling / 見積もり補正) に乗る一方、ADR 0013 で「AI が落ちても core は止まらない」を不変条件にした。e2e は ADR 0014 のとおり `AI_ENABLED=false` で AI 経路を全面バイパスする — つまり **e2e と AI 失敗時で同じコードパス** が走る。

P3-1 / P3-7 の本実装が揃ったタイミングで、Variant E の構造 (子フラット / Top 上下 2 ゾーン / 行カード 3 行 / 平行四辺形プログレス / Top-only complete) と AI 縮退の core path を semantic locator (role / aria-*) で踏む安全網を入れる。

関連 ADR: [0013](../blob/main/docs/adr/0013-ai-as-augmentation-only.md) / [0014](../blob/main/docs/adr/0014-e2e-ai-bypass-via-disabled-switch.md) / [0016](../blob/main/docs/adr/0016-stack-view-decomposition-children-only.md)

## Before → After (概念・フロー・メンタルモデル)

**Before:** Variant E 本実装 (#92) と AI 基盤 (#86) は揃ったが、Phase 3 の AI 縮退・Variant E 構造は **コンポーネントユニット** (`TaskStack.test.tsx` 等) でしかカバーされていなかった。CI 上で AI が誤って有効化されたり、Variant E の semantic 構造が壊れても e2e で検知できない。

**After:** e2e がブラウザ越しに以下を踏むので、AI kill-switch / Variant E 構造の回帰が CI で落ちる。
- `/api/ai/ping` が `200 { skipped: true, reason: "ai_disabled" }` を返す（kill-switch 自動回帰）
- AddPanel 追加で 親 1 件のみ Stack、DB に子レコードなし、`decompose_status='none'` / `task_category=null`
- `decompose_status='none'` seed で「未分解」pill + 補正なしの raw 見積もりが描画される
- `decomposed` 親 + 子 3 件で 親が Stack から消え、Top に `role="progressbar"` + `aria-valuenow/min/max` + `aria-label="進捗 0/3、現在 1/3"` が出る
- 行カードに「完了」「開始」ボタン無し / Top で完了 → `aria-label="完了済みタスク"` リストに移動

## 追加したテスト (How verified)

- [x] `e2e/phase3-ai-bypass-invariants.spec.ts` を新規追加（5 ケース）
- [x] `e2e/db.ts` に直接 seed 用の `seedTask` / `seedProject` / `getTasksForUser` を追加（AddPanel 経路は `triggerDecompose` / `triggerCategorize` を巻き込むため、`decomposed` 親や `none` の leaf-parent を狙って seed したいケースで使う）
- [x] `npm run typecheck` / `npm run lint` / `npm test` (453 tests) / `npm run format:check` 全 pass

未確認:
- [ ] **playwright e2e suite** — 手元に local Supabase stack が無いため未実行。CI (`supabase start` 後の `npm run e2e`) で初回実行を確認したい

## このPRの範囲外 (Out of scope)

- AI 経路 (Route Handler 内ロジック / prompt 構築 / parse) の e2e — ADR 0014 のとおりユニット (`src/shared/ai/route.test.ts` / `src/app/api/ai/*/route.test.ts`) でカバー
- LLM mock — ADR 0014 で却下済み
- `decomposed` 親自身の再実行 (ADR 0021 §6) や子の再分解 (idea #121) — 本 issue scope 外

https://claude.ai/code/session_01LouMJyC7TgoygnyEWuS6JC

---
_Generated by [Claude Code](https://claude.ai/code/session_01LouMJyC7TgoygnyEWuS6JC)_