### PR TITLE
fix(ai): AI 分解の子 insert と親 decompose_status 更新を 1 トランザクション化 (Closes #150)

### DIFF
--- a/src/entities/task/decompose-server.test.ts
+++ b/src/entities/task/decompose-server.test.ts
@@ -13,21 +13,23 @@ import {
 type Plan = {
   fetch: { data: Partial<Tables<"tasks">> | null; error: { message: string } | null };
   update: { error: { message: string } | null };
-  // bulk insert tasks → returns id rows
-  insertTasks: { data: { id: string }[] | null; error: { message: string } | null };
+  // ADR 0021 / Issue #150: 子 insert + 親 decompose_status 更新は fn_decompose_parent_task RPC で
+  // 1 トランザクション化されたので、mock も rpc レイヤで応答を返す。
+  rpc: { data: string[] | null; error: { message: string } | null };
   insertActionLogs: { error: { message: string } | null };
+  rpcThrow?: unknown; // rpc が throw する想定 (last-resort safety net テスト用)
 };
 
 function makeSupabase(plan: Plan): {
   client: SupabaseClient<Database>;
   calls: {
-    insertedTasks: unknown[];
+    rpcCalls: Array<{ name: string; params: Record<string, unknown> }>;
     statusUpdates: Array<{ id: unknown; decompose_status: unknown }>;
     actionLogs: unknown[];
   };
 } {
   const calls = {
-    insertedTasks: [] as unknown[],
+    rpcCalls: [] as Array<{ name: string; params: Record<string, unknown> }>,
     statusUpdates: [] as Array<{ id: unknown; decompose_status: unknown }>,
     actionLogs: [] as unknown[],
   };
@@ -58,30 +60,26 @@ function makeSupabase(plan: Plan): {
         })),
       })),
       // setDecomposeStatus: update({...}).eq("id", taskId) — eq is awaited (PostgrestFilterBuilder is thenable)
-      // bulk insert: insert(payloads).select("id") — chain returns data/error
       update: (patch: { decompose_status?: unknown }) => ({
         eq: (_col: string, val: unknown) => {
           calls.statusUpdates.push({ id: val, decompose_status: patch.decompose_status });
           return Promise.resolve({ error: plan.update.error });
         },
       }),
-      insert: (payloads: unknown) => {
-        // bulk insert tasks: chain ends with .select("id")
-        calls.insertedTasks.push(payloads);
-        return {
-          select: vi.fn(() =>
-            Promise.resolve({
-              data: plan.insertTasks.data,
-              error: plan.insertTasks.error,
-            }),
-          ),
-        };
-      },
     };
+  });
+
+  const rpc = vi.fn((name: string, params: Record<string, unknown>) => {
+    calls.rpcCalls.push({ name, params });
+    if (plan.rpcThrow !== undefined) {
+      throw plan.rpcThrow;
+    }
+    return Promise.resolve({ data: plan.rpc.data, error: plan.rpc.error });
   });
 
   const client = {
     from,
+    rpc,
   } as unknown as SupabaseClient<Database>;
 
   return { client, calls };
@@ -106,7 +104,7 @@ function defaultPlan(parent: Partial<Tables<"tasks">> | null): Plan {
   return {
     fetch: { data: parent, error: null },
     update: { error: null },
-    insertTasks: { data: [{ id: "child-1" }, { id: "child-2" }], error: null },
+    rpc: { data: ["child-1", "child-2"], error: null },
     insertActionLogs: { error: null },
   };
 }
