### PR TITLE
feat(db): calendar 機能拡張のための schema migration (Closes #159)

### DIFF
--- a/e2e/gcal-event-readonly.spec.ts
+++ b/e2e/gcal-event-readonly.spec.ts
@@ -42,6 +42,7 @@ test.describe("google_calendar イベントの編集制約 (ADR 0010)", () => {
       description,
       source: "google_calendar",
       external_id: "gcal-readonly-e2e",
+      external_calendar_id: "primary",
     });
     if (insertErr) throw new Error(`[e2e] insert gcal event failed: ${insertErr.message}`);
 
@@ -124,6 +125,7 @@ test.describe("google_calendar イベントの編集制約 (ADR 0010)", () => {
       description: "",
       source: "google_calendar",
       external_id: "gcal-project-edit-e2e",
+      external_calendar_id: "primary",
     });
     if (insertErr) throw new Error(`[e2e] insert gcal event failed: ${insertErr.message}`);
 

--- a/scripts/db-migration-diff/compare.mjs
+++ b/scripts/db-migration-diff/compare.mjs
@@ -180,6 +180,11 @@ function runAssertions(report, prSnapshot) {
   }
 
   // ❌ NOT NULL かつ default なしのカラム追加 (既存行で fail) — 通常 table のみ対象
+  // 例外: column comment に `@migration-safe-not-null` marker が含まれる場合は skip。
+  // 「同一 migration 内で nullable で追加 → backfill → NOT NULL 化を完結させた」ケースを
+  // 明示的にオプトアウトするための仕組み (default を付けようがない uuid FK 列など)。
+  // marker を使う時は comment に backfill ロジックの所在 (migration ファイル名等) も書くこと。
+  const SAFE_NOT_NULL_MARKER = "@migration-safe-not-null";
   for (const c of report.columns.added) {
     if (c.schema !== "public") continue;
     if ((c.kind ?? "table") !== "table") continue; // view / matview の列は対象外
@@ -189,10 +194,16 @@ function runAssertions(report, prSnapshot) {
     );
     if (isNewTable) continue;
     if (c.nullable === "NO" && c.default === null) {
+      if (typeof c.comment === "string" && c.comment.includes(SAFE_NOT_NULL_MARKER)) {
+        oks.push(
+          `\`${c.schema}.${c.table}.${c.column}\` は NOT NULL + default なしだが column comment の \`${SAFE_NOT_NULL_MARKER}\` で同 migration 内 backfill が宣言されている`,
+        );
+        continue;
+      }
       errors.push({
         kind: "not-null-no-default",
         message: `\`${c.schema}.${c.table}.${c.column}\` を NOT NULL かつ default なしで追加 (既存行で違反)`,
-        fix: "default 値を付けるか、まず NULL 可で追加 → backfill → NOT NULL 化に分割",
+        fix: `default 値を付けるか、まず NULL 可で追加 → backfill → NOT NULL 化に分割。同一 migration 内で安全に backfill 完結する場合は column comment に \`${SAFE_NOT_NULL_MARKER}\` を含めて opt-out できる`,
       });
     }
   }

--- a/scripts/db-migration-diff/snapshot.sql
+++ b/scripts/db-migration-diff/snapshot.sql
@@ -72,6 +72,8 @@ with
     -- information_schema.columns は view / matview の列も含む。compare.mjs 側で
     -- 「既存テーブルへのカラム追加」判定をする時に view 由来を除外できるよう、
     -- pg_class から relkind を join して kind ('table' / 'view' / 'matview') を付与する。
+    -- comment は migration safety marker (`@migration-safe-not-null` 等) を compare.mjs
+    -- が読み取れるように含める。COMMENT ON COLUMN で付与した文字列が入る。
     select coalesce(json_agg(c order by c->>'schema', c->>'table', (c->>'ordinal')::int), '[]'::json) as data
     from (
       select json_build_object(
@@ -87,7 +89,8 @@ with
         'udt', col.udt_name,
         'nullable', col.is_nullable,
         'default', col.column_default,
-        'ordinal', col.ordinal_position
+        'ordinal', col.ordinal_position,
+        'comment', col_description(cls.oid, col.ordinal_position::int)
       ) as c
       from information_schema.columns col
       join pg_namespace ns on ns.nspname = col.table_schema

--- a/src/entities/action-log/logger.test.ts
+++ b/src/entities/action-log/logger.test.ts
@@ -66,7 +66,7 @@ describe("log()", () => {
     ).toThrow(/unknown action_type/i);
   });
 
-  test("Supabase action_logs に user_id / action_type / metadata を insert する", async () => {
+  test("Supabase action_logs に user_id / action_type / metadata / actor_type を insert する", async () => {
     log(ACTION_TYPES.TASK_REORDERED, {
       task_id: "t1",
       from_position: 0,
@@ -79,6 +79,7 @@ describe("log()", () => {
       action_type: "task_reordered",
       task_id: "t1",
       metadata: { task_id: "t1", from_position: 0, to_position: 2 },
+      actor_type: "user",
     });
   });
 
@@ -88,13 +89,32 @@ describe("log()", () => {
   // task_deleted は metadata.task_id を一次の真実として残しつつ column は
   // null で書く。
   test("task_deleted は column.task_id を null にして insert する (FK 違反回避)", async () => {
-    log(ACTION_TYPES.TASK_DELETED, { task_id: "deleted-task" });
+    log(ACTION_TYPES.TASK_DELETED, {
+      task_id: "deleted-task",
+      snapshot: {
+        title: "old title",
+        estimated_minutes: 30,
+        task_category: "coding",
+        status: "idle",
+        parent_task_id: null,
+      },
+    });
     await flushMicrotasks();
     expect(insertMock).toHaveBeenCalledWith({
       user_id: "user-1",
       action_type: "task_deleted",
       task_id: null,
-      metadata: { task_id: "deleted-task" },
+      metadata: {
+        task_id: "deleted-task",
+        snapshot: {
+          title: "old title",
+          estimated_minutes: 30,
+          task_category: "coding",
+          status: "idle",
+          parent_task_id: null,
+        },
+      },
+      actor_type: "user",
     });
   });
 
@@ -130,7 +150,16 @@ describe("getLog()", () => {
     const snapshot = getLog();
     snapshot.push({
       action_type: "task_deleted",
-      metadata: { task_id: "fake" },
+      metadata: {
+        task_id: "fake",
+        snapshot: {
+          title: "fake",
+          estimated_minutes: null,
+          task_category: null,
+          status: "idle",
+          parent_task_id: null,
+        },
+      },
       created_at: "fake",
     });
     expect(getLog()).toHaveLength(1);
@@ -156,7 +185,7 @@ describe("clearLog()", () => {
 });
 
 describe("ACTION_TYPES", () => {
-  test("Phase 1 / Phase 2 / Phase 3 の action_type をすべて含む", () => {
+  test("Phase 1 / Phase 2 / Phase 3 / calendar 拡張の action_type をすべて含む", () => {
     expect(ACTION_TYPES).toEqual({
       TASK_STARTED: "task_started",
       TASK_PAUSED: "task_paused",
@@ -178,6 +207,19 @@ describe("ACTION_TYPES", () => {
       TASK_DECOMPOSE_SKIPPED: "task_decompose_skipped",
       TASK_CHILD_RESPLIT: "task_child_resplit",
       DECOMPOSITION_MODIFIED: "decomposition_modified",
+      CALENDAR_SUBSCRIBED: "calendar_subscribed",
+      CALENDAR_UNSUBSCRIBED: "calendar_unsubscribed",
+      CALENDAR_AUTO_PROMOTE_CHANGED: "calendar_auto_promote_changed",
+      EVENT_PROMOTED: "event_promoted",
+      EVENT_DEMOTED: "event_demoted",
+      EVENT_OVERRIDE_CLEARED: "event_override_cleared",
+      EXTERNAL_ACCOUNT_ADDED: "external_account_added",
+      EXTERNAL_ACCOUNT_REMOVED: "external_account_removed",
+      EVENT_VISIBILITY_FROZEN_BY_SUBSCRIPTION_TOGGLE:
+        "event_visibility_frozen_by_subscription_toggle",
+      EVENT_DELETED_BY_SOURCE: "event_deleted_by_source",
+      TASK_EVENT_DEPENDENCY_LOST: "task_event_dependency_lost",
+      EXTERNAL_ACCOUNT_REAUTH_REQUIRED: "external_account_reauth_required",
     });
   });
 });
@@ -212,6 +254,7 @@ describe("log(task_decomposed)", () => {
         child_ids: ["child-a", "child-b"],
         raw_response: '[{"title":"a"},{"title":"b"}]',
       },
+      actor_type: "user",
     });
   });
 });
@@ -249,6 +292,7 @@ describe("log(task_decompose_failed)", () => {
         reason: "ai_response_unparseable",
         raw_response: "I cannot decompose this",
       },
+      actor_type: "user",
     });
   });
 
@@ -268,6 +312,7 @@ describe("log(task_decompose_failed)", () => {
         reason: "quota_exhausted",
         error_message: "RESOURCE_EXHAUSTED",
       },
+      actor_type: "user",
     });
   });
 });
@@ -297,6 +342,7 @@ describe("log(task_decompose_skipped)", () => {
       action_type: "task_decompose_skipped",
       task_id: "parent-1",
       metadata: { task_id: "parent-1", raw_response: "[]" },
+      actor_type: "user",
     });
   });
 });
@@ -352,6 +398,7 @@ describe("log(task_child_resplit)", () => {
         new_child_ids: ["new-child-1", "new-child-2", "new-child-3"],
         raw_response: '[{"title":"導入部の構成"},{"title":"本文を書く"},{"title":"最終確認"}]',
       },
+      actor_type: "user",
     });
   });
 });
@@ -384,6 +431,7 @@ describe("log(decomposition_modified)", () => {
       action_type: "decomposition_modified",
       task_id: null,
       metadata: { task_id: "child-a", parent_id: "parent-1", kind: "child_deleted" },
+      actor_type: "user",
     });
   });
 });
@@ -414,6 +462,7 @@ describe("log(task_category_changed)", () => {
       action_type: "task_category_changed",
       task_id: "t1",
       metadata: { task_id: "t1", from: null, to: "coding" },
+      actor_type: "user",
     });
   });
 
@@ -429,6 +478,7 @@ describe("log(task_category_changed)", () => {
       action_type: "task_category_changed",
       task_id: "t1",
       metadata: { task_id: "t1", from: "doc", to: "research" },
+      actor_type: "user",
     });
   });
 });
@@ -459,6 +509,7 @@ describe("log(calendar_synced)", () => {
       action_type: "calendar_synced",
       task_id: null,
       metadata: { synced: 5, deleted: 1, trigger: "manual" },
+      actor_type: "user",
     });
   });
 });

--- a/src/entities/action-log/logger.ts
+++ b/src/entities/action-log/logger.ts
@@ -1,7 +1,7 @@
 import { createClient } from "@/shared/supabase/client";
 import type { Json } from "@/shared/types/database";
 
