### PR TITLE
docs(adr): events visibility 3 層モデル + 物理化 + ライフサイクル (ADR 0031〜0034)

### DIFF
--- a/docs/adr/0008-google-calendar-sync-target-primary-only.md
+++ b/docs/adr/0008-google-calendar-sync-target-primary-only.md
@@ -1,8 +1,8 @@
 # ADR 0008: 同期対象は primary カレンダーのみ
 
-- **Status**: Accepted
+- **Status**: Superseded by [ADR 0031](./0031-calendar-subscription-and-event-promotion.md)
 - **Date**: 2026-04-22
-- **Related**: [ADR 0005](./0005-google-calendar-sync-via-route-handler.md)
+- **Related**: [ADR 0005](./0005-google-calendar-sync-via-route-handler.md) / Superseded by [ADR 0031](./0031-calendar-subscription-and-event-promotion.md)
 
 ## Context
 

--- a/docs/adr/0031-calendar-subscription-and-event-promotion.md
+++ b/docs/adr/0031-calendar-subscription-and-event-promotion.md
@@ -1,0 +1,110 @@
+# ADR 0031: カレンダー購読 と event の timeline 予定化を分離した 3 層モデル
+
+- **Status**: Accepted
+- **Date**: 2026-05-03
+- **Related**: Supersedes [ADR 0008](./0008-google-calendar-sync-target-primary-only.md) / [ADR 0005](./0005-google-calendar-sync-via-route-handler.md) / [ADR 0006](./0006-google-calendar-sync-full-then-synctoken.md) / [ADR 0010](./0010-google-calendar-events-read-only.md) / `docs/design/vision.md` / Issue #144 / Issue #145 / Issue #146
+
+## Context
+
+ADR 0008 で「同期対象は primary カレンダーのみ」を仮置きした。Phase 2 の使用を通じて以下の摩擦が判明した:
+
+- 仕事 (Workspace) と家族 / 趣味の calendar が落ちて、日常利用が成立しない
+- 逆に全 calendar を一律取り込むと、祝日 / 他人の勤怠 / 子供の帰宅時間 等のノイズで「自分の時間拘束」が見えなくなる
+- 「見えてはいたいが時間拘束ではない」予定が現実に存在する (子供の帰宅時間 typical)
+
+vision の差別化は「行動データの蓄積による行動ベーススケジューリング」にある。
+そのためには「自分の時間拘束がこのツールに集約されている」状態が前提条件。
+primary 固定では集約が成立せず、一律取り込みでは「時間拘束」が判別できない。
+
+「取り込み (events テーブルに行を入れる)」と「予定化 (DayTimeline / TimelineBar 等の時間拘束 UI に乗せる)」が
+これまで未分離だったことが、この 2 つの摩擦の根本原因。両者を分離した上で、calendar の性質ごとに
+default の予定化方針が違うこと、個別 event ではそれを上書きしたいこと、を素直に表現するモデルが要る。
+
+## Decision
+
+events の visibility を **3 層** で管理する:
+
+| 層 | 概念 | 単位 | 操作 | 影響範囲 |
+|---|---|---|---|---|
+| 1. Subscription | calendar を取り込み対象にする | calendar | 取り込む / 取り込まない | events テーブルに行が入るかどうか |
+| 2. Auto-promote | calendar ごとの「自動予定化」トグル | calendar | ON / OFF | その calendar の event の **default** が timeline に乗るか |
+| 3. Event override | 個別 event の予定化 | event | 予定化する / 予定化解除 | 個別 event を timeline に出すかの最終決定 |
+
+用語:
+- **取り込み (subscription / sync)**: events テーブルへの行追加。layer 1。
+- **予定化 (promote to timeline)**: 取り込んだ event を「自分の時間拘束」UI に乗せること。layer 2 / 3。
+- 「自動取り込み」のような取り込みと予定化を混ぜた呼称は使わない (ミスリードのため)。
+
+行動データ (vision の差別化の核) としては、layer 2 の default に対する layer 3 の **override シグナル**
+(「default では合っていなかった」というユーザーの個別判断) が最も情報濃度が高く、Phase 4 の学習素材として中心になる。
+
+将来の三値モデル (`shown` / `info_only` / `hidden`) への拡張余地を schema レベルで残す
+(layer 3 の visibility を boolean ではなく enum 相当で持つ)。
+ただし三値の即時導入はしない (本 ADR の決定範囲外)。
+
+## Consequences
+
+### 肯定的影響
+
+- **calendar の性質ごとに自然な操作量**:
+  仕事 calendar は auto-promote ON で大半の event が自動で timeline に乗り、家族 calendar は
+  auto-promote OFF で必要な event だけ手動で予定化できる。どちらに振っても操作回数が爆発しない。
+- **「集約」と「ノイズ排除」が両立**: 全予定を取り込みつつ、timeline には時間拘束だけ乗せられる。
+  vision の「全時間拘束がツールに集約されている」前提が成立する。
+- **行動データの濃度が上がる**: layer 2 の default に対する layer 3 の override が
+  「ユーザーの個別判断」として強いシグナルになる (Phase 4 の暗黙フィードバック)。
+- **将来拡張余地**: 「見えるが時間拘束ではない (info_only)」モードが必要になっても、
+  schema レベルで取り込める。
+- **複数アカウント (#146) への素直な拡張**: subscription の単位を `(account, calendar)` 複合キーで
+  持てば、複数 Google アカウント対応の土台になる。
+
+### 否定的影響・トレードオフ
+
+- **DB schema 変更が大きい**: 購読を表す新テーブルと、event 単位 override 列の追加が必要。migration を伴う。
+- **UI の操作軸が増える**:
+  「取り込み (subscription)」「自動予定化トグル (auto-promote)」「個別予定化 (event override)」の 3 軸が
+  ユーザーに露出する。学習コストが上がる。命名 / IA で「取り込み ≠ 予定化」を明示しないと混乱する。
+- **既存ユーザーの移行が必要**: primary のみ取り込み済の既存ユーザーを、auto-promote ON で自動購読した
+  ものとみなして壊さない移行が要る。
+- **subscription default の事後変更時の挙動を決める必要**:
+  auto-promote トグルを後から切り替えた時、既存の event override (layer 3) を保持するのか、
+  リセットするのかをコード側で明確にする必要がある。
+- **取り込み済だが timeline に乗らない event のための表示 / 操作面が要る**:
+  layer 2 OFF の calendar の event を後から手動で予定化するための UI (event 一覧 / 検索 / 当日候補など) が
+  別途必要になる。
+
+## Alternatives considered
+
+- **二値: default include + event 単位 hide のみ (元の #145 案)**:
+  家族 / 趣味 calendar で大量の hide 操作が必要になる。
+  複数 calendar 取り込み時に「ノイズ排除」のコストが爆発する。不採用。
+- **二値: default exclude + event 単位 include のみ (純 whitelist)**:
+  仕事 calendar で取り込みのたびに大量の include 操作が必要になり、「取り込んだ意味」が薄れる。不採用。
+- **calendar 単位制御のみ (event 単位 override なし)**:
+  「家族 calendar の中の自分の用事だけ timeline に乗せたい」「仕事 calendar の中の社内全員定例だけ外したい」
+  というニーズに対応できない。不採用。
+- **event 単位制御のみ (subscription / auto-promote なし)**:
+  calendar の性質に関わらず一律ポラリティになり、上記二値案と同じ問題が出る。不採用。
+- **三値モデル (`shown` / `info_only` / `hidden`) を即時導入**:
+  Phase 1 / 2 のスコープを大きく広げる。timeline への載せ方 / カウントへの寄与 / タスク選択時の扱い等、
+  決めるべき意味論が増える。schema レベルで余地は残すが、運用ロジックの導入は本 ADR では見送る。
+- **subscription を持たず取り込みは Google API の `calendarList` で動的に判定**:
+  sync token / lastSyncedAt を calendar 単位で永続化したいので、subscription は明示的に持つほうが素直。不採用。
+- **#144 と #145 を別 ADR に分割**:
+  layer 1 / 2 / 3 が密結合 (layer 2 を廃止すると layer 3 の override 対象が消える等) しており、
+  3 層を 1 つの概念フレームとして提示するほうが将来の supersede 単位として自然。本 ADR では 1 本にまとめた。
+
+## Notes
+
+- 本 ADR は **概念モデルと層の境界** を確定するもの。テーブル名 / column 名 / enum 値 / migration の具体は
+  実装段階で決める (パラメータ / 実装詳細は ADR に含めない原則)。
+- ADR 0009 (Google provider token self-managed refresh) は本 ADR では触らない。
+  複数アカウント対応 (Issue #146) で別途 supersede する。
+- ADR 0006 (full sync → syncToken) と ADR 0010 (Google 由来 events は read-only) は本 ADR で前提が
+  変わらない。subscription 単位で sync_token を独立に持つ拡張は本 ADR の含意の範囲。
+- 行動データの観点で、Phase 4 までに `is_override_of_default` 相当のシグナルが action_log に
+  載っていることを確認する (action_log schema 設計は別 issue / ADR で扱う、Issue #154 と整合)。
+- 将来見直す条件:
+  - 三値モデル (info_only) のニーズが dogfooding で明確になったら、schema 拡張 + 運用ロジック追加の ADR を起票する
+  - layer 2 と 3 の併存が UX 的に冗長と判明したら、layer 統合の supersede を検討する
+  - 自動フィルタルール (title pattern / participants 数 / RSVP) を導入する場合は別 ADR

--- a/docs/adr/0032-events-visibility-override-physical-model.md
+++ b/docs/adr/0032-events-visibility-override-physical-model.md
@@ -1,0 +1,81 @@
+# ADR 0032: events.visibility_override の物理化
+
+- **Status**: Accepted
+- **Date**: 2026-05-03
+- **Related**: [ADR 0031](./0031-calendar-subscription-and-event-promotion.md) / [ADR 0001](./0001-action-logs-from-phase1.md) / Issue #145 / Issue #154
+
+## Context
+
+ADR 0031 で events visibility の 3 層モデル (subscription / auto-promote toggle / event override) を確定した。
+本 ADR は **Layer 3 (event 単位 override) の物理化方法** を決める。
+
+物理化の選択は以下に影響する:
+
+- 「ユーザーが個別に触ったか」の判別容易性 (Phase 4 の `is_override_of_default` シグナル抽出)
+- subscription auto_promote 切替時の挙動 (override は保持しつつ default 追従の event は新 default へ)
+- 将来の三値モデル (`info_only` 等) への拡張余地
+
+## Decision
+
+`events.visibility_override` を **enum 列 (`'none'` / `'shown'` / `'hidden'`)** で持つ。`NOT NULL DEFAULT 'none'`。
+
+| 値 | 意味 |
+|---|---|
+| `none` | 個別 override なし。subscription default に従う。sync 新規取り込みもこの値で insert |
+| `shown` | ユーザーが「予定化する」と override |
+| `hidden` | ユーザーが「予定化解除」と override |
+
+採用ルール:
+
+- **enum 採用** (kozutsumi 慣習: 構造的ステータスは enum、`task_status` / `decompose_status` 等と揃える)。
+  TypeScript literal union と 1:1 対応する。
+- **日常 UI では `none` への reset 不可**。取り消したい時は反対方向の再 override (`shown` ↔ `hidden`) で行う。
+  完全に default 挙動へ戻したいレアケースは設定画面の「override 一覧 / 一括リセット」専用導線でのみ提供する。
+- **sync の挙動**:
+  - 新規取り込みは `'none'` で insert (subscription default に従う状態)
+  - 既存 event の override は sync で **保持** (Google 由来フィールドだけ upsert)
+- **過去 event の個別 override は制限なし**。いつでも `none → shown` / `none → hidden` / `shown ↔ hidden` 可。
+- **三値モデル (`info_only` 等) の追加** は本 ADR を supersede する別 ADR で扱う (アーキ判断レベル)。
+
+## Consequences
+
+### 肯定的影響
+
+- **column 1 個で全状態を表現できる** (NULL センチネル不要)。意味の曖昧さがない。
+- **override 有無の判定が単純**: `WHERE visibility_override = 'none'` / `!= 'none'`。
+  Phase 4 の `is_override_of_default` シグナル抽出も `(visibility_override != 'none')` で取れる。
+- **kozutsumi 慣習に準拠**。`gen types typescript` の出力も既存 enum と揃う。
+- **subscription auto_promote 切替時の挙動が自然**: `'none'` の event だけが新 default に追従し、
+  ユーザーが個別判断した event (`'shown'` / `'hidden'`) は影響を受けない (詳細は ADR 0034)。
+
+### 否定的影響・トレードオフ
+
+- **enum 値追加は migration が重い** (PostgreSQL の `ALTER TYPE ADD VALUE` はトランザクション内制約あり)。
+  ただし値追加 = 三値モデル導入は重い設計判断なので、軽い追加にはならず筋は通る。
+- **日常 UI で reset 不可** という制約により、「default 挙動に戻したい」レアニーズは
+  設定画面経由でしか満たせない。誤操作はほぼ反対方向 override で復旧できる前提。
+- **過去 event の override を制限しない** ため、過去の timeline 表示が後から変わりうる。
+  履歴改変リスクは action_log で `is_override_of_default` 含めて記録することで追跡可能にする。
+
+## Alternatives considered
+
+- **text + CHECK 制約**: 値追加は軽いが、kozutsumi 慣習 (構造的なものは enum) に反する。
+  `task_category` (text + CHECK) はラベル拡張が頻繁な用途で、`visibility_override` の用途とは性格が違う。不採用。
+- **NULL センチネル方式 (`shown` / `hidden` / NULL)**: 値だけ見たとき NULL の意味が曖昧。
+  `WHERE visibility IS NULL` の SQL も意図を読み取りにくい。column 名 `visibility_override` で意図を担う今案のほうが明示的。不採用。
+- **boolean 2 列分離 (`visibility` boolean + `visibility_user_set` boolean)**:
+  正規化されておらず (`visibility_set=false かつ visibility=true` は意味不明)、複合制約が必要。不採用。
+- **`default` / `user_shown` / `user_hidden` 命名**: prefix で「ユーザーアクション」を示せるが、
+  column 名 `visibility_override` 自体が意図を担うので値側 prefix は冗長。不採用 (好みレベル)。
+- **日常 UI で reset 許容**: 「予定化解除」を取り消すボタンが操作ミスで押されると個別判断が消える。
+  反対方向 override で十分代替できるので不採用。
+- **過去 event の override 不可**: 振り返り補正 (「あの会議は時間拘束じゃなかった」「やっぱり予定化しておこう」) の
+  価値を失う。Phase 4 行動データの濃度も下がる。不採用。
+
+## Notes
+
+- L3 (新規取り込みの初期 override) / L4 (sync は override 保持) / L8 (過去 override 可) の決定を本 ADR に取り込んでいる。
+- subscription auto_promote 切替時の `'none'` の扱い (旧 default で固定する bulk update) は ADR 0034 で扱う。
+- action_log の `event_promoted` / `event_demoted` / `event_visibility_frozen_by_subscription_toggle` の
+  schema は Issue #154 で決める (本 ADR は visibility_override の物理化のみ)。
+- `info_only` 等の三値拡張が必要になったら本 ADR を supersede する別 ADR を起票する。

--- a/docs/adr/0033-events-cross-source-uniqueness.md
+++ b/docs/adr/0033-events-cross-source-uniqueness.md
@@ -1,0 +1,83 @@
+# ADR 0033: events の cross-calendar uniqueness と source-agnostic 命名
+
+- **Status**: Accepted
+- **Date**: 2026-05-03
+- **Related**: [ADR 0031](./0031-calendar-subscription-and-event-promotion.md) / Issue #144 / Issue #146
+
+## Context
+
+ADR 0031 で複数 calendar 取り込みを採用した。これに伴い:
+
+- **同じ external event id が cross-calendar で衝突する**ケースがある。例: 招待された会議が
+  自分の primary と他人 calendar の両方から見える場合、event id は同じでも別レコードとして扱いたい。
+  現状の events UNIQUE は `(source, external_id)` なのでこのケースを表現できない。
+- 既存の `event_source` enum は `('manual', 'google_calendar')` で **複数 source 想定の設計** が
+  最初から入っている。Apple Calendar 等の追加を将来視野に入れるなら、命名を Google 固定にせず
+  source-agnostic にしておく必要がある。
+- `unsubscribe → 再 subscribe` を跨いだ Phase 4 行動データの連続性 (ADR 0034) を action_log の
+  metadata で確保するには、event を一意に識別する **source-agnostic な triple** が必要。
+
+## Decision
+
+events を **`(source, external_calendar_id, external_id)` の triple** で一意に識別する。
+
+具体:
+
+- `events` に `external_calendar_id text` 列を追加 (source 内での calendar 識別子)
+- 既存 UNIQUE 制約 `(source, external_id)` を **`(source, external_calendar_id, external_id)`** に置き換える
+- 命名は **source-agnostic** に統一する。Google 固定の名前 (`google_calendar_id` / `google_account_id`) は使わない:
+  - `external_account_id`: source 内でのアカウント識別子 (Google の email、Apple の iCloud account 等)
+  - `external_calendar_id`: source 内での calendar 識別子 (Google の calendarId、Apple の CalDAV calendar URL 等)
+  - `external_id`: source 内での event 識別子 (既存列名を踏襲)
+- subscription テーブル (ADR 0034 で具体化) も同じ命名を使う:
+  `(user_id, source, external_account_id, external_calendar_id)` を unique key とする。
+- action_log の event 関連 type (詳細は Issue #154) では metadata に **triple `(source, external_calendar_id, external_id)`
+  を必須** で含める。これにより kozutsumi 内 uuid が変わっても (例: unsubscribe → 再 subscribe で events 物理削除を経た後)、
+  Phase 4 分析は triple で同一 event を時系列に追える。
+- `event_source` enum はそのまま維持。新 source 追加 (例: `'apple_calendar'`) は **enum 値追加 +
+  subscription 設計の見直し** で対応する (本 ADR の supersede ではなく、新 source 対応 ADR を別途起票)。
+
+## Consequences
+
+### 肯定的影響
+
+- **cross-calendar 衝突を表現できる**。同じ external event id を別 calendar に持っても conflict しない。
+- **Phase 4 行動データの連続性**: action_log の triple で source 横断 / unsubscribe 跨ぎの同一性判定が可能。
+  「同じ予定に対するユーザー判断の時系列」を再構成できる。
+- **Apple 等の新 source 追加が軽い**: enum 値追加 + subscription テーブル設計の拡張で対応でき、
+  events / action_log の命名変更 migration は不要。
+- **subscription join が自然**: `events.external_calendar_id = subscription.external_calendar_id` で
+  subscription default を引ける。
+
+### 否定的影響・トレードオフ
+
+- **既存 events 行の backfill が必要**。現状 primary 固定 (ADR 0008 supersede 前) で取り込まれた行は
+  `external_calendar_id = 'primary'` で埋める migration が要る。
+- **既存 UNIQUE 制約の置き換え** が migration で発生 (DROP CONSTRAINT + ADD CONSTRAINT)。既存データが
+  triple で衝突しなければ安全だが、念のため事前検証する。
+- **Apple Calendar 等の新 source 追加** は本 ADR 範囲外。新 source 追加時には subscription
+  テーブル設計が源泉ごとに必要な属性 (例: CalDAV エンドポイント URL) で拡張される可能性があり、
+  そのときに別 ADR を起票する。
+
+## Alternatives considered
+
+- **`external_id` を `${calendar_id}::${event_id}` で合成**: 列追加なしで衝突回避できるが、
+  source 内で calendar 識別子が独立した属性として持てなくなり、subscription join が文字列分解を伴う。
+  Phase 4 分析でも calendar 単位の集計が辛い。不採用。
+- **`google_calendar_id` 等 Google 固定の命名**: 短期的には素直だが、将来 Apple 等を入れるたびに
+  rename migration が必要になる。`event_source` enum が既に複数 source 想定なのと整合しない。不採用。
+- **events の uniqueness を変えず、衝突は ON CONFLICT で握り潰す**: データの整合性を失う (どちらの
+  calendar の event か不明になる)。Phase 4 分析が歪む。不採用。
+- **新 source 対応を本 ADR で扱う (Apple / iCloud 含めた完全な設計)**: スコープが膨らむ。
+  Apple 対応の具体的な制約 (CalDAV / EventKit 等) は実際に着手するときに判明するので、
+  そのとき別 ADR で扱うほうが筋。不採用。
+
+## Notes
+
+- subscription テーブルの具体的な column 構成と migration は ADR 0034 + 実装 (Issue #144) で扱う。
+- action_log の type 一覧と metadata schema は Issue #154 で確定する。本 ADR は「triple を必須含める」方針のみ宣言する。
+- 既存 `event_source` enum はそのまま使用。新 source 追加 = enum 値追加 + subscription 設計拡張 (新 ADR)。
+- 将来見直す条件:
+  - cross-calendar 衝突が想定外パターンで起きる場合 (例: source 跨ぎの同一 ID) に triple では足りないと判明したら、
+    本 ADR を supersede。
+  - subscription / event 識別子に追加属性 (CalDAV URL 等) が必要になる新 source 対応時。

--- a/docs/adr/0034-calendar-subscription-lifecycle.md
+++ b/docs/adr/0034-calendar-subscription-lifecycle.md
@@ -1,0 +1,104 @@
+# ADR 0034: subscription 取り込み戦略 (subscribe / sync / 切替 / unsubscribe / 再 subscribe)
+
+- **Status**: Accepted
+- **Date**: 2026-05-03
+- **Related**: [ADR 0031](./0031-calendar-subscription-and-event-promotion.md) / [ADR 0032](./0032-events-visibility-override-physical-model.md) / [ADR 0033](./0033-events-cross-source-uniqueness.md) / [ADR 0001](./0001-action-logs-from-phase1.md) / Issue #144 / Issue #145 / Issue #146 / Issue #154
+
+## Context
+
+ADR 0031 で events visibility の 3 層モデル (subscription / auto-promote toggle / event override) を確定し、
+ADR 0032 で Layer 3 の物理化 (`visibility_override` enum)、ADR 0033 で events の triple identifier を確定した。
+
+本 ADR は **Layer 1〜2 (subscription) のライフサイクル** に関わる挙動を確定する。
+具体的には以下の操作と event / action_log への影響:
+
+- 初回 subscribe (calendar を新規取り込み対象にする)
+- 通常 sync (定期 / 手動)
+- Google 側での event 削除検知
+- subscription auto_promote の ON ↔ OFF 切替
+- unsubscribe (calendar を取り込み対象から外す)
+- 再 subscribe (一度 unsubscribe した calendar を再度 subscribe)
+
+これらの判断は **Phase 4 行動データの連続性** に直結する (vision 差別化の核)。
+events を物理削除する操作 (Google 削除 / unsubscribe) でも分析価値が失われない設計が必要。
+
+## Decision
+
+### 操作ごとの挙動
+
+| 操作 | 挙動 |
+|---|---|
+| **初回 subscribe** | 過去 N 日分も含めて event を取り込む (N は code 定数、現状 7 日想定で調整可)。新規取り込み event は `visibility_override='none'` で insert。auto_promote=ON なら timeline 表示、OFF なら非表示 (subscription default に従う) |
+| **過去 event の表示** | subscription default に従う (過去だけの特別ルールなし)。「振り返って見たくない」場合は個別に demote する |
+| **通常 sync** | 新規 event は `'none'` で insert。既存 event の `visibility_override` は **保持**、Google 由来フィールド (title / start / end / location 等) のみ upsert |
+| **Google 側 event 削除** | events 物理削除 + 後述の `event_deleted_by_source` を action_log に記録 + 関連 tasks への伝播 |
+| **auto_promote 切替** | 切替時点で `visibility_override='none'` の **過去 event** を旧 default の値 (`'shown'` または `'hidden'`) で固定する bulk update を行う。`'none'` の **未来 event** は更新しない (新 default に追従)。bulk update 操作は system 主体として action_log に `event_visibility_frozen_by_subscription_toggle` を記録 |
+| **過去 event の個別 override** | 制限なし、いつでも `none → shown` / `none → hidden` / `shown ↔ hidden` 可 |
+| **unsubscribe** | events 物理削除 + `calendar_unsubscribed` を action_log に記録 (削除された events の snapshot を含む) + 関連 tasks への伝播。Google 削除と挙動は揃える |
+| **再 subscribe** | ゼロから取り込み直し (kozutsumi 内 uuid は新規)。Phase 4 の連続性は action_log metadata の triple `(source, external_calendar_id, external_id)` で確保 |
+
+### 「過去」と「未来」の境界
+
+auto_promote 切替時の bulk update における「過去 event」とは **切替操作のサーバー時刻 (`now()`) より `start_time` が前** の event を指す。タイムゾーン解釈の必要はない (UTC 比較で十分)。
+
+### action_log の必須要件 (Phase 4 連続性の担保)
+
+ADR 0033 で確定した triple `(source, external_calendar_id, external_id)` を、event 関連の全 action_log type の metadata に **必須** で含める。詳細 schema は Issue #154 で扱うが、対象 type は以下:
+
+| action_type | 主体 | 主な metadata |
+|---|---|---|
+| `calendar_subscribed` | user | triple の calendar 部分 (source / external_account_id / external_calendar_id) + initial auto_promote |
+| `calendar_unsubscribed` | user | triple の calendar 部分 + 削除された events の snapshot list |
+| `calendar_auto_promote_changed` | user | triple の calendar 部分 + from / to |
+| `event_promoted` | user | triple + from / to |
+| `event_demoted` | user | triple + from / to |
+| `event_visibility_frozen_by_subscription_toggle` | system | triple + frozen_to (`'shown'` / `'hidden'`) + triggered_by (auto_promote 切替操作の参照) |
+| `event_deleted_by_source` | system | triple + 削除前 snapshot (title / start / end / visibility_override) |
+| `task_event_dependency_lost` | system | task_id + triple + 削除理由 (`deleted_by_source` / `unsubscribed`) + 削除前 event snapshot |
+
+削除系 (events 物理削除を伴うもの) では title / start / end の snapshot を必ず残す。kozutsumi 内 uuid は失われても、triple + snapshot で「あの時の予定」が後から再構成できる。
+
+### tasks への伝播
+
+`tasks.depends_on_event_id` は ON DELETE SET NULL で孤児化されるが、SET NULL される **前** に該当タスクの action_log に `task_event_dependency_lost` を記録する。これにより「あのタスクは元々この event に紐づいていた」が後から追える。
+
+## Consequences
+
+### 肯定的影響
+
+- **過去 event の振り返り価値**: 初回 subscribe で過去 N 日分も取り込むため、Phase 4 行動分析の素材が即座に蓄積される。
+- **subscription 切替の UX が自然**: 過去は固定、未来は追従、というシンメトリックな分割。「もう見たくない予定タイプを今日から非表示にしたい」要求に応えつつ、過去のタイムラインを書き換えない。
+- **削除でも連続性が保たれる**: events を物理削除しても action_log に triple + snapshot が残るので、Phase 4 分析は時系列で同一 event を識別可能。
+- **source-agnostic**: ADR 0033 の triple identifier に依存することで、Apple 等の新 source 追加時も本 ADR の方針 (取り込みライフサイクル) は流用できる。
+- **役割分担の明確化**: 「一時的に非表示」は auto_promote=OFF、「完全に取り込みやめ」は unsubscribe、と操作の意味が分かれる。
+
+### 否定的影響・トレードオフ
+
+- **subscription 切替時の bulk update**: 過去 event 全件を旧 default の値で更新する SQL が走る。切替頻度は低い前提なので大きな負荷ではないが、event 数が万単位になると注意が要る。
+- **action_log のエントリ増加**: event 削除時の snapshot や tasks 伝播で 1 操作あたりのログが多くなる。Phase 4 価値とのトレードオフで採用。
+- **再 subscribe で過去の個別 override は復活しない**: kozutsumi 内 uuid は新規になり、`visibility_override` も `'none'` から始まる。Phase 4 分析は action_log で連続するが、events テーブルの現在状態としては「ユーザーが個別判断していた事実」は失われる。これは「unsubscribe = 不要」の意思を尊重する設計判断として受け入れる。
+- **bulk update のタイミング解釈**: 「サーバー時刻で過去」と一律に決めることで、ユーザーのタイムゾーンや日付境界の議論を避ける。本人の感覚と数時間ずれる可能性はあるが、許容。
+
+## Alternatives considered
+
+- **L1 で未来のみ取り込み**: 過去取り込みなしだと Phase 4 振り返り価値を失う。subscribe 時の即時性も低い。不採用。
+- **L2 で過去 event を一律非表示** (`override='hidden'` で seed): subscription default の意味が薄れ、後から個別 promote が大量に必要。不採用。
+- **L5/L9 で論理削除 (deleted_at)**: テーブル肥大、表示クエリで `deleted_at IS NULL` フィルタが必須化。Phase 4 連続性は action_log で代替可能なので物理削除を採用。不採用。
+- **L6 で全 event を新 default に追従**: 過去のタイムライン表示が一気に変わる UX ショック。「これからの予定」と「過去の記録」を分けたい意図と整合しない。不採用。
+- **L6 で events に `visibility_override_origin` 列追加** (`'user'` / `'system_freeze'`): events 単独で origin が見える利点があるが、action_log と二重管理になる。ADR 0001 の「action_log で拡張コスト下げる」設計と整合させて action_log 駆動で識別する。不採用。
+- **L8 で過去 override 不可**: 振り返り補正の価値を失う。Phase 4 シグナルも弱まる。不採用。
+- **L9 で events を残す (subscription だけ削除)**: subscription join が解決できなくなり、auto_promote が引けない event が残る。表示クエリ複雑化。不採用。
+- **L10 で再 subscribe 時に action_log から override 復元**: append-only log を reducer として使うコードが複雑、unsubscribe の意思に逆らう。Phase 4 連続性は triple identifier で十分担保されるので不採用。
+- **N (過去取り込み期間) を ADR で固定**: パラメータは ADR にしない原則 (kozutsumi-adr skill)。code 定数で柔軟に調整する。
+
+## Notes
+
+- 本 ADR は ADR 0031 の Layer 1〜2 (subscription) を具体化し、ADR 0008 (primary 固定) の supersede を ADR 0031 と合わせて完了させる位置付け。
+- N (過去取り込み期間) / sync 間隔 / bulk update のバッチサイズなどは code 定数 (パラメータ扱い)。
+- subscription テーブルの具体的 column 構成は実装時 (Issue #144) で migration として確定する (ADR には書かない)。
+- action_log type の完全 list / metadata schema / 主体 (`actor`) の表現方法は Issue #154 で確定する。本 ADR は「event 関連 type の metadata に triple を必須含める」「削除系は snapshot を含める」という制約のみ宣言。
+- Apple 等の新 source 対応時は subscription テーブルの拡張可能性を考慮し、新 ADR を別途起票する (本 ADR の supersede ではなく、新 source 対応 ADR)。
+- 将来見直す条件:
+  - subscription 切替時の bulk update 性能が問題になったら、論理削除 + lazy resolution に切り替えて本 ADR を supersede。
+  - 「再 subscribe で個別 override 復活させたい」という要望が dogfooding で強く出たら、本 ADR を supersede して L10 を変更。
+  - action_log の triple metadata 要件が schema 変更で変わるなら、本 ADR の該当節と Issue #154 を同時更新。


### PR DESCRIPTION
## 概要 (What)

events visibility / カレンダー取り込みライフサイクルを ADR 4 本で再設計し、関連 issue #144 / #145 の本文を新方針に書き換える。実装変更は含まない、stock (ADR) と flow (issue 本文) の整理 PR。

## 関連 Issue

Refs #144, Refs #145, Refs #146

（実装は #144 / #145 / #146 で別 PR）

## 背景 (Why)

ADR 0008 (primary calendar 固定) を仮置きで進めたが、Phase 2 dogfooding で 2 つの摩擦が判明:

- 仕事 / 家族 / 趣味 calendar が落ちて日常利用が成立しない
- 一律取り込むと祝日 / 他人の勤怠 / 子供の帰宅時間でノイズだらけになる
- 「見えてはいたいが時間拘束ではない」予定が現実に存在する

vision の「自分の時間拘束がツールに集約されている」前提が成立しないので、設計を再構成する必要があった。

着手検討中に「除外を選ぶより採用を選ぶほうが正しい polarity では」という問題提起が出たことで、polarity 自体が calendar の性質によって違うことが見え、二値論争ではなく **「取り込み (sync) と予定化 (timeline 載せ) の分離」** + **「calendar ごとに default polarity を持つ」** という構造判断に至った。さらに L1〜L10 のユースケース洗い出しで、subscribe / sync / 切替 / unsubscribe / 再 subscribe のライフサイクルと、それぞれが Phase 4 行動データの連続性に与える影響まで詰めた。

## Before → After (概念・フロー・メンタルモデル)

**Before:**

- 「同期対象 = タイムバーに乗る対象」が同一概念だった (primary 1 本固定)
- visibility 制御の軸が無く、複数 calendar に対応できない
- event は Google 固有 ID で識別、source 拡張時の命名 / 連続性が曖昧

**After:**

events visibility を **3 層** に分離 (ADR 0031):

| 層 | 概念 | 単位 | 影響 |
|---|---|---|---|
| 1. Subscription | calendar を取り込み対象にする | calendar | events テーブルに行が入るか |
| 2. Auto-promote | calendar ごとの「自動予定化」トグル | calendar | その calendar の event の **default** が timeline に乗るか |
| 3. Event override | 個別 event の予定化 | event | 個別 event を timeline に乗せる最終決定 |

物理化と運用方針を 3 本の ADR で具体化:

- **ADR 0032**: `events.visibility_override` を enum 3 値 (`'none'` / `'shown'` / `'hidden'`) で持つ。日常 UI で `none` への reset は不可 (反対方向 override で復旧、設定画面で一括リセットだけ)
- **ADR 0033**: events を **`(source, external_calendar_id, external_id)` の triple** で識別。命名は source-agnostic (`google_*` を使わず `external_*`) にし、Apple Calendar 等の将来拡張に備える
- **ADR 0034**: subscribe / sync / auto_promote 切替 / unsubscribe / 再 subscribe のライフサイクル仕様。**events 物理削除を伴う操作でも action_log の triple metadata + snapshot で Phase 4 連続性を担保**。auto_promote 切替時は過去 event だけ旧 default で固定、未来は新 default に追従

## 追加した ADR

- [ADR 0031](../blob/claude/review-next-issue-SfXwy/docs/adr/0031-calendar-subscription-and-event-promotion.md): カレンダー購読と event の timeline 予定化を分離した 3 層モデル (Supersedes ADR 0008)
- [ADR 0032](../blob/claude/review-next-issue-SfXwy/docs/adr/0032-events-visibility-override-physical-model.md): events.visibility_override の物理化
- [ADR 0033](../blob/claude/review-next-issue-SfXwy/docs/adr/0033-events-cross-source-uniqueness.md): events の cross-calendar uniqueness と source-agnostic 命名
- [ADR 0034](../blob/claude/review-next-issue-SfXwy/docs/adr/0034-calendar-subscription-lifecycle.md): subscription 取り込み戦略

## 更新した既存ドキュメント / issue

- ADR 0008: Status を `Superseded by ADR 0031` に変更
- Issue #144: 本文を Layer 1+2 (subscription + auto-promote) に再定義
- Issue #145: 本文を Layer 3 (event 単位 override) に再定義、`Depends on: #144` を明示

## 追加したテスト (How verified)

- [x] ADR 0008 が ADR 0031 で正しく Superseded として記録されている
- [x] ADR 0031〜0034 が `Related` で正しく結ばれており、粒度の原則 (1 ADR = 1 supersede trigger) に沿っている
- [x] #144 / #145 の本文が ADR と整合し、依存関係 (`Depends on`) が正しい
- [x] `docs/open-questions.md` に該当論点なし、削除不要

実装変更を含まないため自動テストは無し。実装着手 (#144 → #145) 時に別 PR で検証する。

## このPRの範囲外 (Out of scope)

- 実装一切 (DB schema / sync ロジック / UI / action_log)
  - Layer 1+2 実装: #144
  - Layer 3 実装: #145
  - 複数アカウント: #146
- ADR 0009 (token self-managed refresh) の supersede (#146 の前段で別途扱う)
- 三値モデル (`info_only` 等) の運用ロジック (ADR 0032 で将来拡張余地のみ確保)
- Apple Calendar 等の新 source 対応 (ADR 0033 で source-agnostic 命名は採用済、新 source 対応は別 ADR で扱う)
- 自動フィルタルール (title pattern / participants 数 / RSVP)
- action_log の type 一覧 / metadata 詳細 schema (ADR 0033/0034 で「triple metadata 必須」「snapshot 必須」の方針のみ宣言、詳細は #154)
