### PR TITLE
fix(e2e): プロジェクト削除テストの楽観的更新 race を expect.poll で吸収

### DIFF
--- a/e2e/project-event-crud.spec.ts
+++ b/e2e/project-event-crud.spec.ts
@@ -355,12 +355,21 @@ test.describe("プロジェクト削除 (cascade SET NULL)", () => {
 
     // 4. DB 検証
     // - projects 行が消えている
-    const { data: remaining, error } = await admin
-      .from("projects")
-      .select("*")
-      .eq("id", project.id);
-    expect(error).toBeNull();
-    expect(remaining).toEqual([]);
+    //   AppShell の deleteProjectMutation は onMutate で楽観的に
+    //   keys.projects キャッシュから対象 project を消す。`projectDetail` は
+    //   projects.find(...) で導出されているため ProjectDetailPanel は実際の
+    //   Supabase delete 完了前に unmount される。`editDialog` の消失だけでは
+    //   DB 反映を保証できないので poll で待つ (task-crud.spec.ts と同方針)。
+    await expect
+      .poll(
+        async () => {
+          const { data, error } = await admin.from("projects").select("id").eq("id", project.id);
+          if (error) throw error;
+          return data ?? [];
+        },
+        { message: "projects row should be deleted", timeout: 5_000 },
+      )
+      .toEqual([]);
 
     // - tasks.project_id が null になっている (cascade SET NULL)
     const task = await getTaskByTitle(admin, userId, taskTitle);


### PR DESCRIPTION
## 概要 (What)

`e2e/project-event-crud.spec.ts:313` のプロジェクト削除テストで、楽観的更新と Supabase delete 完了の race を `expect.poll` で吸収する。

## 関連 Issue

Closes #147

## 背景 (Why)

main の CI [run 25197232502](https://github.com/y-oga-819/kozutsumi/actions/runs/25197232502) で本テストが初回 + retry 連続で fail。直前の commit (`ecd7dd8`) は DayTimeline 関連の独立変更で、本テストとは無関係 → タイミング由来の flaky と判断。

`AppShell` の `deleteProjectMutation` は `onMutate` で `keys.projects` キャッシュから対象 project を即座に削除する楽観的更新を持つ。`projectDetail` は `projects.find((p) => p.id === projectDetailId)` で導出されているため、`ProjectDetailPanel` は実際の Supabase delete が完了する前に unmount される。テストはこの `editDialog` 消失をトリガに DB を覗きにいくため、delete が in-flight のまま行が残って見える瞬間がある。

`task-crud.spec.ts:194` および同 spec の event 削除テスト (line 229) はこの race を見越して `expect.poll` で DB 反映を待っており、project 削除テストだけが古い同期 assertion のまま残っていた。

## Before → After

**Before:**

```ts
const { data: remaining, error } = await admin
  .from("projects").select("*").eq("id", project.id);
expect(error).toBeNull();
expect(remaining).toEqual([]);  // delete 完了前だと 1 行残って見える
```

**After:**

```ts
await expect.poll(
  async () => {
    const { data, error } = await admin.from("projects").select("id").eq("id", project.id);
    if (error) throw error;
    return data ?? [];
  },
  { message: "projects row should be deleted", timeout: 5_000 },
).toEqual([]);
```

production 挙動 (`deleteProjectMutation` の楽観的更新) は UX 上正しいので変更しない。e2e の検証手順だけを「DB 反映が確実に終わるまで待つ」形に揃える。

## 追加したテスト (How verified)

- [x] 既存テスト `e2e/project-event-crud.spec.ts:313` を本修正で書き換え（新規 spec は追加せず）
- [x] `npm run lint` (src) / `npm run typecheck` ローカル pass
- [x] `npx prettier --check` pass
- [ ] PR の CI で E2E (shard 2/2) が通ること

## このPRの範囲外 (Out of scope)

- `e2e/project-event-crud.spec.ts:138` 等に残る pre-existing な lint warning (`prefer-const`) は CI lint scope (`src` のみ) 外なので本 PR では触らない
- 楽観的更新の挙動自体の見直し（panel が delete 完了まで残るべきか等）は別議論