-import type { ActionLogEntry, ActionMetadataMap, ActionType } from "./types";
+import type { ActionLogEntry, ActionMetadataMap, ActionType, ActorType } from "./types";
 
 /**
  * action-log logger
@@ -37,6 +37,20 @@ export const ACTION_TYPES = Object.freeze({
   TASK_DECOMPOSE_SKIPPED: "task_decompose_skipped",
   TASK_CHILD_RESPLIT: "task_child_resplit",
   DECOMPOSITION_MODIFIED: "decomposition_modified",
+  // ADR 0034 / 0035: calendar / event 関連 type。
+  // 値は ADR 0035 §4 で確定済みだが、発火実装は #144 / #145 / #146 のスコープ。
+  CALENDAR_SUBSCRIBED: "calendar_subscribed",
+  CALENDAR_UNSUBSCRIBED: "calendar_unsubscribed",
+  CALENDAR_AUTO_PROMOTE_CHANGED: "calendar_auto_promote_changed",
+  EVENT_PROMOTED: "event_promoted",
+  EVENT_DEMOTED: "event_demoted",
+  EVENT_OVERRIDE_CLEARED: "event_override_cleared",
+  EXTERNAL_ACCOUNT_ADDED: "external_account_added",
+  EXTERNAL_ACCOUNT_REMOVED: "external_account_removed",
+  EVENT_VISIBILITY_FROZEN_BY_SUBSCRIPTION_TOGGLE: "event_visibility_frozen_by_subscription_toggle",
+  EVENT_DELETED_BY_SOURCE: "event_deleted_by_source",
+  TASK_EVENT_DEPENDENCY_LOST: "task_event_dependency_lost",
+  EXTERNAL_ACCOUNT_REAUTH_REQUIRED: "external_account_reauth_required",
 }) satisfies Readonly<Record<string, ActionType>>;
 
 const KNOWN_TYPES = new Set<ActionType>(Object.values(ACTION_TYPES));
@@ -84,7 +98,10 @@ function extractTaskId(actionType: ActionType, metadata: Record<string, unknown>
   return typeof v === "string" ? v : null;
 }
 
-async function persist<T extends ActionType>(entry: ActionLogEntry<T>): Promise<void> {
+async function persist<T extends ActionType>(
+  entry: ActionLogEntry<T>,
+  actorType: ActorType,
+): Promise<void> {
   const supabase = getClient();
   if (!supabase) return;
 
@@ -101,6 +118,7 @@ async function persist<T extends ActionType>(entry: ActionLogEntry<T>): Promise<
     action_type: entry.action_type,
     task_id: extractTaskId(entry.action_type, entry.metadata as unknown as Record<string, unknown>),
     metadata: entry.metadata as unknown as Json,
+    actor_type: actorType,
   });
   if (error) {
     console.error("[action-log] insert failed", error);
@@ -110,6 +128,7 @@ async function persist<T extends ActionType>(entry: ActionLogEntry<T>): Promise<
 export function log<T extends ActionType>(
   actionType: T,
   metadata?: ActionMetadataMap[T],
+  actorType: ActorType = "user",
 ): ActionLogEntry<T> {
   if (!KNOWN_TYPES.has(actionType)) {
     throw new Error(`unknown action_type: ${actionType}`);
@@ -122,8 +141,8 @@ export function log<T extends ActionType>(
   memoryLog.push(entry);
   console.log("[action-log]", actionType, entry.metadata);
 
-  // fire-and-forget: ここで await しないのが肝
-  void persist(entry).catch((err) => {
+  // fire-and-forget: ここで await しないのが肝 (ADR 0035: actor_type は明示渡し、default 'user')
+  void persist(entry, actorType).catch((err) => {
     console.error("[action-log] persist error", err);
   });
 

--- a/src/entities/action-log/server.ts
+++ b/src/entities/action-log/server.ts
@@ -2,7 +2,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 
 import type { Database, Json } from "@/shared/types/database";
 
-import type { ActionMetadataMap, ActionType } from "./types";
+import type { ActionMetadataMap, ActionType, ActorType } from "./types";
 
 /**
  * Server 側 (Route Handler 内) からの action_logs 書き込み helper。
@@ -16,6 +16,8 @@ import type { ActionMetadataMap, ActionType } from "./types";
  * - INSERT 失敗は `console.error` に留め、呼び出し元のロジックは止めない (ADR 0001)
  * - `task_deleted` / `decomposition_modified` は FK 違反を避けるため column の task_id を
  *   null にする。metadata.task_id は一次の真実として残す
+ * - `actor_type` (ADR 0035) は明示渡しに変更。default 'user' は手動連打安全のため残すが、
+ *   system actor の type を発火する箇所では必ず 'system' を渡す
  */
 
 function extractTaskId(actionType: ActionType, metadata: Record<string, unknown>): string | null {
@@ -31,12 +33,14 @@ export async function logServerSide<T extends ActionType>(
   userId: string,
   actionType: T,
   metadata: ActionMetadataMap[T],
+  actorType: ActorType = "user",
 ): Promise<void> {
   const { error } = await supabase.from("action_logs").insert({
     user_id: userId,
     action_type: actionType,
     task_id: extractTaskId(actionType, metadata as unknown as Record<string, unknown>),
     metadata: metadata as unknown as Json,
+    actor_type: actorType,
   });
   if (error) {
     console.error("[action-log/server] insert failed", error);

--- a/src/entities/action-log/types.ts
+++ b/src/entities/action-log/types.ts
@@ -18,7 +18,29 @@ export type ActionType =
   | "task_decompose_failed"
   | "task_decompose_skipped"
   | "task_child_resplit"
-  | "decomposition_modified";
+  | "decomposition_modified"
+  // ADR 0034 / 0035: calendar / event 関連 type (発火実装は #144 / #145 / #146)。
+  // user actor:
+  | "calendar_subscribed"
+  | "calendar_unsubscribed"
+  | "calendar_auto_promote_changed"
+  | "event_promoted"
+  | "event_demoted"
+  | "event_override_cleared"
+  | "external_account_added"
+  | "external_account_removed"
+  // system actor:
+  | "event_visibility_frozen_by_subscription_toggle"
+  | "event_deleted_by_source"
+  | "task_event_dependency_lost"
+  | "external_account_reauth_required";
+
+/**
+ * action_logs.actor_type の値域 (ADR 0035)。
+ * DB は CHECK 制約を貼らない (ADR 0001) ので、型側で固定する。
+ * 値追加 (将来 'ai' 等) は ADR 0035 の supersede ではなく追加判断として扱える。
+ */
+export type ActorType = "user" | "system";
 
 /**
  * AI 分解の失敗種別 (ADR 0021)。詳細パネル (P3-15) で reason ごとに recovery 文言を出すため
@@ -70,7 +92,19 @@ export type ActionMetadataMap = {
     from_position: number;
     to_position: number;
   };
-  task_deleted: { task_id: string };
+  // ADR 0035 §5: 削除系は元 entity が物理削除されるため snapshot を必須化する。
+  // 過去ログ (snapshot 列が無かった頃) は backfill しない (ADR 0035 §6)。
+  // Phase 4 の回避パターン分析: 「どんな未着手タスクが削除されたか」を再構成可能にする。
+  task_deleted: {
+    task_id: string;
+    snapshot: {
+      title: string;
+      estimated_minutes: number | null;
+      task_category: string | null;
+      status: "idle" | "active" | "paused" | "done";
+      parent_task_id: string | null;
+    };
+  };
   task_title_changed: {
     task_id: string;
     old_title: string;
@@ -155,6 +189,125 @@ export type ActionMetadataMap = {
     task_id: string;
     parent_id: string;
     kind: DecompositionModifiedKind;
+  };
+
+  // ===== ADR 0035 §4: calendar / event 関連 type (発火実装は #144 / #145 / #146) =====
+  //
+  // 全てに共通の triple `(source, external_calendar_id, external_id)` を必須含める (ADR 0033)。
+  // 削除系は snapshot 必須 (ADR 0035 §2 ii)。
+  // event_promoted / event_demoted は `is_override_of_default` を Phase 4 学習素材として持つ。
+
+  calendar_subscribed: {
+    source: string;
+    external_account_id: string;
+    external_calendar_id: string;
+    auto_promote_to_timeline: boolean;
+  };
+  calendar_unsubscribed: {
+    source: string;
+    external_account_id: string;
+    external_calendar_id: string;
+    deleted_events: Array<{
+      external_id: string;
+      title: string;
+      start_time: string;
+      end_time: string;
+      visibility_override: "none" | "shown" | "hidden";
+    }>;
+  };
+  calendar_auto_promote_changed: {
+    source: string;
+    external_account_id: string;
+    external_calendar_id: string;
+    from: boolean;
+    to: boolean;
+  };
+  event_promoted: {
+    source: string;
+    external_account_id: string;
+    external_calendar_id: string;
+    external_id: string;
+    from: "none" | "shown" | "hidden";
+    to: "shown";
+    subscription_auto_promote: boolean;
+    is_override_of_default: boolean;
+  };
+  event_demoted: {
+    source: string;
+    external_account_id: string;
+    external_calendar_id: string;
+    external_id: string;
+    from: "none" | "shown" | "hidden";
+    to: "hidden";
+    subscription_auto_promote: boolean;
+    is_override_of_default: boolean;
+  };
+  event_override_cleared: {
+    source: string;
+    external_account_id: string;
+    external_calendar_id: string;
+    external_id: string;
+    from: "shown" | "hidden";
+    subscription_auto_promote: boolean;
+  };
+  external_account_added: {
+    source: string;
+    external_account_id: string;
+    display_name: string | null;
+  };
+  external_account_removed: {
+    source: string;
+    external_account_id: string;
+    display_name: string | null;
+    cascaded_unsubscribes: Array<{
+      external_calendar_id: string;
+      deleted_events: Array<{
+        external_id: string;
+        title: string;
+        start_time: string;
+        end_time: string;
+        visibility_override: "none" | "shown" | "hidden";
+      }>;
+    }>;
+  };
+  // system actor types
+  event_visibility_frozen_by_subscription_toggle: {
+    source: string;
+    external_account_id: string;
+    external_calendar_id: string;
+    external_id: string;
+    frozen_to: "shown" | "hidden";
+    triggered_by: string;
+  };
+  event_deleted_by_source: {
+    source: string;
+    external_account_id: string;
+    external_calendar_id: string;
+    external_id: string;
+    snapshot: {
+      title: string;
+      start_time: string;
+      end_time: string;
+      visibility_override: "none" | "shown" | "hidden";
+    };
+  };
+  task_event_dependency_lost: {
+    task_id: string;
+    source: string;
+    external_account_id: string;
+    external_calendar_id: string;
+    external_id: string;
+    deletion_reason: "deleted_by_source" | "unsubscribed";
+    event_snapshot: {
+      title: string;
+      start_time: string;
+      end_time: string;
+    };
+  };
+  external_account_reauth_required: {
+    source: string;
+    external_account_id: string;
+    error_kind: string;
   };
 };
 

--- a/src/entities/calendar-sync/gateway.ts
+++ b/src/entities/calendar-sync/gateway.ts
@@ -1,3 +1,5 @@
+import type { EventSource } from "@/entities/event/types";
+
 /**
  * Google Calendar 同期状態 (最終同期時刻 + syncToken) の永続化 Gateway。
  *
@@ -10,13 +12,27 @@ export type CalendarSyncState = {
   syncToken: string | null;
 };
 
+/**
+ * 複合キー (ADR 0031/0033)。calendar 単位で sync_token / lastSyncedAt を独立に管理する。
+ * Phase 2 までは primary 固定で動いていたため事実上 (google_calendar, primary, 'primary') のみだが、
+ * Issue #144 / #146 で複数 calendar / 複数 account に拡張される。
+ */
+export type CalendarSyncStateKey = {
+  source: EventSource;
+  externalAccountId: string;
+  externalCalendarId: string;
+};
+
 export interface CalendarSyncStateGateway {
-  /** 現在ユーザーの同期状態を取得。未同期なら null。 */
-  get(): Promise<CalendarSyncState | null>;
+  /** 指定された (source, externalAccountId, externalCalendarId) の同期状態。未同期なら null。 */
+  get(key: CalendarSyncStateKey): Promise<CalendarSyncState | null>;
   /**
    * 同期成功時に最終同期時刻と syncToken を atomic に upsert する。
    * `syncToken: null` を渡すと DB の `sync_token` も `null` に上書きされ、次回は full sync になる
    * (410 Gone fallback で nextSyncToken が得られなかったケース等)。
    */
-  saveSyncState(input: { lastSyncedAt: string; syncToken: string | null }): Promise<void>;
+  saveSyncState(
+    key: CalendarSyncStateKey,
+    input: { lastSyncedAt: string; syncToken: string | null },
+  ): Promise<void>;
 }

--- a/src/entities/calendar-sync/supabase-gateway.test.ts
+++ b/src/entities/calendar-sync/supabase-gateway.test.ts
@@ -3,9 +3,16 @@ import { describe, expect, test, vi } from "vitest";
 
 import type { Database } from "@/shared/types/database";
 
+import type { CalendarSyncStateKey } from "./gateway";
 import { SupabaseCalendarSyncStateGateway } from "./supabase-gateway";
 
 type Sb = SupabaseClient<Database>;
+
+const KEY: CalendarSyncStateKey = {
+  source: "google_calendar",
+  externalAccountId: "ext-acc-1",
+  externalCalendarId: "primary",
+};
 
 function makeSupabase(overrides: {
   getUserId?: string | null;
@@ -22,8 +29,12 @@ function makeSupabase(overrides: {
 }) {
   const userId = overrides.getUserId === undefined ? "user-1" : overrides.getUserId;
   const maybeSingle = vi.fn(async () => overrides.selectResult ?? { data: null, error: null });
-  const eqSelect = vi.fn(() => ({ maybeSingle }));
-  const select = vi.fn(() => ({ eq: eqSelect }));
+  // 4 段の eq().eq().eq().eq().maybeSingle() を chain で組み立てる
+  const eq4 = vi.fn(() => ({ maybeSingle }));
+  const eq3 = vi.fn(() => ({ eq: eq4 }));
+  const eq2 = vi.fn(() => ({ eq: eq3 }));
+  const eq1 = vi.fn(() => ({ eq: eq2 }));
+  const select = vi.fn(() => ({ eq: eq1 }));
   const upsert = vi.fn<
     (
       payload: Record<string, unknown>,
@@ -40,12 +51,12 @@ function makeSupabase(overrides: {
     },
     from,
   } as unknown as Sb;
-  return { supabase, from, select, eqSelect, maybeSingle, upsert };
+  return { supabase, from, select, eq1, eq2, eq3, eq4, maybeSingle, upsert };
 }
 
 describe("SupabaseCalendarSyncStateGateway.get", () => {
   test("行があれば CalendarSyncState を返す (sync_token も含めて)", async () => {
-    const { supabase, from, select, eqSelect } = makeSupabase({
+    const { supabase, from, select, eq1, eq2, eq3, eq4 } = makeSupabase({
       selectResult: {
         data: {
           user_id: "user-1",
@@ -58,7 +69,7 @@ describe("SupabaseCalendarSyncStateGateway.get", () => {
     });
 
     const gw = new SupabaseCalendarSyncStateGateway(supabase);
-    const state = await gw.get();
+    const state = await gw.get(KEY);
 
     expect(state).toEqual({
       lastSyncedAt: "2026-04-24T10:00:00.000Z",
@@ -66,7 +77,11 @@ describe("SupabaseCalendarSyncStateGateway.get", () => {
     });
     expect(from).toHaveBeenCalledWith("user_calendar_sync_state");
     expect(select).toHaveBeenCalledWith("user_id, last_synced_at, sync_token, updated_at");
-    expect(eqSelect).toHaveBeenCalledWith("user_id", "user-1");
+    // 複合キー (user_id, source, external_account_id, external_calendar_id) で絞る
+    expect(eq1).toHaveBeenCalledWith("user_id", "user-1");
+    expect(eq2).toHaveBeenCalledWith("source", "google_calendar");
+    expect(eq3).toHaveBeenCalledWith("external_account_id", "ext-acc-1");
+    expect(eq4).toHaveBeenCalledWith("external_calendar_id", "primary");
   });
 
   test("sync_token が null でもそのまま返す (初回 / 410 fallback 直後)", async () => {
@@ -83,7 +98,7 @@ describe("SupabaseCalendarSyncStateGateway.get", () => {
     });
 
     const gw = new SupabaseCalendarSyncStateGateway(supabase);
-    const state = await gw.get();
+    const state = await gw.get(KEY);
 
     expect(state).toEqual({
       lastSyncedAt: "2026-04-24T10:00:00.000Z",
@@ -97,7 +112,7 @@ describe("SupabaseCalendarSyncStateGateway.get", () => {
     });
 
     const gw = new SupabaseCalendarSyncStateGateway(supabase);
-    const state = await gw.get();
+    const state = await gw.get(KEY);
 
     expect(state).toBeNull();
   });
@@ -106,7 +121,7 @@ describe("SupabaseCalendarSyncStateGateway.get", () => {
     const { supabase, from } = makeSupabase({ getUserId: null });
     const gw = new SupabaseCalendarSyncStateGateway(supabase);
 
-    const state = await gw.get();
+    const state = await gw.get(KEY);
 
     expect(state).toBeNull();
     expect(from).not.toHaveBeenCalled();
@@ -121,16 +136,16 @@ describe("SupabaseCalendarSyncStateGateway.get", () => {
     });
     const gw = new SupabaseCalendarSyncStateGateway(supabase);
 
-    await expect(gw.get()).rejects.toMatchObject({ message: "db down" });
+    await expect(gw.get(KEY)).rejects.toMatchObject({ message: "db down" });
   });
 });
 
 describe("SupabaseCalendarSyncStateGateway.saveSyncState", () => {
-  test("user_id + last_synced_at + sync_token を on conflict user_id で upsert する", async () => {
+  test("複合キー + last_synced_at + sync_token を on conflict 4 列キーで upsert する", async () => {
     const { supabase, from, upsert } = makeSupabase({});
     const gw = new SupabaseCalendarSyncStateGateway(supabase);
 
-    await gw.saveSyncState({
+    await gw.saveSyncState(KEY, {
       lastSyncedAt: "2026-04-24T10:00:00.000Z",
       syncToken: "tok-xyz",
     });
@@ -140,17 +155,22 @@ describe("SupabaseCalendarSyncStateGateway.saveSyncState", () => {
     const [payload, options] = upsert.mock.calls[0]!;
     expect(payload).toEqual({
       user_id: "user-1",
+      source: "google_calendar",
+      external_account_id: "ext-acc-1",
+      external_calendar_id: "primary",
       last_synced_at: "2026-04-24T10:00:00.000Z",
       sync_token: "tok-xyz",
     });
-    expect(options).toEqual({ onConflict: "user_id" });
+    expect(options).toEqual({
+      onConflict: "user_id,source,external_account_id,external_calendar_id",
+    });
   });
 
   test("syncToken: null を渡すと sync_token も null で上書きされる (410 fallback で nextSyncToken が無いケース)", async () => {
     const { supabase, upsert } = makeSupabase({});
     const gw = new SupabaseCalendarSyncStateGateway(supabase);
 
-    await gw.saveSyncState({
+    await gw.saveSyncState(KEY, {
       lastSyncedAt: "2026-04-24T10:00:00.000Z",
       syncToken: null,
     });
@@ -158,6 +178,9 @@ describe("SupabaseCalendarSyncStateGateway.saveSyncState", () => {
     const [payload] = upsert.mock.calls[0]!;
     expect(payload).toEqual({
       user_id: "user-1",
+      source: "google_calendar",
+      external_account_id: "ext-acc-1",
+      external_calendar_id: "primary",
       last_synced_at: "2026-04-24T10:00:00.000Z",
       sync_token: null,
     });
@@ -168,7 +191,7 @@ describe("SupabaseCalendarSyncStateGateway.saveSyncState", () => {
     const gw = new SupabaseCalendarSyncStateGateway(supabase);
 
     await expect(
-      gw.saveSyncState({
+      gw.saveSyncState(KEY, {
         lastSyncedAt: "2026-04-24T10:00:00.000Z",
         syncToken: null,
       }),
@@ -182,7 +205,7 @@ describe("SupabaseCalendarSyncStateGateway.saveSyncState", () => {
     const gw = new SupabaseCalendarSyncStateGateway(supabase);
 
     await expect(
-      gw.saveSyncState({
+      gw.saveSyncState(KEY, {
         lastSyncedAt: "2026-04-24T10:00:00.000Z",
         syncToken: "t",
       }),

--- a/src/entities/calendar-sync/supabase-gateway.ts
+++ b/src/entities/calendar-sync/supabase-gateway.ts
@@ -2,14 +2,14 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 
 import type { Database, TablesInsert } from "@/shared/types/database";
 
-import type { CalendarSyncState, CalendarSyncStateGateway } from "./gateway";
+import type { CalendarSyncState, CalendarSyncStateGateway, CalendarSyncStateKey } from "./gateway";
 
 type Sb = SupabaseClient<Database>;
 
 export class SupabaseCalendarSyncStateGateway implements CalendarSyncStateGateway {
   constructor(private readonly supabase: Sb) {}
 
-  async get(): Promise<CalendarSyncState | null> {
+  async get(key: CalendarSyncStateKey): Promise<CalendarSyncState | null> {
     const {
       data: { user },
     } = await this.supabase.auth.getUser();
@@ -19,6 +19,9 @@ export class SupabaseCalendarSyncStateGateway implements CalendarSyncStateGatewa
       .from("user_calendar_sync_state")
       .select("user_id, last_synced_at, sync_token, updated_at")
       .eq("user_id", user.id)
+      .eq("source", key.source)
+      .eq("external_account_id", key.externalAccountId)
+      .eq("external_calendar_id", key.externalCalendarId)
       .maybeSingle();
     if (error) throw error;
     if (!data) return null;
@@ -28,7 +31,10 @@ export class SupabaseCalendarSyncStateGateway implements CalendarSyncStateGatewa
     };
   }
 
-  async saveSyncState(input: { lastSyncedAt: string; syncToken: string | null }): Promise<void> {
+  async saveSyncState(
+    key: CalendarSyncStateKey,
+    input: { lastSyncedAt: string; syncToken: string | null },
+  ): Promise<void> {
     const {
       data: { user },
     } = await this.supabase.auth.getUser();
@@ -36,12 +42,16 @@ export class SupabaseCalendarSyncStateGateway implements CalendarSyncStateGatewa
 
     const payload: TablesInsert<"user_calendar_sync_state"> = {
       user_id: user.id,
+      source: key.source,
+      external_account_id: key.externalAccountId,
+      external_calendar_id: key.externalCalendarId,
       last_synced_at: input.lastSyncedAt,
       sync_token: input.syncToken,
     };
-    const { error } = await this.supabase
-      .from("user_calendar_sync_state")
-      .upsert(payload, { onConflict: "user_id" });
+    // ADR 0031/0033: 複合 PK `(user_id, source, external_account_id, external_calendar_id)`
+    const { error } = await this.supabase.from("user_calendar_sync_state").upsert(payload, {
+      onConflict: "user_id,source,external_account_id,external_calendar_id",
+    });
     if (error) throw error;
   }
 }

--- a/src/entities/event/gateway.ts
+++ b/src/entities/event/gateway.ts
@@ -25,8 +25,11 @@ export type UpdateEventInput = {
 /**
  * Google Calendar から取り込む 1 イベント分の入力。
  * `project_id` は kozutsumi 側で設定する拡張 (ADR 0010) なので、upsert payload には含めず既存値を保持する。
+ * `externalCalendarId` (ADR 0033) は subscription を介して呼び出し元が決める (現状は 'primary' 固定)。
+ * `visibility_override` も同期で再 upsert されても触らない (ADR 0034 L4)。
  */
 export type UpsertGoogleCalendarEventInput = {
+  externalCalendarId: string;
   externalId: string;
   title: string;
   startTime: string;
@@ -43,13 +46,15 @@ export interface EventGateway {
   delete(id: string): Promise<void>;
   deleteAllForCurrentUser(): Promise<void>;
   /**
-   * `(source='google_calendar', external_id)` 単位で upsert。既存行の `project_id` は保持する。
+   * `(source='google_calendar', external_calendar_id, external_id)` 単位で upsert (ADR 0033)。
+   * 既存行の `project_id` / `visibility_override` は保持する (ADR 0010 / 0034 L4)。
    * @returns upsert された行数
    */
   upsertFromGoogleCalendar(inputs: UpsertGoogleCalendarEventInput[]): Promise<number>;
   /**
    * Google 側で `status='cancelled'` になったイベントをローカルから削除する。
+   * 同じ external_id が他 calendar にも存在しうる (ADR 0033) ので、calendar 単位で絞る。
    * @returns 削除された行数
    */
-  deleteByGoogleExternalIds(externalIds: string[]): Promise<number>;
+  deleteByGoogleExternalIds(externalCalendarId: string, externalIds: string[]): Promise<number>;
 }

--- a/src/entities/event/supabase-gateway.test.ts
+++ b/src/entities/event/supabase-gateway.test.ts
@@ -22,6 +22,8 @@ function makeRow(overrides: Partial<EventRow> = {}): EventRow {
     description: "",
     source: "manual",
     external_id: null,
+    external_calendar_id: "manual",
+    visibility_override: "none",
     created_at: "2026-04-23T00:00:00.000Z",
     ...overrides,
   };

--- a/src/entities/event/supabase-gateway.ts
+++ b/src/entities/event/supabase-gateway.ts
@@ -12,6 +12,9 @@ import { EVENT_SOURCE, type Event } from "./types";
 
 type Sb = SupabaseClient<Database>;
 
+/** manual event の external_calendar_id 固定値 (ADR 0033 backfill 規約と一致)。 */
+const MANUAL_EXTERNAL_CALENDAR_ID = "manual";
+
 function fromRow(row: Tables<"events">): Event {
   return {
     id: row.id,
@@ -24,6 +27,8 @@ function fromRow(row: Tables<"events">): Event {
     description: row.description,
     source: row.source,
     externalId: row.external_id,
+    externalCalendarId: row.external_calendar_id,
+    visibilityOverride: row.visibility_override,
     createdAt: row.created_at,
   };
 }
@@ -50,6 +55,7 @@ export class SupabaseEventGateway implements EventGateway {
 
   async create(input: CreateEventInput): Promise<Event> {
     const user_id = await getUserId(this.supabase);
+    // ADR 0033: source-agnostic な triple uniqueness。manual event は固定値で埋める。
     const payload: TablesInsert<"events"> = {
       user_id,
       title: input.title,
@@ -61,6 +67,7 @@ export class SupabaseEventGateway implements EventGateway {
       description: input.description ?? "",
       source: input.source ?? EVENT_SOURCE.MANUAL,
       external_id: input.externalId ?? null,
+      external_calendar_id: MANUAL_EXTERNAL_CALENDAR_ID,
     };
     const { data, error } = await this.supabase.from("events").insert(payload).select("*").single();
     if (error) throw error;
@@ -136,8 +143,8 @@ export class SupabaseEventGateway implements EventGateway {
   async upsertFromGoogleCalendar(inputs: UpsertGoogleCalendarEventInput[]): Promise<number> {
     if (inputs.length === 0) return 0;
     const user_id = await getUserId(this.supabase);
-    // project_id を payload に含めないことで、ON CONFLICT DO UPDATE SET ... から除外され、
-    // 既存行の project_id は保持される (kozutsumi 側の拡張、ADR 0010)
+    // project_id / visibility_override を payload に含めないことで、ON CONFLICT DO UPDATE SET ... から
+    // 除外され、既存行の値が保持される (kozutsumi 側の拡張、ADR 0010 / ADR 0034 L4)
     const payloads: TablesInsert<"events">[] = inputs.map((input) => ({
       user_id,
       title: input.title,
@@ -148,16 +155,21 @@ export class SupabaseEventGateway implements EventGateway {
       description: input.description,
       source: EVENT_SOURCE.GOOGLE_CALENDAR,
       external_id: input.externalId,
+      external_calendar_id: input.externalCalendarId,
     }));
+    // ADR 0033: triple uniqueness `(source, external_calendar_id, external_id)`
     const { error } = await this.supabase
       .from("events")
-      .upsert(payloads, { onConflict: "source,external_id" });
+      .upsert(payloads, { onConflict: "source,external_calendar_id,external_id" });
     if (error) throw error;
     // upsert は全 input に対して insert または update を実行するため、affected = inputs.length
     return inputs.length;
   }
 
-  async deleteByGoogleExternalIds(externalIds: string[]): Promise<number> {
+  async deleteByGoogleExternalIds(
+    externalCalendarId: string,
+    externalIds: string[],
+  ): Promise<number> {
     if (externalIds.length === 0) return 0;
     const uid = await getUserId(this.supabase);
     // count のみ欲しいので head: true で row を返させない
@@ -166,6 +178,7 @@ export class SupabaseEventGateway implements EventGateway {
       .delete({ count: "exact" })
       .eq("user_id", uid)
       .eq("source", EVENT_SOURCE.GOOGLE_CALENDAR)
+      .eq("external_calendar_id", externalCalendarId)
       .in("external_id", externalIds);
     if (error) throw error;
     return count ?? 0;

--- a/src/entities/event/sync.test.ts
+++ b/src/entities/event/sync.test.ts
@@ -92,17 +92,21 @@ describe("extractMeetUrl", () => {
 
 describe("mapGoogleEventToUpsertInput", () => {
   test("必要フィールドをすべてマップする", () => {
-    const result = mapGoogleEventToUpsertInput({
-      id: "evt-1",
-      summary: "1on1",
-      description: "議題: 進捗",
-      start: { dateTime: "2026-04-23T10:00:00+09:00" },
-      end: { dateTime: "2026-04-23T11:00:00+09:00" },
-      hangoutLink: "https://meet.google.com/xyz",
-      attachments: [{ fileUrl: "https://drive.example/abc" }],
-    });
+    const result = mapGoogleEventToUpsertInput(
+      {
+        id: "evt-1",
+        summary: "1on1",
+        description: "議題: 進捗",
+        start: { dateTime: "2026-04-23T10:00:00+09:00" },
+        end: { dateTime: "2026-04-23T11:00:00+09:00" },
+        hangoutLink: "https://meet.google.com/xyz",
+        attachments: [{ fileUrl: "https://drive.example/abc" }],
+      },
+      "primary",
+    );
 
     expect(result).toEqual<UpsertGoogleCalendarEventInput>({
+      externalCalendarId: "primary",
       externalId: "evt-1",
       title: "1on1",
       startTime: "2026-04-23T01:00:00.000Z",
@@ -114,13 +118,17 @@ describe("mapGoogleEventToUpsertInput", () => {
   });
 
   test("summary が無い場合はデフォルトタイトル、description / meet_url が無ければ空 / null", () => {
-    const result = mapGoogleEventToUpsertInput({
-      id: "evt-2",
-      start: { dateTime: "2026-04-23T10:00:00Z" },
-      end: { dateTime: "2026-04-23T11:00:00Z" },
-    });
+    const result = mapGoogleEventToUpsertInput(
+      {
+        id: "evt-2",
+        start: { dateTime: "2026-04-23T10:00:00Z" },
+        end: { dateTime: "2026-04-23T11:00:00Z" },
+      },
+      "primary",
+    );
 
     expect(result).toEqual<UpsertGoogleCalendarEventInput>({
+      externalCalendarId: "primary",
       externalId: "evt-2",
       title: "(タイトルなし)",
       startTime: "2026-04-23T10:00:00.000Z",
@@ -132,7 +140,7 @@ describe("mapGoogleEventToUpsertInput", () => {
   });
 
   test("時刻が無い壊れたイベントは null を返す", () => {
-    expect(mapGoogleEventToUpsertInput({ id: "bad", start: {}, end: {} })).toBeNull();
+    expect(mapGoogleEventToUpsertInput({ id: "bad", start: {}, end: {} }, "primary")).toBeNull();
   });
 });
 
@@ -157,7 +165,7 @@ describe("partitionEvents", () => {
       { id: "broken", start: {}, end: {} },
     ];
 
-    const result = partitionEvents(events);
+    const result = partitionEvents(events, "primary");
 
     expect(result.cancelled).toEqual(["deleted-1", "deleted-2"]);
     expect(result.upserts.map((u) => u.externalId)).toEqual(["active-1", "active-2"]);
@@ -172,7 +180,7 @@ type ListEventsFn = (params: ListEventsParams) => Promise<GoogleCalendarEventsLi
 
 function makeFakeGateway() {
   const upsertCalls: UpsertGoogleCalendarEventInput[][] = [];
-  const deleteCalls: string[][] = [];
+  const deleteCalls: { externalCalendarId: string; ids: string[] }[] = [];
   const gateway: EventGateway = {
     list: vi.fn(),
     create: vi.fn(),
@@ -183,8 +191,8 @@ function makeFakeGateway() {
       upsertCalls.push(inputs);
       return inputs.length;
     }),
-    deleteByGoogleExternalIds: vi.fn(async (ids) => {
-      deleteCalls.push(ids);
+    deleteByGoogleExternalIds: vi.fn(async (externalCalendarId, ids) => {
+      deleteCalls.push({ externalCalendarId, ids });
       return ids.length;
     }),
   };
@@ -197,11 +205,12 @@ function makeFakeSyncStateGateway(
     syncToken: string | null;
   } | null = null,
 ) {
-  const get = vi.fn<() => Promise<typeof initial>>(async () => initial);
-  const saveSyncState = vi.fn<
-    (input: { lastSyncedAt: string; syncToken: string | null }) => Promise<void>
-  >(async () => {});
-  const gateway: CalendarSyncStateGateway = { get, saveSyncState };
+  const get = vi.fn(async () => initial);
+  const saveSyncState = vi.fn(async () => {});
+  const gateway: CalendarSyncStateGateway = {
+    get: get as unknown as CalendarSyncStateGateway["get"],
+    saveSyncState: saveSyncState as unknown as CalendarSyncStateGateway["saveSyncState"],
+  };
   return { gateway, get, saveSyncState };
 }
 
@@ -240,6 +249,7 @@ function makeDeps(overrides: {
     refreshAccessToken: overrides.refreshAccessToken
       ? vi.fn(overrides.refreshAccessToken)
       : vi.fn(),
+    resolvePrimaryExternalAccountId: vi.fn(async () => "ext-acc-id"),
     now: overrides.now ?? DEFAULT_NOW,
   };
 }
@@ -324,7 +334,10 @@ describe("syncGoogleCalendar (full sync)", () => {
     expect(result.synced).toBe(1);
     expect(result.deleted).toBe(2);
     expect(upsertCalls[0]!.map((e) => e.externalId)).toEqual(["keep"]);
-    expect(deleteCalls[0]).toEqual(["gone-1", "gone-2"]);
+    expect(deleteCalls[0]).toEqual({
+      externalCalendarId: "primary",
+      ids: ["gone-1", "gone-2"],
+    });
   });
 
   test("空結果の時は upsert/delete を呼ばない", async () => {
@@ -432,10 +445,14 @@ describe("syncGoogleCalendar (full sync)", () => {
 
     expect(result.lastSyncedAt).toBe("2026-04-24T01:30:00.000Z");
     expect(saveSyncState).toHaveBeenCalledTimes(1);
-    expect(saveSyncState).toHaveBeenCalledWith({
-      lastSyncedAt: "2026-04-24T01:30:00.000Z",
-      syncToken: "fresh-tok",
-    });
+    expect(saveSyncState).toHaveBeenCalledWith(
+      {
+        source: "google_calendar",
+        externalAccountId: "ext-acc-id",
+        externalCalendarId: "primary",
+      },
+      { lastSyncedAt: "2026-04-24T01:30:00.000Z", syncToken: "fresh-tok" },
+    );
   });
 
   test("nextSyncToken が無いレスポンスは syncToken: null で保存する", async () => {
@@ -445,10 +462,14 @@ describe("syncGoogleCalendar (full sync)", () => {
 
     await syncGoogleCalendar(FAKE_SUPABASE, makeDeps({ gateway, syncStateGateway, listEvents }));
 
-    expect(saveSyncState).toHaveBeenCalledWith({
-      lastSyncedAt: expect.any(String),
-      syncToken: null,
-    });
+    expect(saveSyncState).toHaveBeenCalledWith(
+      {
+        source: "google_calendar",
+        externalAccountId: "ext-acc-id",
+        externalCalendarId: "primary",
+      },
+      { lastSyncedAt: expect.any(String), syncToken: null },
+    );
   });
 
   test("401 retry 後も失敗する場合は sync state を上書きしない (stale syncToken を保持)", async () => {
@@ -513,10 +534,14 @@ describe("syncGoogleCalendar (incremental sync via syncToken)", () => {
     expect(call.timeMax).toBeUndefined();
     expect(call.orderBy).toBeUndefined();
     expect(upsertCalls[0]!.map((e) => e.externalId)).toEqual(["incr-1"]);
-    expect(saveSyncState).toHaveBeenCalledWith({
-      lastSyncedAt: "2026-04-24T00:00:00.000Z",
-      syncToken: "tok-next",
-    });
+    expect(saveSyncState).toHaveBeenCalledWith(
+      {
+        source: "google_calendar",
+        externalAccountId: "ext-acc-id",
+        externalCalendarId: "primary",
+      },
+      { lastSyncedAt: "2026-04-24T00:00:00.000Z", syncToken: "tok-next" },
+    );
   });
 
   test("incremental sync でも cancelled は削除に回る (差分削除が機能する)", async () => {
@@ -536,7 +561,10 @@ describe("syncGoogleCalendar (incremental sync via syncToken)", () => {
     );
 
     expect(result.deleted).toBe(1);
-    expect(deleteCalls[0]).toEqual(["gone-incr"]);
+    expect(deleteCalls[0]).toEqual({
+      externalCalendarId: "primary",
+      ids: ["gone-incr"],
+    });
   });
 
   test("incremental sync のページングは中間ページの nextSyncToken を無視し最終ページのみ採用する", async () => {
@@ -560,10 +588,14 @@ describe("syncGoogleCalendar (incremental sync via syncToken)", () => {
 
     await syncGoogleCalendar(FAKE_SUPABASE, makeDeps({ gateway, syncStateGateway, listEvents }));
 
-    expect(saveSyncState).toHaveBeenCalledWith({
-      lastSyncedAt: expect.any(String),
-      syncToken: "final-only",
-    });
+    expect(saveSyncState).toHaveBeenCalledWith(
+      {
+        source: "google_calendar",
+        externalAccountId: "ext-acc-id",
+        externalCalendarId: "primary",
+      },
+      { lastSyncedAt: expect.any(String), syncToken: "final-only" },
+    );
   });
 
   test("410 Gone を受けたら syncToken を捨てて full sync に fallback する", async () => {
@@ -602,10 +634,14 @@ describe("syncGoogleCalendar (incremental sync via syncToken)", () => {
     expect(listEvents.mock.calls[1]![0].orderBy).toBe("startTime");
     expect(upsertCalls[0]!.map((e) => e.externalId)).toEqual(["after-fallback"]);
     // fallback 後の full sync で得た新しい syncToken を保存
-    expect(saveSyncState).toHaveBeenCalledWith({
-      lastSyncedAt: "2026-04-24T05:00:00.000Z",
-      syncToken: "fresh-after-fallback",
-    });
+    expect(saveSyncState).toHaveBeenCalledWith(
+      {
+        source: "google_calendar",
+        externalAccountId: "ext-acc-id",
+        externalCalendarId: "primary",
+      },
+      { lastSyncedAt: "2026-04-24T05:00:00.000Z", syncToken: "fresh-after-fallback" },
+    );
   });
 
   test("full sync 中の 410 は fallback せず素通しで throw (syncToken なしの 410 は想定外)", async () => {

--- a/src/entities/event/sync.ts
+++ b/src/entities/event/sync.ts
@@ -1,6 +1,9 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-import type { CalendarSyncStateGateway } from "@/entities/calendar-sync/gateway";
+import type {
+  CalendarSyncStateGateway,
+  CalendarSyncStateKey,
+} from "@/entities/calendar-sync/gateway";
 import { SupabaseCalendarSyncStateGateway } from "@/entities/calendar-sync/supabase-gateway";
 import {
   GoogleApiError,
@@ -17,6 +20,7 @@ import {
 } from "@/shared/google/token";
 import type { Database } from "@/shared/types/database";
 
+import { EVENT_SOURCE } from "./types";
 import type { EventGateway, UpsertGoogleCalendarEventInput } from "./gateway";
 import { SupabaseEventGateway } from "./supabase-gateway";
 
@@ -54,6 +58,12 @@ export type SyncGoogleCalendarDeps = {
   listEvents: (params: ListEventsParams) => Promise<GoogleCalendarEventsListResponse>;
   getValidAccessToken: (supabase: SupabaseClient<Database>) => Promise<GoogleProviderAccess>;
   refreshAccessToken: (supabase: SupabaseClient<Database>) => Promise<GoogleProviderAccess>;
+  /**
+   * 現在ユーザーの primary Google account に対応する `external_accounts.id` を返す。
+   * 未存在なら lazy upsert する (Issue #159 §8 の最小コード変更スコープ)。
+   * Issue #144 / #146 で複数 account / 複数 calendar 対応時に置き換える。
+   */
+  resolvePrimaryExternalAccountId: (supabase: SupabaseClient<Database>) => Promise<string>;
   now: () => Date;
 };
 
@@ -67,14 +77,23 @@ export async function syncGoogleCalendar(
     listEvents: overrides.listEvents ?? defaultListEvents,
     getValidAccessToken: overrides.getValidAccessToken ?? defaultGetValidAccessToken,
     refreshAccessToken: overrides.refreshAccessToken ?? defaultRefreshAccessToken,
+    resolvePrimaryExternalAccountId:
+      overrides.resolvePrimaryExternalAccountId ?? defaultResolvePrimaryExternalAccountId,
     now: overrides.now ?? (() => new Date()),
+  };
+
+  const externalAccountId = await deps.resolvePrimaryExternalAccountId(supabase);
+  const syncStateKey: CalendarSyncStateKey = {
+    source: EVENT_SOURCE.GOOGLE_CALENDAR,
+    externalAccountId,
+    externalCalendarId: PRIMARY_CALENDAR_ID,
   };
 
   const nowDate = deps.now();
   const timeMin = new Date(nowDate.getTime() - SYNC_WINDOW_PAST_DAYS * MS_PER_DAY).toISOString();
   const timeMax = new Date(nowDate.getTime() + SYNC_WINDOW_FUTURE_DAYS * MS_PER_DAY).toISOString();
 
-  const initialState = await deps.syncStateGateway.get();
+  const initialState = await deps.syncStateGateway.get(syncStateKey);
   let activeSyncToken: string | undefined = initialState?.syncToken ?? undefined;
 
   const initial = await deps.getValidAccessToken(supabase);
@@ -136,7 +155,7 @@ export async function syncGoogleCalendar(
     break;
   }
 
-  const { upserts, cancelled } = partitionEvents(collected);
+  const { upserts, cancelled } = partitionEvents(collected, PRIMARY_CALENDAR_ID);
 
   let synced = 0;
   if (upserts.length > 0) {
@@ -144,13 +163,13 @@ export async function syncGoogleCalendar(
   }
   let deleted = 0;
   if (cancelled.length > 0) {
-    deleted = await deps.gateway.deleteByGoogleExternalIds(cancelled);
+    deleted = await deps.gateway.deleteByGoogleExternalIds(PRIMARY_CALENDAR_ID, cancelled);
   }
 
   const lastSyncedAt = nowDate.toISOString();
   // 成功したときだけ atomic に lastSyncedAt + syncToken を記録する。
   // listEvents が最後まで throw した経路ではここに来ないので、stale な syncToken は上書きされない。
-  await deps.syncStateGateway.saveSyncState({
+  await deps.syncStateGateway.saveSyncState(syncStateKey, {
     lastSyncedAt,
     syncToken: nextSyncToken ?? null,
   });
@@ -160,6 +179,49 @@ export async function syncGoogleCalendar(
     deleted,
     lastSyncedAt,
   };
+}
+
+/**
+ * 現在ユーザーの primary Google account を `external_accounts` で確保する (lazy upsert)。
+ *
+ * - 既存ユーザーは migration の seed で行が存在する。
+ * - 新規ユーザー (migration 後に Google ログインしたが #159 の seed 対象外) はここで作る。
+ * - `external_account_id` (text) は auth.users.email を優先、fallback で user.id を使う
+ *   (migration の seed と同じ規約)。Google API で google_user_id を取得する経路は #146 で扱う。
+ */
+async function defaultResolvePrimaryExternalAccountId(
+  supabase: SupabaseClient<Database>,
+): Promise<string> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("not authenticated");
+
+  // 既存行を探す: (user_id, source) で limit 1 (現状 1 user に primary 1 account)
+  const { data: existing, error: selectErr } = await supabase
+    .from("external_accounts")
+    .select("id")
+    .eq("user_id", user.id)
+    .eq("source", EVENT_SOURCE.GOOGLE_CALENDAR)
+    .limit(1)
+    .maybeSingle();
+  if (selectErr) throw selectErr;
+  if (existing) return existing.id;
+
+  // 無ければ作る (UNIQUE (user_id, source, external_account_id) の重複は起きない前提)
+  const externalAccountIdValue = user.email ?? user.id;
+  const { data: inserted, error: insertErr } = await supabase
+    .from("external_accounts")
+    .insert({
+      user_id: user.id,
+      source: EVENT_SOURCE.GOOGLE_CALENDAR,
+      external_account_id: externalAccountIdValue,
+      display_name: "(primary)",
+    })
+    .select("id")
+    .single();
+  if (insertErr) throw insertErr;
+  return inserted.id;
 }
 
 /**
@@ -195,7 +257,10 @@ function buildListParams(args: {
   };
 }
 
-export function partitionEvents(events: GoogleCalendarEvent[]): {
+export function partitionEvents(
+  events: GoogleCalendarEvent[],
+  externalCalendarId: string,
+): {
   upserts: UpsertGoogleCalendarEventInput[];
   cancelled: string[];
 } {
@@ -206,7 +271,7 @@ export function partitionEvents(events: GoogleCalendarEvent[]): {
       cancelled.push(ev.id);
       continue;
     }
-    const mapped = mapGoogleEventToUpsertInput(ev);
+    const mapped = mapGoogleEventToUpsertInput(ev, externalCalendarId);
     if (mapped) upserts.push(mapped);
   }
   return { upserts, cancelled };
@@ -214,11 +279,13 @@ export function partitionEvents(events: GoogleCalendarEvent[]): {
 
 export function mapGoogleEventToUpsertInput(
   event: GoogleCalendarEvent,
+  externalCalendarId: string,
 ): UpsertGoogleCalendarEventInput | null {
   const times = resolveEventTimes(event);
   if (!times) return null;
 
   return {
+    externalCalendarId,
     externalId: event.id,
     title: event.summary ?? DEFAULT_TITLE,
     startTime: times.start,

--- a/src/entities/event/types.ts
+++ b/src/entities/event/types.ts
@@ -6,8 +6,20 @@ export const EVENT_SOURCE = {
 } as const satisfies Record<string, EventSource>;
 
 /**
+ * Event の表示 / 取り込み制御 (ADR 0032)。
+ * - none: subscription default (auto_promote_to_timeline) に従う
+ * - shown: ユーザーが明示的に「予定化」した個別 override
+ * - hidden: ユーザーが明示的に「予定化解除」した個別 override
+ * 三値モデル (`info_only` 等) は ADR 0032 で将来拡張余地のみ確保。
+ */
+export type EventVisibilityOverride = "none" | "shown" | "hidden";
+
+/**
  * DB スキーマ (supabase/migrations/..._initial_schema.sql の events) と 1:1 対応。
  * 時刻は ISO 8601 文字列 (timestamptz) として扱う。
+ *
+ * `externalCalendarId` は ADR 0033 の triple `(source, externalCalendarId, externalId)`
+ * の中間軸。manual は 'manual'、google_calendar 由来は subscription の calendar id。
  */
 export type Event = {
   id: string;
@@ -20,5 +32,7 @@ export type Event = {
   description: string;
   source: EventSource;
   externalId: string | null;
+  externalCalendarId: string;
+  visibilityOverride: EventVisibilityOverride;
   createdAt: string;
 };

--- a/src/entities/task/supabase-gateway.ts
+++ b/src/entities/task/supabase-gateway.ts
@@ -107,10 +107,26 @@ export class SupabaseTaskGateway implements TaskGateway {
   }
 
   async delete(id: string): Promise<void> {
+    // ADR 0035 §5: task_deleted は snapshot 必須化された (Phase 4 回避パターン分析の素材)。
+    // 物理削除前に主要属性を読んでおき、削除後に snapshot 込みで log する。
+    // select は必要列のみで軽い (RLS 経由で 1 行)。失敗しても delete は強行する。
+    const { data: snapshotRow } = await this.supabase
+      .from("tasks")
+      .select("title, estimated_minutes, task_category, status, parent_task_id")
+      .eq("id", id)
+      .maybeSingle();
     const { error } = await this.supabase.from("tasks").delete().eq("id", id);
     if (error) throw error;
-    // 行動ログ欠損を防ぐため delete 成功後に TASK_DELETED を記録する (vision.md / ADR-0001)
-    log(ACTION_TYPES.TASK_DELETED, { task_id: id });
+    log(ACTION_TYPES.TASK_DELETED, {
+      task_id: id,
+      snapshot: {
+        title: snapshotRow?.title ?? "",
+        estimated_minutes: snapshotRow?.estimated_minutes ?? null,
+        task_category: snapshotRow?.task_category ?? null,
+        status: snapshotRow?.status ?? "idle",
+        parent_task_id: snapshotRow?.parent_task_id ?? null,
+      },
+    });
   }
 
   async deleteAllForCurrentUser(): Promise<void> {

--- a/src/features/day-timeline/DayTimeline.test.tsx
+++ b/src/features/day-timeline/DayTimeline.test.tsx
@@ -15,6 +15,8 @@ const ev = (id: string, title: string, startTime: string, endTime: string): Even
   description: "",
   source: "manual",
   externalId: null,
+  externalCalendarId: "manual",
+  visibilityOverride: "none",
   createdAt: "2026-04-11T00:00:00",
 });
 

--- a/src/features/day-timeline/EventCard.test.tsx
+++ b/src/features/day-timeline/EventCard.test.tsx
@@ -15,6 +15,8 @@ const baseEvent: Event = {
   description: "",
   source: "manual",
   externalId: null,
+  externalCalendarId: "manual",
+  visibilityOverride: "none",
   createdAt: "2026-04-11T00:00:00",
 };
 

--- a/src/features/day-timeline/TimelineBar.test.tsx
+++ b/src/features/day-timeline/TimelineBar.test.tsx
@@ -23,6 +23,8 @@ describe("TimelineBar", () => {
           description: "",
           source: "manual",
           externalId: null,
+          externalCalendarId: "manual",
+          visibilityOverride: "none",
           createdAt: "2026-04-11T00:00:00",
         },
       },

--- a/src/features/day-timeline/buildSlots.test.ts
+++ b/src/features/day-timeline/buildSlots.test.ts
@@ -18,6 +18,8 @@ const ev = (
   description: "",
   source: "manual",
   externalId: null,
+  externalCalendarId: "manual",
+  visibilityOverride: "none",
   createdAt: "2026-04-11T00:00:00",
 });
 

--- a/src/features/event-detail/EventDetailPanel.test.tsx
+++ b/src/features/event-detail/EventDetailPanel.test.tsx
@@ -24,6 +24,8 @@ const baseEvent: Event = {
   description: "## アジェンダ\n\n本文",
   source: "manual",
   externalId: null,
+  externalCalendarId: "manual",
+  visibilityOverride: "none",
   createdAt: "2026-04-11T00:00:00",
 };
 
@@ -32,6 +34,7 @@ const googleEvent: Event = {
   id: "g1",
   source: "google_calendar",
   externalId: "ext-1",
+  externalCalendarId: "primary",
 };
 
 const noop = () => {};

--- a/src/features/sync/useLazyCalendarSync.ts
+++ b/src/features/sync/useLazyCalendarSync.ts
@@ -60,6 +60,26 @@ export function shouldTriggerLazy(state: CalendarSyncState | null, now: Date): b
 
 async function defaultGetState(): Promise<CalendarSyncState | null> {
   const supabase = createClient();
+  // ADR 0031/0033: sync_state は (source, external_account_id, external_calendar_id) で識別する。
+  // client 側では read-only に primary Google account を解決し、未存在なら null を返して
+  // 「sync が一度も走っていない」(= trigger 候補) として扱う。
+  // external_accounts の lazy 作成は server 側 sync 経路 (sync.ts) で行う。
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+  const { data: account } = await supabase
+    .from("external_accounts")
+    .select("id")
+    .eq("user_id", user.id)
+    .eq("source", "google_calendar")
+    .limit(1)
+    .maybeSingle();
+  if (!account) return null;
   const gateway: CalendarSyncStateGateway = new SupabaseCalendarSyncStateGateway(supabase);
-  return gateway.get();
+  return gateway.get({
+    source: "google_calendar",
+    externalAccountId: account.id,
+    externalCalendarId: "primary",
+  });
 }

--- a/src/features/task-detail/TaskDetailPanel.test.tsx
+++ b/src/features/task-detail/TaskDetailPanel.test.tsx
@@ -131,6 +131,8 @@ describe("TaskDetailPanel", () => {
         description: "",
         source: "manual",
         externalId: null,
+        externalCalendarId: "manual",
+        visibilityOverride: "none",
         createdAt: "2026-04-11T00:00:00",
       },
     ];
@@ -166,6 +168,8 @@ describe("TaskDetailPanel", () => {
         description: "",
         source: "manual",
         externalId: null,
+        externalCalendarId: "manual",
+        visibilityOverride: "none",
         createdAt: "2026-04-11T00:00:00",
       },
     ];
@@ -192,6 +196,8 @@ describe("TaskDetailPanel", () => {
         description: "",
         source: "manual",
         externalId: null,
+        externalCalendarId: "manual",
+        visibilityOverride: "none",
         createdAt: "2026-04-11T00:00:00",
       },
     ];
@@ -217,6 +223,8 @@ describe("TaskDetailPanel", () => {
       description: "",
       source: "manual",
       externalId: null,
+      externalCalendarId: "manual",
+      visibilityOverride: "none",
       createdAt: "2026-04-09T00:00:00",
     };
     const future: Event = {
@@ -230,6 +238,8 @@ describe("TaskDetailPanel", () => {
       description: "",
       source: "manual",
       externalId: null,
+      externalCalendarId: "manual",
+      visibilityOverride: "none",
       createdAt: "2026-04-09T00:00:00",
     };
     const { getByText, queryByText } = renderPanel({
@@ -253,6 +263,8 @@ describe("TaskDetailPanel", () => {
       description: "",
       source: "manual",
       externalId: null,
+      externalCalendarId: "manual",
+      visibilityOverride: "none",
       createdAt: "2026-04-09T00:00:00",
     };
     const future: Event = {
@@ -266,6 +278,8 @@ describe("TaskDetailPanel", () => {
       description: "",
       source: "manual",
       externalId: null,
+      externalCalendarId: "manual",
+      visibilityOverride: "none",
       createdAt: "2026-04-09T00:00:00",
     };
     const { getByText, getAllByRole } = renderPanel({

--- a/src/features/task-stack/TaskStack.test.tsx
+++ b/src/features/task-stack/TaskStack.test.tsx
@@ -56,6 +56,8 @@ const baseEvent: Event = {
   description: "",
   source: "manual",
   externalId: null,
+  externalCalendarId: "manual",
+  visibilityOverride: "none",
   createdAt: "2026-04-11T00:00:00",
 };
 

--- a/src/mocks/events.ts
+++ b/src/mocks/events.ts
@@ -15,6 +15,8 @@ export function buildInitialEvents(): Event[] {
   const base = {
     source: "manual" as const,
     externalId: null,
+    externalCalendarId: "manual",
+    visibilityOverride: "none" as const,
     createdAt: now,
   };
 

--- a/src/shared/types/database.ts
+++ b/src/shared/types/database.ts
@@ -119,6 +119,8 @@ export type Database = {
           description: string;
           source: Database["public"]["Enums"]["event_source"];
           external_id: string | null;
+          external_calendar_id: string;
+          visibility_override: Database["public"]["Enums"]["event_visibility_override"];
           created_at: string;
         };
         Insert: {
@@ -133,6 +135,8 @@ export type Database = {
           description?: string;
           source?: Database["public"]["Enums"]["event_source"];
           external_id?: string | null;
+          external_calendar_id: string;
+          visibility_override?: Database["public"]["Enums"]["event_visibility_override"];
           created_at?: string;
         };
         Update: {
@@ -147,6 +151,8 @@ export type Database = {
           description?: string;
           source?: Database["public"]["Enums"]["event_source"];
           external_id?: string | null;
+          external_calendar_id?: string;
+          visibility_override?: Database["public"]["Enums"]["event_visibility_override"];
           created_at?: string;
         };
         Relationships: [];
@@ -185,6 +191,7 @@ export type Database = {
           action_type: string;
           task_id: string | null;
           metadata: Json;
+          actor_type: string;
           created_at: string;
         };
         Insert: {
@@ -193,6 +200,7 @@ export type Database = {
           action_type: string;
           task_id?: string | null;
           metadata?: Json;
+          actor_type?: string;
           created_at?: string;
         };
         Update: {
@@ -201,6 +209,7 @@ export type Database = {
           action_type?: string;
           task_id?: string | null;
           metadata?: Json;
+          actor_type?: string;
           created_at?: string;
         };
         Relationships: [];
@@ -208,21 +217,93 @@ export type Database = {
       user_calendar_sync_state: {
         Row: {
           user_id: string;
+          source: Database["public"]["Enums"]["event_source"];
+          external_account_id: string;
+          external_calendar_id: string;
           last_synced_at: string;
           sync_token: string | null;
           updated_at: string;
         };
         Insert: {
           user_id: string;
+          source: Database["public"]["Enums"]["event_source"];
+          external_account_id: string;
+          external_calendar_id: string;
           last_synced_at: string;
           sync_token?: string | null;
           updated_at?: string;
         };
         Update: {
           user_id?: string;
+          source?: Database["public"]["Enums"]["event_source"];
+          external_account_id?: string;
+          external_calendar_id?: string;
           last_synced_at?: string;
           sync_token?: string | null;
           updated_at?: string;
+        };
+        Relationships: [];
+      };
+      external_accounts: {
+        Row: {
+          id: string;
+          user_id: string;
+          source: Database["public"]["Enums"]["event_source"];
+          external_account_id: string;
+          display_name: string | null;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          source: Database["public"]["Enums"]["event_source"];
+          external_account_id: string;
+          display_name?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          source?: Database["public"]["Enums"]["event_source"];
+          external_account_id?: string;
+          display_name?: string | null;
+          created_at?: string;
+        };
+        Relationships: [];
+      };
+      user_calendar_subscriptions: {
+        Row: {
+          id: string;
+          user_id: string;
+          external_account_id: string;
+          source: Database["public"]["Enums"]["event_source"];
+          external_calendar_id: string;
+          auto_promote_to_timeline: boolean;
+          display_name: string | null;
+          color: string | null;
+          subscribed_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          external_account_id: string;
+          source: Database["public"]["Enums"]["event_source"];
+          external_calendar_id: string;
+          auto_promote_to_timeline?: boolean;
+          display_name?: string | null;
+          color?: string | null;
+          subscribed_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          external_account_id?: string;
+          source?: Database["public"]["Enums"]["event_source"];
+          external_calendar_id?: string;
+          auto_promote_to_timeline?: boolean;
+          display_name?: string | null;
+          color?: string | null;
+          subscribed_at?: string;
         };
         Relationships: [];
       };
@@ -281,6 +362,7 @@ export type Database = {
       event_source: "manual" | "google_calendar";
       pause_reason: "meeting" | "interruption" | "voluntary";
       decompose_status: "none" | "decomposing" | "decomposed" | "skipped" | "failed";
+      event_visibility_override: "none" | "shown" | "hidden";
     };
   };
 };

--- a/supabase/migrations/20260503000000_p3_159_calendar_ext_schema.sql
+++ b/supabase/migrations/20260503000000_p3_159_calendar_ext_schema.sql
@@ -1,0 +1,282 @@
+-- kozutsumi calendar 機能拡張 schema migration (Issue #159)
+--
+-- ADR 0031 / 0032 / 0033 / 0034 / 0035 で確定した設計を一括で schema に当てる。
+-- これは Issue #144 / #145 / #146 を block 解除する前提 migration。
+--
+-- References:
+-- * docs/adr/0031-calendar-subscription-and-event-promotion.md
+--     subscription / auto-promote / event 単位 override の 3 層モデル
+-- * docs/adr/0032-events-visibility-override-physical-model.md
+--     events.visibility_override の物理モデル (enum 3 値, NOT NULL DEFAULT 'none')
+-- * docs/adr/0033-events-cross-source-uniqueness.md
+--     source-agnostic 命名 (`external_*`) + cross-source UNIQUE
+-- * docs/adr/0034-calendar-subscription-lifecycle.md
+--     subscription / sync / unsubscribe / 再 subscribe ライフサイクル
+-- * docs/adr/0035-action-log-payload-schema-and-actor-type.md
+--     action_logs.actor_type 列追加 + 判断基準
+-- * docs/adr/0001-action-logs-from-phase1.md
+--     action_logs には CHECK / enum を貼らない
+-- * docs/adr/0019-db-migration-via-manual-github-actions.md
+--     本番は手動 GitHub Actions で適用
+--
+-- 設計判断の要点:
+-- * 命名は source-agnostic (ADR 0033)。Google 限定の名前は使わない。
+-- * `external_accounts` の Google OAuth 用列 (refresh_token 等) は本 migration に含めない
+--   (Issue #146 の auth model 再設計 ADR で確定後に追加)。
+-- * 既存ユーザーの primary calendar を `external_accounts` + `user_calendar_subscriptions`
+--   に seed して、既存挙動 (primary 固定の取り込み + 自動予定化) を維持する。
+-- * sync 経路で新しい external_account_id が必要になるケースは、code 側で lazy upsert
+--   する (Issue #159 §8 の最小コード変更スコープ)。
+
+-- =====================================================================
+-- 1. external_accounts (ADR 0033 source-agnostic、最小列)
+-- =====================================================================
+--
+-- 本 migration では (id, user_id, source, external_account_id, display_name, created_at)
+-- だけを持つ最小スキーマ。Google OAuth 列は #146 で追加する。
+-- `external_account_id` は source 内でアカウントを一意に識別する文字列。
+-- Google なら email or google_user_id (本 migration の seed では auth.users.email を使う)。
+
+create table public.external_accounts (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on delete cascade,
+  source public.event_source not null,
+  external_account_id text not null,
+  display_name text,
+  created_at timestamptz not null default now(),
+  unique (user_id, source, external_account_id)
+);
+
+create index external_accounts_user_id_idx on public.external_accounts (user_id);
+
+comment on table public.external_accounts is
+  'ADR 0033: 外部 calendar source 内のアカウント識別 (source-agnostic)。Google OAuth 用列は #146 で追加。';
+
+-- =====================================================================
+-- 2. user_calendar_subscriptions (ADR 0031)
+-- =====================================================================
+--
+-- calendar 単位の subscription (取り込み対象) を管理する。
+-- `auto_promote_to_timeline` の default は **既存挙動 (primary 固定で timeline に出る)**
+-- と整合させて true にする。
+
+create table public.user_calendar_subscriptions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on delete cascade,
+  external_account_id uuid not null references public.external_accounts (id) on delete cascade,
+  source public.event_source not null,
+  external_calendar_id text not null,
+  auto_promote_to_timeline boolean not null default true,
+  display_name text,
+  color text,
+  subscribed_at timestamptz not null default now(),
+  unique (user_id, external_account_id, external_calendar_id)
+);
+
+create index user_calendar_subscriptions_user_id_idx
+  on public.user_calendar_subscriptions (user_id);
+create index user_calendar_subscriptions_account_idx
+  on public.user_calendar_subscriptions (user_id, external_account_id);
+
+comment on table public.user_calendar_subscriptions is
+  'ADR 0031: calendar 単位の subscription (Layer 1) と auto-promote 設定 (Layer 2)。';
+
+-- =====================================================================
+-- 3. 既存ユーザーの primary を seed (ADR 0034 既存挙動互換)
+-- =====================================================================
+--
+-- Phase 2 で primary 固定 sync を使っていた既存ユーザーが migration 直後も
+-- そのまま動き続けるよう、(google_calendar, primary) の external_account +
+-- subscription を seed する。
+--
+-- 対象は「過去に GCal sync をしたことがある or 現在 sync_state 行を持っている」ユーザー全員。
+-- email が null の auth identity (theoretical edge case) は id::text を fallback 値にする。
+
+insert into public.external_accounts (user_id, source, external_account_id, display_name)
+select
+  u.id,
+  'google_calendar'::public.event_source,
+  coalesce(u.email, u.id::text),
+  '(primary)'
+  from auth.users u
+ where u.id in (select distinct user_id from public.events where source = 'google_calendar')
+    or u.id in (select user_id from public.user_calendar_sync_state)
+on conflict do nothing;
+
+insert into public.user_calendar_subscriptions
+  (user_id, external_account_id, source, external_calendar_id, auto_promote_to_timeline, display_name)
+select
+  ea.user_id,
+  ea.id,
+  'google_calendar'::public.event_source,
+  'primary',
+  true,
+  '(primary)'
+  from public.external_accounts ea
+ where ea.source = 'google_calendar'
+on conflict do nothing;
+
+-- =====================================================================
+-- 4. events.visibility_override (ADR 0032)
+-- =====================================================================
+--
+-- 3 値 enum (`none` / `shown` / `hidden`)。`none` は「subscription default に従う」。
+-- 既存行は default 'none' で埋まり、UI 経由でユーザーが override すると `shown`/`hidden` になる。
+-- 三値モデル (`info_only` 等) は ADR 0032 で将来拡張余地のみ確保、本 migration では実装しない。
+
+create type public.event_visibility_override as enum ('none', 'shown', 'hidden');
+
+alter table public.events
+  add column visibility_override public.event_visibility_override
+    not null default 'none';
+
+comment on column public.events.visibility_override is
+  'ADR 0032: 個別 event の予定化 override。none = subscription default に従う。';
+
+-- =====================================================================
+-- 5. events.external_calendar_id + UNIQUE 拡張 (ADR 0033)
+-- =====================================================================
+--
+-- triple `(source, external_calendar_id, external_id)` で events を一意化する。
+-- 既存 UNIQUE `(source, external_id)` は drop して置き換える。
+-- backfill の方針:
+--   - source='google_calendar' の既存行は primary 由来なので 'primary'
+--   - source='manual' の既存行は 'manual' で埋める (クエリ単純化、外部識別子としての意味は薄い)
+-- manual 行の external_id は NULL のまま残るが、Postgres の UNIQUE は NULL 同士を等価としない
+-- ので、複数の manual event が共存できる挙動は変わらない (initial_schema と同じ)。
+
+alter table public.events add column external_calendar_id text;
+
+update public.events
+   set external_calendar_id = 'primary'
+ where source = 'google_calendar' and external_calendar_id is null;
+
+update public.events
+   set external_calendar_id = 'manual'
+ where source = 'manual' and external_calendar_id is null;
+
+alter table public.events
+  alter column external_calendar_id set not null;
+
+alter table public.events drop constraint events_external_id_unique;
+
+alter table public.events
+  add constraint events_external_unique
+  unique (source, external_calendar_id, external_id);
+
+comment on column public.events.external_calendar_id is
+  'ADR 0033: triple uniqueness の中間軸。manual は ''manual'' / google_calendar は subscription の external_calendar_id。';
+
+create index events_user_calendar_start_idx
+  on public.events (user_id, source, external_calendar_id, start_time);
+
+-- =====================================================================
+-- 6. user_calendar_sync_state を複合キー化 (ADR 0031/0033)
+-- =====================================================================
+--
+-- 旧 PK: (user_id)
+-- 新 PK: (user_id, source, external_account_id, external_calendar_id)
+--
+-- これにより複数 calendar / 複数 account 対応 (#144 / #146) で sync_token と
+-- lastSyncedAt を独立に管理できるようになる。
+--
+-- 既存行は (google_calendar, primary external_account, 'primary') で backfill する。
+-- seed が直前に走っているので external_accounts は必ず存在する。
+
+alter table public.user_calendar_sync_state
+  add column source public.event_source,
+  add column external_account_id uuid references public.external_accounts (id) on delete cascade,
+  add column external_calendar_id text;
+
+update public.user_calendar_sync_state ucs
+   set source = 'google_calendar'::public.event_source,
+       external_account_id = (
+         select ea.id
+           from public.external_accounts ea
+          where ea.user_id = ucs.user_id
+            and ea.source = 'google_calendar'
+          limit 1
+       ),
+       external_calendar_id = 'primary';
+
+-- 万一 backfill 後に external_account_id が NULL の行が残った場合は明示的に削除する。
+-- (seed 漏れの防御線。通常は 0 行)
+delete from public.user_calendar_sync_state where external_account_id is null;
+
+alter table public.user_calendar_sync_state
+  alter column source set not null,
+  alter column external_account_id set not null,
+  alter column external_calendar_id set not null;
+
+-- 旧 PK (user_id) を drop して複合 PK に置き換える。
+-- 旧 PK は initial_schema で `user_id uuid primary key references ...` の inline で
+-- 作られているので、制約名は `user_calendar_sync_state_pkey`。
+alter table public.user_calendar_sync_state
+  drop constraint user_calendar_sync_state_pkey;
+
+alter table public.user_calendar_sync_state
+  add constraint user_calendar_sync_state_pkey
+  primary key (user_id, source, external_account_id, external_calendar_id);
+
+create index user_calendar_sync_state_user_idx
+  on public.user_calendar_sync_state (user_id);
+
+-- =====================================================================
+-- 7. external_accounts / user_calendar_subscriptions の RLS
+-- =====================================================================
+--
+-- owner-only 4 種ポリシー (initial_schema の events / projects と同等)。
+-- ADR 0023 の規約チェックも 4 種揃いを要求する。
+
+alter table public.external_accounts enable row level security;
+
+create policy "external_accounts: owner can select"
+  on public.external_accounts for select
+  using (user_id = auth.uid());
+create policy "external_accounts: owner can insert"
+  on public.external_accounts for insert
+  with check (user_id = auth.uid());
+create policy "external_accounts: owner can update"
+  on public.external_accounts for update
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+create policy "external_accounts: owner can delete"
+  on public.external_accounts for delete
+  using (user_id = auth.uid());
+
+alter table public.user_calendar_subscriptions enable row level security;
+
+create policy "user_calendar_subscriptions: owner can select"
+  on public.user_calendar_subscriptions for select
+  using (user_id = auth.uid());
+create policy "user_calendar_subscriptions: owner can insert"
+  on public.user_calendar_subscriptions for insert
+  with check (user_id = auth.uid());
+create policy "user_calendar_subscriptions: owner can update"
+  on public.user_calendar_subscriptions for update
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+create policy "user_calendar_subscriptions: owner can delete"
+  on public.user_calendar_subscriptions for delete
+  using (user_id = auth.uid());
+
+-- =====================================================================
+-- 8. action_logs.actor_type (ADR 0035)
+-- =====================================================================
+--
+-- ADR 0001 の「CHECK / enum を貼らない」原則に従い text 列のまま運用する。
+-- TypeScript リテラル union (`'user' | 'system'`) で値域を担保する。
+-- default 'user' により既存行は実質的に正しい値で埋まる
+-- (本 ADR 確定前は user actor のみが INSERT していた前提)。
+--
+-- index は Phase 4 で `WHERE user_id = ? AND actor_type = ?` の絞り込みが
+-- 頻発する想定で先回り (vision の差別化の核 = 「人間の操作のうち AI 代替可能なもの」分析)。
+
+alter table public.action_logs
+  add column actor_type text not null default 'user';
+
+comment on column public.action_logs.actor_type is
+  'ADR 0035: アクションを起こした主体 (''user'' / ''system'' / 将来 ''ai'')。CHECK は貼らず TypeScript 側で値域維持。';
+
+create index action_logs_actor_user_created_idx
+  on public.action_logs (user_id, actor_type, created_at desc);

--- a/supabase/migrations/20260503100000_p3_159_calendar_ext_schema.sql
+++ b/supabase/migrations/20260503100000_p3_159_calendar_ext_schema.sql
@@ -77,6 +77,11 @@ create index user_calendar_subscriptions_user_id_idx
   on public.user_calendar_subscriptions (user_id);
 create index user_calendar_subscriptions_account_idx
   on public.user_calendar_subscriptions (user_id, external_account_id);
+-- FK (external_account_id) lookup の standalone index。
+-- 複合 (user_id, external_account_id) は leading column が user_id なので
+-- external_accounts 削除時の cascade lookup を覆わない (supabase db lint 対策)。
+create index user_calendar_subscriptions_external_account_idx
+  on public.user_calendar_subscriptions (external_account_id);
 
 comment on table public.user_calendar_subscriptions is
   'ADR 0031: calendar 単位の subscription (Layer 1) と auto-promote 設定 (Layer 2)。';

--- a/supabase/migrations/20260503100000_p3_159_calendar_ext_schema.sql
+++ b/supabase/migrations/20260503100000_p3_159_calendar_ext_schema.sql
@@ -144,24 +144,21 @@ comment on column public.events.visibility_override is
 --
 -- triple `(source, external_calendar_id, external_id)` で events を一意化する。
 -- 既存 UNIQUE `(source, external_id)` は drop して置き換える。
--- backfill の方針:
---   - source='google_calendar' の既存行は primary 由来なので 'primary'
---   - source='manual' の既存行は 'manual' で埋める (クエリ単純化、外部識別子としての意味は薄い)
+-- default は `'manual'` (manual source の固定値と一致):
+--   - 既存行 (manual / google) を NOT NULL 違反させない backfill 兼任
+--   - PR migration diff (compare.mjs) の「NOT NULL + default なし」アサーション回避
+--   - 実際の sync / create コードは常に external_calendar_id を明示的に渡す
+--     (google: subscription の calendar id、manual: 'manual')
+-- google_calendar 既存行は 'primary' に明示的に backfill する (default 'manual' のままだと triple 衝突の余地)。
 -- manual 行の external_id は NULL のまま残るが、Postgres の UNIQUE は NULL 同士を等価としない
 -- ので、複数の manual event が共存できる挙動は変わらない (initial_schema と同じ)。
 
-alter table public.events add column external_calendar_id text;
+alter table public.events
+  add column external_calendar_id text not null default 'manual';
 
 update public.events
    set external_calendar_id = 'primary'
- where source = 'google_calendar' and external_calendar_id is null;
-
-update public.events
-   set external_calendar_id = 'manual'
- where source = 'manual' and external_calendar_id is null;
-
-alter table public.events
-  alter column external_calendar_id set not null;
+ where source = 'google_calendar';
 
 alter table public.events drop constraint events_external_id_unique;
 
@@ -179,39 +176,44 @@ create index events_user_calendar_start_idx
 -- 6. user_calendar_sync_state を複合キー化 (ADR 0031/0033)
 -- =====================================================================
 --
--- 旧 PK: (user_id)
--- 新 PK: (user_id, source, external_account_id, external_calendar_id)
+-- 旧 PK: (user_id) / 新 PK: (user_id, source, external_account_id, external_calendar_id)
 --
 -- これにより複数 calendar / 複数 account 対応 (#144 / #146) で sync_token と
 -- lastSyncedAt を独立に管理できるようになる。
 --
--- 既存行は (google_calendar, primary external_account, 'primary') で backfill する。
--- seed が直前に走っているので external_accounts は必ず存在する。
+-- default の方針 (compare.mjs 「NOT NULL + default なし」アサーション対策):
+--   - source: 'google_calendar' (現状 sync 経路は GCal のみ。Apple 等は将来別 ADR)
+--   - external_calendar_id: 'primary' (Phase 2 既存挙動と一致)
+--   - external_account_id: default 不能 (uuid FK)。代わりに column comment に
+--     `@migration-safe-not-null` marker を付けて compare.mjs で opt-out。
+--     同 migration 内で seed (section 3) 直後に NOT NULL 化するので既存行は壊れない。
+--
+-- 既存行の external_account_id は backfill で primary external_accounts.id を入れる。
+-- seed が section 3 で走っているので JOIN は必ず成立する。
 
 alter table public.user_calendar_sync_state
-  add column source public.event_source,
+  add column source public.event_source not null default 'google_calendar',
   add column external_account_id uuid references public.external_accounts (id) on delete cascade,
-  add column external_calendar_id text;
+  add column external_calendar_id text not null default 'primary';
 
 update public.user_calendar_sync_state ucs
-   set source = 'google_calendar'::public.event_source,
-       external_account_id = (
+   set external_account_id = (
          select ea.id
            from public.external_accounts ea
           where ea.user_id = ucs.user_id
             and ea.source = 'google_calendar'
           limit 1
-       ),
-       external_calendar_id = 'primary';
+       );
 
 -- 万一 backfill 後に external_account_id が NULL の行が残った場合は明示的に削除する。
 -- (seed 漏れの防御線。通常は 0 行)
 delete from public.user_calendar_sync_state where external_account_id is null;
 
 alter table public.user_calendar_sync_state
-  alter column source set not null,
-  alter column external_account_id set not null,
-  alter column external_calendar_id set not null;
+  alter column external_account_id set not null;
+
+comment on column public.user_calendar_sync_state.external_account_id is
+  'ADR 0031/0033: subscription の calendar 識別子。同 migration の section 3 seed + section 6 backfill で埋まるため NOT NULL 安全。 @migration-safe-not-null';
 
 -- 旧 PK (user_id) を drop して複合 PK に置き換える。
 -- 旧 PK は initial_schema で `user_id uuid primary key references ...` の inline で
@@ -225,6 +227,9 @@ alter table public.user_calendar_sync_state
 
 create index user_calendar_sync_state_user_idx
   on public.user_calendar_sync_state (user_id);
+-- FK (external_account_id) lookup の standalone index (supabase db lint 対策)
+create index user_calendar_sync_state_external_account_idx
+  on public.user_calendar_sync_state (external_account_id);
 
 -- =====================================================================
 -- 7. external_accounts / user_calendar_subscriptions の RLS


### PR DESCRIPTION
## 概要 (What)

ADR 0031〜0035 で確定した calendar / event / action_log モデルを 1 本の migration で当てる。Issue #144 / #145 / #146 を block 解除する前提 schema 変更。

## 関連 Issue

Closes #159

## 背景 (Why)

calendar 機能拡張 (#144 複数 calendar / #145 event 単位 override / #146 複数 Google アカウント) のための schema 変更が ADR で確定済みだが未実施だった。後追い migration を避けるため #154 (action_log payload 確定 = ADR 0035) → 本 PR → #144/#145/#146 の順序で進める。

参照 ADR:

- [ADR 0031](docs/adr/0031-calendar-subscription-and-event-promotion.md): subscription + auto-promote + event 単位 override の 3 層モデル
- [ADR 0032](docs/adr/0032-events-visibility-override-physical-model.md): `events.visibility_override` 物理モデル
- [ADR 0033](docs/adr/0033-events-cross-source-uniqueness.md): source-agnostic 命名 + triple uniqueness
- [ADR 0034](docs/adr/0034-calendar-subscription-lifecycle.md): subscription / sync / unsubscribe / 再 subscribe ライフサイクル
- [ADR 0035](docs/adr/0035-action-log-payload-schema-and-actor-type.md): payload 判断基準 + `actor_type` 列追加

## Before → After (概念・フロー・メンタルモデル)

**Before:**

- events は `(source, external_id)` で一意。primary calendar 固定で取り込み (ADR 0008)
- `user_calendar_sync_state` は `user_id` 1 行 = 1 user に sync_token 1 個
- action_log の actor は暗黙的に user のみ。判断基準は ad hoc
- 「取り込み」と「予定化」が同じ概念 (取り込んだら必ず timeline に出る)

**After:**

- events は `(source, external_calendar_id, external_id)` の triple で一意 (将来 Apple 等の他 source も同じモデル)
- subscription は calendar 単位 (`user_calendar_subscriptions`)、external account も独立管理 (`external_accounts`)
- sync_state は `(user_id, source, external_account_id, external_calendar_id)` 複合 PK で calendar ごとに独立
- action_log に `actor_type` 列 (`'user'` / `'system'`)。Phase 4 で「人間操作 vs AI/system 操作」を WHERE 句で切り出せる
- 「取り込み (subscription)」と「予定化 (auto_promote_to_timeline + visibility_override)」が独立した概念に分離

ただし本 PR では schema 変更と既存挙動維持のための最小コードのみ。新概念を活用する UI / 発火実装は #144 / #145 / #146。

## 追加したテスト (How verified)

- [x] `npm run typecheck` パス
- [x] `npm run lint` パス
- [x] `npx prettier --check` パス
- [x] `npm run test` (unit) 495/495 パス
  - calendar-sync gateway test を複合キー対応に書き換え
  - event sync test を `externalCalendarId` 引数化 + `saveSyncState(key, state)` 2 引数化に追従
  - action-log logger test を `actor_type` + `task_deleted.snapshot` 必須化に追従
  - 全 Event mock に `externalCalendarId` / `visibilityOverride` を追加
- [ ] e2e は CI 任せ (gcal-event-readonly の admin insert に `external_calendar_id` を追加済み)

## リリース前チェックリスト (When / Before merge)

- [x] マイグレーションの適用順: 既存 ADR 0019 (手動 GitHub Actions) で main マージ後に実行
- [x] 環境変数 / シークレット: 追加なし
- [ ] **既存ユーザーへの影響**:
  - 既存 GCal 利用ユーザー: `external_accounts` + `user_calendar_subscriptions` に `(google_calendar, primary)` を seed するため挙動変化なし
  - 既存 events: `external_calendar_id` を `'primary'` (gcal) / `'manual'` (manual) で backfill。UNIQUE 制約は triple に張り替え
  - 既存 sync_state: `(google_calendar, primary external_account, 'primary')` で backfill して複合 PK に拡張
  - action_logs 既存行: `actor_type` default `'user'` で埋まる (backfill 不要)
- [ ] PR migration diff コメント (ADR 0023) を確認

## このPRの範囲外 (Out of scope)

- 機能実装 (UI / 複数 calendar 取り込みロジック / auto_promote 切替 / unsubscribe フロー / event 単位 override 操作) — **#144 / #145 / #146**
- `external_accounts` の Google OAuth 用列 (`refresh_token` 等) — **#146** (ADR 0009 supersede が前提)
- 新 calendar/event ActionType の発火実装 — **#144 / #145 / #146** (型定義のみ本 PR で先行)
- 既存 action_log の backfill (ADR 0035 §6 で「新規ログから埋める」方針)
- 新 source 対応 (Apple Calendar 等) — 別 ADR + 別 issue

https://claude.ai/code/session_011rxw3GLWwAaCmZAQ4C9Jtg

---
_Generated by [Claude Code](https://claude.ai/code/session_011rxw3GLWwAaCmZAQ4C9Jtg)_