### PR TITLE
fix(day-timeline): 他日付の event を今日のタイムラインに重ねないよう filter

### DIFF
--- a/src/features/day-timeline/DayTimeline.test.tsx
+++ b/src/features/day-timeline/DayTimeline.test.tsx
@@ -4,21 +4,21 @@ import { DayTimeline } from "./DayTimeline";
 
 import type { Event } from "../../entities/event/types";
 
-const events: Event[] = [
-  {
-    id: "e1",
-    title: "Meeting A",
-    startTime: "2026-04-11T10:00:00",
-    endTime: "2026-04-11T11:00:00",
-    projectId: "slo",
-    meetUrl: null,
-    hasAttachments: false,
-    description: "",
-    source: "manual",
-    externalId: null,
-    createdAt: "2026-04-11T00:00:00",
-  },
-];
+const ev = (id: string, title: string, startTime: string, endTime: string): Event => ({
+  id,
+  title,
+  startTime,
+  endTime,
+  projectId: "slo",
+  meetUrl: null,
+  hasAttachments: false,
+  description: "",
+  source: "manual",
+  externalId: null,
+  createdAt: "2026-04-11T00:00:00",
+});
+
+const events: Event[] = [ev("e1", "Meeting A", "2026-04-11T10:00:00", "2026-04-11T11:00:00")];
 
 describe("DayTimeline", () => {
   test("today を formatDate して表示する", () => {
@@ -51,5 +51,21 @@ describe("DayTimeline", () => {
     );
     // 9:30 (nowMin) から 10:00 (イベント開始) まで 30分の空き
     expect(getByText(/空き 30m/)).toBeTruthy();
+  });
+
+  test("today に開始しない event はタイムラインに含めない (昨日 / 明日 / 先週は除外)", () => {
+    const mixed: Event[] = [
+      ev("e1", "Today event", "2026-04-11T10:00:00", "2026-04-11T11:00:00"),
+      ev("yesterday", "Yesterday event", "2026-04-10T14:00:00", "2026-04-10T15:00:00"),
+      ev("tomorrow", "Tomorrow event", "2026-04-12T09:00:00", "2026-04-12T10:00:00"),
+      ev("last-week", "Last week event", "2026-04-04T10:00:00", "2026-04-04T11:00:00"),
+    ];
+    const { getByText, queryByText } = render(
+      <DayTimeline events={mixed} nowMin={9 * 60 + 30} today="2026-04-11" onOpenEvent={() => {}} />,
+    );
+    expect(getByText("Today event")).toBeTruthy();
+    expect(queryByText("Yesterday event")).toBeNull();
+    expect(queryByText("Tomorrow event")).toBeNull();
+    expect(queryByText("Last week event")).toBeNull();
   });
 });

--- a/src/features/day-timeline/DayTimeline.tsx
+++ b/src/features/day-timeline/DayTimeline.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import type { Event } from "../../entities/event/types";
-import { fmtDuration, fmtMin, formatDate, minutesOfDay } from "../../shared/lib/time";
+import { fmtDuration, fmtMin, formatDate, localDateOf, minutesOfDay } from "../../shared/lib/time";
 import { buildSlots, computeDayBounds } from "./buildSlots";
 import { EventCard } from "./EventCard";
 import { TimelineBar } from "./TimelineBar";
@@ -13,11 +13,21 @@ type DayTimelineProps = {
 };
 
 export function DayTimeline({ events, nowMin, today, onOpenEvent }: DayTimelineProps) {
-  const { dayStart, dayEnd } = computeDayBounds(events, nowMin);
-  const slots = useMemo(() => buildSlots(events, dayStart, dayEnd), [events, dayStart, dayEnd]);
+  // 呼び出し側 (AppShell) は events を全期間取得して渡す。タイムラインは today に始まる
+  // event だけを対象にする (minutesOfDay は HH:MM のみ抽出するため、日付フィルタが
+  // 抜けると昨日 / 明日の event が今日のバーに重なる)。
+  const todayEvents = useMemo(
+    () => events.filter((e) => localDateOf(e.startTime) === today),
+    [events, today],
+  );
+  const { dayStart, dayEnd } = computeDayBounds(todayEvents, nowMin);
+  const slots = useMemo(
+    () => buildSlots(todayEvents, dayStart, dayEnd),
+    [todayEvents, dayStart, dayEnd],
+  );
   const sortedEvents = useMemo(
-    () => [...events].sort((a, b) => minutesOfDay(a.startTime) - minutesOfDay(b.startTime)),
-    [events],
+    () => [...todayEvents].sort((a, b) => minutesOfDay(a.startTime) - minutesOfDay(b.startTime)),
+    [todayEvents],
   );
 
   const currentSlot = slots.find((s) => s.start <= nowMin && s.end > nowMin);

--- a/src/shared/lib/time.test.ts
+++ b/src/shared/lib/time.test.ts
@@ -4,6 +4,7 @@ import {
   formatRelativeTime,
   fmtDuration,
   fmtMin,
+  localDateOf,
   timeToMin,
   toDateTimeLocalInput,
 } from "./time";
@@ -81,6 +82,17 @@ describe("formatRelativeTime", () => {
   test("2日以上先は「M/D HH:MM」", () => {
     expect(formatRelativeTime("2026-04-15T10:00:00", now)).toBe("4/15 10:00");
     expect(formatRelativeTime("2026-05-02T18:30:00", now)).toBe("5/2 18:30");
+  });
+});
+
+describe("localDateOf", () => {
+  test("ISO 8601 文字列のローカル日付を YYYY-MM-DD で返す", () => {
+    expect(localDateOf("2026-04-11T09:00:00")).toBe("2026-04-11");
+    expect(localDateOf("2026-04-11T23:59:59")).toBe("2026-04-11");
+  });
+
+  test("月日は 2 桁ゼロ埋めする", () => {
+    expect(localDateOf("2026-01-02T03:04:05")).toBe("2026-01-02");
   });
 });
 

--- a/src/shared/lib/time.ts
+++ b/src/shared/lib/time.ts
@@ -22,6 +22,15 @@ export function formatClock(iso: string): string {
   return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
 }
 
+/** ISO 8601 文字列をローカル時刻の "YYYY-MM-DD" に整形する。 */
+export function localDateOf(iso: string): string {
+  const d = new Date(iso);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
 /**
  * ISO 8601 文字列を `<input type="datetime-local">` の value 形式 (`YYYY-MM-DDTHH:MM`)
  * にローカル時刻で整形する。タイムゾーン情報は落ちる (input は tz-naive)。


### PR DESCRIPTION
## 概要 (What)

DayTimeline (本日のタイムライン) が昨日 / 明日 / 先週など他日付の event を今日の同時刻スロットに重ねて表示する不具合を修正する。

## 関連 Issue

Closes #142

## 背景 (Why)

`events` query は supabase から全期間の events を返す（日付フィルタなし）。一方 `DayTimeline` は受け取った全 event を `minutesOfDay()` (HH:MM のみ抽出) で描画していたため、日付情報が落ちて他日付の event が今日のバーに重なる。

Google Calendar 同期で過去 7 日 / 未来 30 日のイベントが入る構成 (ADR 0006) では、毎日数件の他日付 event が紛れ込んで、スケジュール判断に使えない状態だった。

## Before → After (概念・フロー・メンタルモデル)

**Before:**
AppShell が「全期間 events」を `DayTimeline` に渡し、DayTimeline は受け取った全 event を today の HH:MM に投影していた。日付フィルタの責務がどこにも置かれていない。

**After:**
DayTimeline が `today` prop を contract として持ち、startTime のローカル日付が today に一致する event だけを内部で抽出してから `computeDayBounds` / `buildSlots` / 予定リストに渡す。「render events for `today`」という DayTimeline の責務を自身に閉じ込めた。

## 追加したテスト (How verified)

- [x] `localDateOf(iso)` の unit test (shared/lib/time.test.ts)
- [x] DayTimeline に昨日 / 明日 / 先週の event を混ぜても today の event しか描画されないテスト
- [x] 既存 unit test 全 495 件 green
- [x] typecheck / lint / format:check 全 green

## このPRの範囲外 (Out of scope)

- 日跨ぎ event (today 23:00 → 翌 02:00 等) を today のバーに clamp して表示する処理。現状は startTime のローカル日付で判定するため、日跨ぎ event は開始日側のバーにしか出ない。必要なら別 issue で。
- 複数カレンダー / 複数 Google アカウント / 表示フィルタの拡張機能（ADR 0008 supersede 含む新 milestone「カレンダー機能拡張」で別途対応予定）。

https://claude.ai/code/session_01EjEXjmN5tp5DSzKsFxZ3Tk

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjEXjmN5tp5DSzKsFxZ3Tk)_