### PR TITLE
fix(task-timer): useTaskTimer 戻り値の参照を安定化して memo を機能させる

### DIFF
--- a/src/features/task-stack/useTaskTimer.ts
+++ b/src/features/task-stack/useTaskTimer.ts
@@ -145,18 +145,34 @@ export function useTaskTimer(task: Task | null): TaskTimerApi {
     await invalidate();
   }, [task, openEntry, taskGateway, taskTimeEntryGateway, invalidate]);
 
-  return {
-    isActive,
-    isPaused,
-    isRunning,
-    elapsedSeconds,
-    pauseReason,
-    entries,
-    start,
-    pause,
-    resume,
-    complete,
-  };
+  // 戻り値の参照を安定化させ、呼び出し側で [timer] を依存にした useMemo / useCallback が
+  // 機能するようにする。これがないと毎レンダーで新オブジェクトになり memo が効かない。
+  return useMemo(
+    () => ({
+      isActive,
+      isPaused,
+      isRunning,
+      elapsedSeconds,
+      pauseReason,
+      entries,
+      start,
+      pause,
+      resume,
+      complete,
+    }),
+    [
+      isActive,
+      isPaused,
+      isRunning,
+      elapsedSeconds,
+      pauseReason,
+      entries,
+      start,
+      pause,
+      resume,
+      complete,
+    ],
+  );
 }
 
 /** "HH:MM:SS" または "MM:SS" に整形する。 */


### PR DESCRIPTION
## 概要 (What)

`useTaskTimer` の戻り値を `useMemo` で囲み、参照を安定化させる。これにより呼び出し側の `useMemo([timer])` / `useCallback([timer])` が期待通り memo として機能するようになる。

## 関連 Issue

Closes #151

## 背景 (Why)

`useTaskTimer` は毎レンダーで新しいオブジェクト (`return { isActive, ... }`) を返していたため、`AppShell.tsx:560-576` の `topTimer` を作る `useMemo([timer])` と `handlePauseSelect` の `useCallback([timer])` が事実上メモ化として機能していなかった。`TopTimerBinding` が毎レンダーで再生成され、`TaskStack` 配下の `React.memo` / shallow 比較が効かない状態。

直し方は 2 通りあった:

1. AppShell 側で依存を個別フィールドに展開する (`[timer.elapsedSeconds, timer.start, ...]`)
2. `useTaskTimer` 側で戻り値を `useMemo` で安定化する

(2) を選択。理由:

- (1) は ESLint `react-hooks/exhaustive-deps` が「`[timer]` 全体を含めろ」と警告し、ルールに反した形で運用しないといけない（バグの再導入を招きやすい）
- (2) は呼び出し側がシンプルな `[timer]` のままでよく、将来 `useTaskTimer` の利用箇所が増えても自然に恩恵が出る

## Before → After

**Before:**

```
useTaskTimer → 毎レンダー新オブジェクト
  ↓ [timer]
useMemo / useCallback (実質ノーメモ)
  ↓ 毎レンダー新 binding
TopTaskCard (React.memo が効かない)
```

**After:**

```
useTaskTimer → useMemo で安定化された参照
  ↓ [timer]
useMemo / useCallback (実際にメモ化)
  ↓ 依存が変わったときだけ新 binding
TopTaskCard (React.memo が機能)
```

## 追加したテスト (How verified)

- [x] 既存の `useTaskTimer` テスト (495 件) が全 pass
- [x] `typecheck` / `lint` / `format:check` 通過
- [x] パフォーマンスの体感差は計測していない（小さい修正なので observable な影響は限定的。Phase 2 で UI が重くなった際の再計測が現実的）

## このPRの範囲外 (Out of scope)

- AppShell.tsx (889 行) 全体の責務分離 → #152 で別途
- `useTaskTimer` 内部の他の memo の最適化 → 必要になったら別 issue

https://claude.ai/code/session_012NcV7mCTuugF6YC8Zwosq5

---
_Generated by [Claude Code](https://claude.ai/code/session_012NcV7mCTuugF6YC8Zwosq5)_