### PR TITLE
chore(devex): pre-push の prettier ドリフトを auto-fix + block する hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git push*)",
+            "command": "./node_modules/.bin/prettier --check . >/dev/null 2>&1 || { ./node_modules/.bin/prettier --write . >/dev/null 2>&1 || true; echo 'prettier がフォーマットドリフトを auto-fix しました。git diff を確認して commit してから push し直してください。' >&2; exit 2; }",
+            "timeout": 60,
+            "statusMessage": "Pre-push prettier check..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "check": "npm run format:check && npm run lint && npm run typecheck && npm run test"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
## 概要 (What)

PR #118 で format:check が CI でだけ落ちて気付けなかった漏れを、`git push` の手前で 1 回だけ確実に止める hook で塞ぐ。lint / typecheck / test は Claude のワークフロー判断に任せ、prettier 1 点に絞る。

## 関連 Issue

Closes #119

## 背景 (Why)

PR #118 (P3-15) で prettier 差分を取り込み忘れ、CI Format job を 1 回落とした。手元の `typecheck` / `lint` / `test` は通っていたので、漏れていたのは format だけ。

issue では PostToolUse + Stop の二段構えも候補に上がっていたが、議論の中で:

- edit ごとに prettier を回すのは過剰
- Stop で毎ターン `npm run check` を強制するのは lint / typecheck / test の重複コスト (Claude が普段から model 判断で回す) の方が大きい
- 実際 #118 で漏れたのは format だけ

→ **prettier 1 点に絞り、push の手前で確定発火させる** が最小コストで最大効果と判断した。

## Before → After (考え方)

**Before:** "format:check 忘れない" を model 判断 + 規律で守る前提 → 抜けたら CI が拾うまで気付けない

**After:** `git push` を hook で gate する。format ドリフトは push 通過の前提条件として機械的に弾かれる → 規律に頼らない

## 追加したテスト (How verified)

- [x] hook command を synthetic drift 入りファイルで pipe-test
  - `prettier --check` が drift を検出 → `--write` で auto-fix → exit 2 で block
- [x] clean baseline で hook が exit 0 (素通し) になることを確認
- [x] `npm run check` 単体実行で全 step (format:check + lint + typecheck + test) が通ることを確認 (~28s)
- [x] `jq -e` で `.claude/settings.json` の hook スキーマを検証

## リリース前チェックリスト (When / Before merge)

- [x] settings.json は `.claude/settings.json` (commit) に置いた → 自分の他端末でも有効化される
- [ ] **既存 session では settings.json watcher が新規ファイルを load しないので、merge 後に `/hooks` を 1 度開くか restart で有効化される** (handoff メモ)

## このPRの範囲外 (Out of scope)

- **Husky / lefthook の pre-push hook**: Claude のターン外で push する頻度が低いのでオーバーキル。必要になったら別 issue で
- **Stop hook での `npm run check` 自動実行**: Claude が普段から lint/typecheck/test を回すため重複と判断
- **PostToolUse(Write|Edit) での edit ごとの prettier --write**: push の手前 1 回で十分

---
_Generated by [Claude Code](https://claude.ai/code/session_01CeXAt6kmBK9YZR7cCk4ANe)_