@@ -131,7 +129,7 @@ describe("decomposeTask", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
-  test("happy path: AI が 2 件返す → 子 insert + 親 decomposed + action_log 記録 (raw_response を含む)", async () => {
+  test("happy path: AI が 2 件返す → rpc で 子 insert + 親 decomposed を atomic 実行 + action_log (raw_response 含む)", async () => {
     const { client, calls } = makeSupabase(defaultPlan(makeParentRow()));
     const rawResponse = JSON.stringify([
       {
@@ -148,34 +146,30 @@ describe("decomposeTask", () => {
 
     expect(result).toEqual({ kind: "decomposed", childIds: ["child-1", "child-2"] });
 
-    // bulk insert payload を検証
-    expect(calls.insertedTasks).toHaveLength(1);
-    const inserted = calls.insertedTasks[0] as Array<Record<string, unknown>>;
-    expect(inserted).toHaveLength(2);
-    expect(inserted[0]).toMatchObject({
-      user_id: "user-1",
-      project_id: "proj-1", // 親から継承
-      depends_on_event_id: "evt-1", // 親から継承
-      parent_task_id: "parent-1",
+    // ADR 0021 / Issue #150: rpc が想定通りの params で呼ばれている
+    expect(calls.rpcCalls).toHaveLength(1);
+    expect(calls.rpcCalls[0].name).toBe("fn_decompose_parent_task");
+    expect(calls.rpcCalls[0].params).toMatchObject({
+      p_parent_id: "parent-1",
+      p_base_stack_order: 5, // = parent.stack_order
+    });
+    const newChildren = calls.rpcCalls[0].params.p_new_children as Array<Record<string, unknown>>;
+    expect(newChildren).toHaveLength(2);
+    expect(newChildren[0]).toMatchObject({
       title: "子A",
       body: "- 手順を書く\n- 注意点を確認", // #120: AI 生成 body を子 insert に渡す
       estimated_minutes: 30,
       task_category: "research", // ADR 0022: decompose プロンプトが同時推論
-      stack_order: 5, // baseStackOrder = parent.stack_order
-      decompose_status: "none",
     });
-    expect(inserted[1]).toMatchObject({
+    expect(newChildren[1]).toMatchObject({
       title: "子B",
       body: "", // body が無い子は空文字で insert される
+      estimated_minutes: 15,
       task_category: "doc",
-      stack_order: 6, // baseStackOrder + 1
     });
 
-    // 状態遷移: decomposing → decomposed
-    expect(calls.statusUpdates).toEqual([
-      { id: "parent-1", decompose_status: "decomposing" },
-      { id: "parent-1", decompose_status: "decomposed" },
-    ]);
+    // 状態遷移: decomposing に倒すのみ (success path では rpc が親 status='decomposed' まで実行する)
+    expect(calls.statusUpdates).toEqual([{ id: "parent-1", decompose_status: "decomposing" }]);
 
     // action_log: task_decomposed (ADR 0021 で raw_response を必須化)
     expect(calls.actionLogs).toHaveLength(1);
@@ -203,7 +197,7 @@ describe("decomposeTask", () => {
 
     expect(result).toEqual({ kind: "skipped", reason: "task_not_found" });
     expect(generate).not.toHaveBeenCalled();
-    expect(calls.insertedTasks).toHaveLength(0);
+    expect(calls.rpcCalls).toHaveLength(0);
     expect(calls.statusUpdates).toHaveLength(0);
     expect(calls.actionLogs).toHaveLength(0);
   });
@@ -216,7 +210,7 @@ describe("decomposeTask", () => {
 
     expect(result).toEqual({ kind: "skipped", reason: "parent_active_or_locked" });
     expect(generate).not.toHaveBeenCalled();
-    expect(calls.insertedTasks).toHaveLength(0);
+    expect(calls.rpcCalls).toHaveLength(0);
     expect(calls.statusUpdates).toHaveLength(0); // decomposing にすら倒さない
   });
 
@@ -242,7 +236,7 @@ describe("decomposeTask", () => {
 
     expect(result).toEqual({ kind: "skipped", reason: "already_resolved" });
     expect(generate).not.toHaveBeenCalled();
-    expect(calls.insertedTasks).toHaveLength(0);
+    expect(calls.rpcCalls).toHaveLength(0);
   });
 
   test("既に skipped → 再分解しない", async () => {
@@ -269,10 +263,10 @@ describe("decomposeTask", () => {
 
     expect(result).toEqual({ kind: "decomposed", childIds: ["child-1", "child-2"] });
     expect(generate).toHaveBeenCalledOnce();
-    expect(calls.statusUpdates).toEqual([
-      { id: "parent-1", decompose_status: "decomposing" },
-      { id: "parent-1", decompose_status: "decomposed" },
-    ]);
+    // success path では rpc が親 status まで `decomposed` に倒すので、orchestrator の
+    // 追加 status update は decomposing 1 回のみ (Issue #150 / ADR 0021)
+    expect(calls.statusUpdates).toEqual([{ id: "parent-1", decompose_status: "decomposing" }]);
+    expect(calls.rpcCalls).toHaveLength(1);
     // 再実行の試行履歴が action_logs に残る (#133 / ADR 0021)
     expect(calls.actionLogs).toHaveLength(1);
     expect(calls.actionLogs[0]).toMatchObject({
@@ -289,7 +283,7 @@ describe("decomposeTask", () => {
     const result = await decomposeTask(makeDeps({ client, generate }));
 
     expect(result).toEqual({ kind: "failed", reason: "ai_response_unparseable" });
-    expect(calls.insertedTasks).toHaveLength(0);
+    expect(calls.rpcCalls).toHaveLength(0);
     // 状態: decomposing → failed (旧: none に戻していたのを ADR 0021 で変更)
     expect(calls.statusUpdates).toEqual([
       { id: "parent-1", decompose_status: "decomposing" },
@@ -316,7 +310,7 @@ describe("decomposeTask", () => {
     const result = await decomposeTask(makeDeps({ client, generate }));
 
     expect(result).toEqual({ kind: "skipped", reason: "ai_decided_not_to_split" });
-    expect(calls.insertedTasks).toHaveLength(0);
+    expect(calls.rpcCalls).toHaveLength(0);
     expect(calls.statusUpdates).toEqual([
       { id: "parent-1", decompose_status: "decomposing" },
       { id: "parent-1", decompose_status: "skipped" },
@@ -339,7 +333,7 @@ describe("decomposeTask", () => {
     const result = await decomposeTask(makeDeps({ client, generate }));
 
     expect(result).toEqual({ kind: "skipped", reason: "ai_decided_not_to_split" });
-    expect(calls.insertedTasks).toHaveLength(0);
+    expect(calls.rpcCalls).toHaveLength(0);
     // 1 件 → parser が空配列扱いにするので task_decompose_skipped 記録
     expect(calls.actionLogs).toHaveLength(1);
     expect(calls.actionLogs[0]).toMatchObject({
@@ -347,9 +341,9 @@ describe("decomposeTask", () => {
     });
   });
 
-  test("子 insert が DB 失敗 → failed に倒し task_decompose_failed を記録 (raw_response 付き)", async () => {
+  test("rpc が error を返す (子 insert / 親 status update が atomic に失敗) → failed/insert_failed (Issue #150)", async () => {
     const plan = defaultPlan(makeParentRow());
-    plan.insertTasks = { data: null, error: { message: "FK violation" } };
+    plan.rpc = { data: null, error: { message: "FK violation" } };
     const { client, calls } = makeSupabase(plan);
     const raw = JSON.stringify([
       { title: "a", estimated_minutes: 15 },
@@ -360,7 +354,8 @@ describe("decomposeTask", () => {
     const result = await decomposeTask(makeDeps({ client, generate }));
 
     expect(result).toEqual({ kind: "failed", reason: "insert_failed" });
-    // 旧: none に戻す → ADR 0021 で failed に変更
+    expect(calls.rpcCalls).toHaveLength(1);
+    // ADR 0021: rpc 失敗で transaction 全体が rollback され、orchestrator が failed に倒す
     expect(calls.statusUpdates).toEqual([
       { id: "parent-1", decompose_status: "decomposing" },
       { id: "parent-1", decompose_status: "failed" },
@@ -375,6 +370,28 @@ describe("decomposeTask", () => {
         raw_response: raw,
         error_message: "FK violation",
       },
+    });
+  });
+
+  test("rpc が想定外 throw (last-resort safety net) → failed/internal_error (Issue #150)", async () => {
+    const plan = defaultPlan(makeParentRow());
+    plan.rpcThrow = new Error("boom in rpc layer");
+    const { client, calls } = makeSupabase(plan);
+    const raw = JSON.stringify([
+      { title: "a", estimated_minutes: 15 },
+      { title: "b", estimated_minutes: 15 },
+    ]);
+    const generate = vi.fn(async () => raw);
+
+    const result = await decomposeTask(makeDeps({ client, generate }));
+
+    expect(result).toEqual({ kind: "failed", reason: "internal_error" });
+    // 旧実装の「子 insert 成功 + 親 status 更新失敗 → decomposing で固まる」経路は
+    // RPC 化により構造的に消えた。throw でも parent は failed で終端する。
+    expect(calls.statusUpdates.some((u) => u.decompose_status === "failed")).toBe(true);
+    expect(calls.actionLogs[0]).toMatchObject({
+      action_type: "task_decompose_failed",
+      metadata: { reason: "internal_error", error_message: "boom in rpc layer" },
     });
   });
 
@@ -393,7 +410,7 @@ describe("decomposeTask", () => {
       { id: "parent-1", decompose_status: "decomposing" },
       { id: "parent-1", decompose_status: "failed" },
     ]);
-    expect(calls.insertedTasks).toHaveLength(0);
+    expect(calls.rpcCalls).toHaveLength(0);
     expect(calls.actionLogs).toHaveLength(1);
     expect(calls.actionLogs[0]).toMatchObject({
       action_type: "task_decompose_failed",
@@ -462,7 +479,7 @@ describe("decomposeTask", () => {
     });
   });
 
-  test("親の stack_order が null でも子は 0 始まりで割り当てられる", async () => {
+  test("親の stack_order が null でも rpc には base=0 が渡る (子は 0 始まりで割り当てられる)", async () => {
     const { client, calls } = makeSupabase(defaultPlan(makeParentRow({ stack_order: null })));
     const generate = vi.fn(async () =>
       JSON.stringify([
@@ -473,28 +490,12 @@ describe("decomposeTask", () => {
 
     await decomposeTask(makeDeps({ client, generate }));
 
-    const inserted = calls.insertedTasks[0] as Array<Record<string, unknown>>;
-    expect(inserted[0]).toMatchObject({ stack_order: 0 });
-    expect(inserted[1]).toMatchObject({ stack_order: 1 });
+    expect(calls.rpcCalls[0].params.p_base_stack_order).toBe(0);
   });
 
-  test("親の depends_on_event_id が null なら子も null", async () => {
-    const { client, calls } = makeSupabase(
-      defaultPlan(makeParentRow({ depends_on_event_id: null })),
-    );
-    const generate = vi.fn(async () =>
-      JSON.stringify([
-        { title: "a", estimated_minutes: 15 },
-        { title: "b", estimated_minutes: 15 },
-      ]),
-    );
-
-    await decomposeTask(makeDeps({ client, generate }));
-
-    const inserted = calls.insertedTasks[0] as Array<Record<string, unknown>>;
-    expect(inserted[0].depends_on_event_id).toBeNull();
-    expect(inserted[1].depends_on_event_id).toBeNull();
-  });
+  // depends_on_event_id の継承は SQL (fn_decompose_parent_task) が担うので、TypeScript レイヤでの
+  // テストは行わない。RPC params には parent_task_id 由来の値は含まれず、SQL 側で parent から
+  // select user_id / project_id / depends_on_event_id して継承する設計。
 
   test("task_category が混在 (値域内 / 値域外 / 欠損) → 値域内は採用 / それ以外は null で子は作られる (ADR 0022)", async () => {
     const { client, calls } = makeSupabase(defaultPlan(makeParentRow()));
@@ -510,11 +511,11 @@ describe("decomposeTask", () => {
 
     // category の部分失敗で子の生成自体は止めない (フェイルソフト)
     expect(result.kind).toBe("decomposed");
-    const inserted = calls.insertedTasks[0] as Array<Record<string, unknown>>;
-    expect(inserted).toHaveLength(3);
-    expect(inserted[0]).toMatchObject({ title: "a", task_category: "coding" });
-    expect(inserted[1]).toMatchObject({ title: "b", task_category: null });
-    expect(inserted[2]).toMatchObject({ title: "c", task_category: null });
+    const newChildren = calls.rpcCalls[0].params.p_new_children as Array<Record<string, unknown>>;
+    expect(newChildren).toHaveLength(3);
+    expect(newChildren[0]).toMatchObject({ title: "a", task_category: "coding" });
+    expect(newChildren[1]).toMatchObject({ title: "b", task_category: null });
+    expect(newChildren[2]).toMatchObject({ title: "c", task_category: null });
   });
 });
 

--- a/src/entities/task/decompose-server.ts
+++ b/src/entities/task/decompose-server.ts
@@ -7,7 +7,7 @@ import {
   parseDecomposeResponse,
   type DecomposeInput,
 } from "@/shared/ai/prompts/decompose";
-import type { Database, Tables, TablesInsert } from "@/shared/types/database";
+import type { Database, Json, Tables } from "@/shared/types/database";
 
 /**
  * AI タスク分解 (P3-6 / ADR 0017 / 0018 / 0016 / 0021) の server 側 orchestrator。
@@ -130,39 +130,35 @@ async function runDecompose(
   const baseStackOrder = parent.stack_order ?? 0;
   // 子の task_category は decompose プロンプトが同時推論する (ADR 0022 Decision 2)。
   // categorize の fan-out を避けることで 1 親あたりの Gemini 呼び出しを最大 2 回に固定する。
-  const childPayloads: TablesInsert<"tasks">[] = parsed.map((child, idx) => ({
-    user_id: userId,
-    project_id: parent.project_id,
+  const newChildren: Json = parsed.map((child) => ({
     title: child.title,
     body: child.body,
     estimated_minutes: child.estimatedMinutes,
     task_category: child.taskCategory,
-    parent_task_id: parent.id,
-    depends_on_event_id: parent.depends_on_event_id,
-    stack_order: baseStackOrder + idx,
-    decompose_status: "none",
   }));
 
-  const { data: insertedRows, error: insertErr } = await supabase
-    .from("tasks")
-    .insert(childPayloads)
-    .select("id");
+  // ADR 0021 / Issue #150: 子 insert + 親 decompose_status 更新を 1 トランザクションで行う。
+  // 旧実装は 2 クエリに分かれており、子 insert 成功後の status 更新失敗 (接続断 / タイムアウト)
+  // で親が `decomposing` で固まる経路があった。RPC 化することで中間 failure を構造的に消す。
+  // RPC が error を返す / throw した場合は orchestrator 側 (catch / 後段) で `failed` に倒す。
+  const { data: childIds, error: rpcError } = await supabase.rpc("fn_decompose_parent_task", {
+    p_parent_id: parent.id,
+    p_base_stack_order: baseStackOrder,
+    p_new_children: newChildren,
+  });
 
-  if (insertErr || !insertedRows) {
-    console.error("[ai/decompose] child insert failed", insertErr);
+  if (rpcError || !childIds || childIds.length === 0) {
+    console.error("[ai/decompose] rpc failed", rpcError);
     await setDecomposeStatus(supabase, parent.id, "failed");
     await logServerSide(supabase, userId, "task_decompose_failed", {
       task_id: parent.id,
       reason: "insert_failed",
       raw_response: responseText,
-      error_message: insertErr?.message,
+      error_message: rpcError?.message,
     });
     return { kind: "failed", reason: "insert_failed" };
   }
 
-  const childIds = insertedRows.map((r) => r.id);
-
-  await setDecomposeStatus(supabase, parent.id, "decomposed");
   await logServerSide(supabase, userId, "task_decomposed", {
     task_id: parent.id,
     child_ids: childIds,

--- a/src/shared/types/database.ts
+++ b/src/shared/types/database.ts
@@ -263,6 +263,18 @@ export type Database = {
         };
         Returns: string[];
       };
+      // ADR 0021 / Issue #150: AI 分解の子 insert + 親 decompose_status='decomposed' 更新を
+      // 1 トランザクションで行う PL/pgSQL function。
+      // 中間 failure (子 insert 成功 + 親 status 更新失敗) で decomposing 固まりを起こさない。
+      // 戻り値は新規子の id 配列 (jsonb 入力順 = stack_order 昇順)。
+      fn_decompose_parent_task: {
+        Args: {
+          p_parent_id: string;
+          p_base_stack_order: number;
+          p_new_children: Json;
+        };
+        Returns: string[];
+      };
     };
     Enums: {
       task_status: "idle" | "active" | "paused" | "done";

--- a/supabase/migrations/20260503000000_p3_decompose_parent_task_fn.sql
+++ b/supabase/migrations/20260503000000_p3_decompose_parent_task_fn.sql
@@ -1,0 +1,117 @@
+-- kozutsumi Phase 3 派生 (issue #150): AI 分解の子 insert + 親 decompose_status 更新を 1 トランザクション化
+--
+-- References:
+-- * docs/adr/0017-ai-task-decomposition-async.md (AI 分解は async fire-and-forget)
+-- * docs/adr/0021-ai-decomposition-failure-visibility.md
+--   (decomposing で固まらない不変条件: 子 insert と親 status 更新の中間 failure を消す)
+-- * supabase/migrations/20260430230402_p3_resplit_child_task_fn.sql
+--   (子の再分解 RPC fn_resplit_child_task。本 migration は同じパターンで親 → 子 insert を atomic 化する)
+--
+-- 本 migration が決めること:
+-- 1. fn_decompose_parent_task PL/pgSQL function を新設
+--    新規子 insert + 親 decompose_status='decomposed' 更新を 1 トランザクションで行う
+-- 2. action_logs への記録は呼び出し側 (decompose-server.ts) で行う
+--    (RPC 内で log すると失敗時のロールバック範囲が広がる + 学習素材の主要属性は呼び出し側でしか取れない。
+--     fn_resplit_child_task と同じ設計方針)
+
+-- =====================================================================
+-- fn_decompose_parent_task
+-- =====================================================================
+--
+-- 引数:
+--   p_parent_id         : 分解対象の親 task id
+--   p_base_stack_order  : 子の先頭 stack_order (= 親の stack_order を引き継ぐ)
+--   p_new_children      : 新規子の配列 (jsonb)。各要素は
+--                         { title, body, estimated_minutes, task_category } を持つ
+--
+-- 戻り値:
+--   uuid[]              : 新規子の id 配列 (jsonb 入力順 = stack_order 昇順)
+--
+-- security invoker: RLS で auth.uid() 一致のみ許可 (kozutsumi の Phase 1 方針 / ADR 0001)。
+-- 別ユーザーの行は select / update / insert すべてが 0 行扱いで弾かれる。
+--
+-- 順序:
+--   1. 親 row から user_id / project_id / depends_on_event_id を取得 (子継承用)
+--   2. 新規子を base_stack_order, base+1, ..., base+N-1 で連続 insert
+--   3. 親の decompose_status を 'decomposed' に更新
+--
+-- 中間で失敗すれば transaction 全体が rollback され、orchestrator (decompose-server.ts) が
+-- ADR 0021 の last-resort safety net で parent を 'failed' に倒す経路に合流する。
+-- これにより「子 insert 成功 + 親 status 更新失敗 → decomposing で固まる」経路を構造的に消す。
+
+create or replace function public.fn_decompose_parent_task(
+  p_parent_id uuid,
+  p_base_stack_order integer,
+  p_new_children jsonb
+) returns uuid[]
+language plpgsql
+security invoker
+as $$
+declare
+  v_user_id uuid;
+  v_project_id uuid;
+  v_depends_on_event_id uuid;
+  v_idx int;
+  v_count int;
+  v_child jsonb;
+  v_new_id uuid;
+  v_new_ids uuid[] := '{}';
+begin
+  -- 1. 親 row の継承用属性を取得 (RLS で別 user の親は 0 行 → v_user_id is null になる)
+  select user_id, project_id, depends_on_event_id
+    into v_user_id, v_project_id, v_depends_on_event_id
+    from public.tasks
+   where id = p_parent_id;
+
+  if v_user_id is null then
+    raise exception 'fn_decompose_parent_task: parent task not found or not authorized: %', p_parent_id;
+  end if;
+
+  -- 2. 新規子配列のサイズを確認 (空配列禁止: orchestrator で 0 件は skipped 経路に流れる)
+  v_count := jsonb_array_length(p_new_children);
+  if v_count < 1 then
+    raise exception 'fn_decompose_parent_task: new_children must be non-empty (got %)', v_count;
+  end if;
+
+  -- 3. 新規子を base_stack_order, base+1, ..., base+N-1 で順に insert
+  for v_idx in 0 .. v_count - 1 loop
+    v_child := p_new_children -> v_idx;
+    insert into public.tasks (
+      user_id,
+      project_id,
+      parent_task_id,
+      depends_on_event_id,
+      title,
+      body,
+      estimated_minutes,
+      task_category,
+      stack_order,
+      decompose_status
+    ) values (
+      v_user_id,
+      v_project_id,
+      p_parent_id,
+      v_depends_on_event_id,
+      v_child ->> 'title',
+      coalesce(v_child ->> 'body', ''),
+      nullif(v_child ->> 'estimated_minutes', '')::integer,
+      nullif(v_child ->> 'task_category', '')::text,
+      p_base_stack_order + v_idx,
+      'none'::public.decompose_status
+    )
+    returning id into v_new_id;
+
+    v_new_ids := array_append(v_new_ids, v_new_id);
+  end loop;
+
+  -- 4. 親の decompose_status を 'decomposed' に倒す (ADR 0021 の終端 status)
+  update public.tasks
+     set decompose_status = 'decomposed'::public.decompose_status
+   where id = p_parent_id;
+
+  return v_new_ids;
+end;
+$$;
+
+comment on function public.fn_decompose_parent_task(uuid, integer, jsonb) is
+  'Issue #150 / ADR 0021: AI 分解の子 insert + 親 decompose_status 更新を 1 トランザクション化。security invoker (RLS 適用)。';


### PR DESCRIPTION
## 概要 (What)

AI タスク分解で「子 insert は成功 / 親 `decompose_status` 更新は失敗」が起きた時に親が `decomposing` のまま固まる経路を、`fn_decompose_parent_task` RPC で 1 トランザクション化して構造的に消す。

## 関連 Issue

Closes #150

## 背景 (Why)

- `src/entities/task/decompose-server.ts:146-165` で子 `INSERT` 直後の `setDecomposeStatus(parent, "decomposed")` が別クエリ。子 insert 成功後にネットワーク断 / タイムアウトで status 更新が失敗すると、子はテーブルに存在するが親は `decomposing` のまま残る。
- `setDecomposeStatus` は `console.error` で握り潰す (decompose-server.ts:247-258) のでサイレントに発生し得る。
- ADR 0021 の不変条件「`decomposing` で固まらない」を破る低頻度経路。
- 子の再分解 (`src/entities/task/resplit-server.ts`) は同等処理を `fn_resplit_child_task` RPC で 1 トランザクション化済みなので、同じパターンに揃える。

## Before → After (概念・フロー・メンタルモデル)

**Before:**

```
runDecompose
├─ supabase.from("tasks").insert(childPayloads).select("id")  ← クエリ1
│   └─ 失敗 → setDecomposeStatus("failed") で終端
└─ setDecomposeStatus(parent, "decomposed")                    ← クエリ2
    └─ 失敗 → console.error のみ (= 親は decomposing のまま固まる)
```

クエリ間にネットワーク断 / タイムアウトが入ると「子は存在 / 親は decomposing」のデッドロック状態が残る。

**After:**

```
runDecompose
└─ supabase.rpc("fn_decompose_parent_task", { ... })           ← 単一 RPC
    ├─ SQL 内で 子 insert + 親 status='decomposed' 更新を atomic 実行
    ├─ rpc.error → orchestrator が "failed" + insert_failed log
    └─ rpc throw → outer try/catch の last-resort safety net で
                   "failed" + internal_error log (ADR 0021)
```

中間 failure (どちらか片方だけ成功) は SQL レベルで起こり得なくなる。throw / error はどちらも `failed` に倒す既存経路に合流するので、`decomposing` 固まりが構造的に消える。

## 追加したテスト (How verified)

- [x] `npm run typecheck` / `npm run lint` / `npm test` (495 tests) いずれも通過
- [x] `decompose-server.test.ts` を rpc モックに移行
  - happy path: rpc 1 回 + statusUpdates は decomposing のみ + action_log に raw_response
  - rpc が `error` を返す → `failed/insert_failed` で記録
  - **rpc が throw する → `failed/internal_error` で last-resort safety net 経由 (新規)**
  - 既存の guard / parse / quota / network ケースは rpc が呼ばれていないこと (`rpcCalls.length === 0`) で確認

## リリース前チェックリスト (When / Before merge)

- [x] マイグレーション適用順を確認 (`20260503000000_p3_decompose_parent_task_fn.sql` を最新タイムスタンプで追加)
- [ ] `npm test` ベースの確認だけで、本番 Supabase / 実 RPC 経路は未確認 (RPC のシグネチャ・型は `fn_resplit_child_task` の既存パターンを踏襲)

## このPRの範囲外 (Out of scope)

- `decomposed` / `skipped` の再分解は ADR 0021 通り対象外
- 旧実装で残っていた `setDecomposeStatus` の握り潰し挙動 (失敗時 console.error のみ) は触らない。本 PR の経路では status 更新失敗が `failed` 経路に倒す last-resort safety net で吸収される設計


---
_Generated by [Claude Code](https://claude.ai/code/session_01W6PYJmheuqEuYSsEDFSzcn)_