### PR TITLE
refactor(app-shell): AppShell.tsx の責務分離 (Closes #152)

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -1,10 +1,15 @@
 "use client";
 
-import { useMutation, useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { useCallback, useMemo, useState } from "react";
 
 import { useAutoSeed } from "./useAutoSeed";
+import {
+  dashboardKeys as keys,
+  invalidateDashboardData as invalidateAll,
+  useDashboardQueries,
+} from "./useDashboardQueries";
 import { useNowClock } from "./useNowClock";
 import { ACTION_TYPES, log } from "@/entities/action-log/logger";
 import type { CreateEventInput, UpdateEventInput } from "@/entities/event/gateway";
@@ -13,7 +18,6 @@ import type { CreateProjectInput, UpdateProjectInput } from "@/entities/project/
 import { ProjectsProvider } from "@/entities/project/ProjectsContext";
 import type { Project } from "@/entities/project/types";
 import { CorrectionFactorsProvider } from "@/entities/task/CorrectionFactorsContext";
-import type { CorrectionFactor } from "@/entities/task/correction";
 import type { CreateTaskInput } from "@/entities/task/gateway";
 import type { Task, TaskCategory } from "@/entities/task/types";
 import { AddButton } from "@/features/add-forms/AddButton";
@@ -65,20 +69,6 @@ type AppShellProps = {
   };
 };
 
-/**
- * Query key と「どの queryClient から書き換えるか」をここに集約する。
- * 各ミューテーションは optimistic update を同じキーに対して適用する。
- */
-const keys = {
-  projects: ["projects"] as const,
-  tasks: ["tasks"] as const,
-  events: ["events"] as const,
-  /** 詳細パネル (P3-15) で fetch する AI 分解の最新試行ログ。タスク id 単位で分離する。 */
-  decomposeLog: (taskId: string) => ["actionLog", "decompose", taskId] as const,
-  /** 見積もり補正倍率 (P3-9 / #93、ADR 0025): user-scoped、view 経由で取る。 */
-  correctionFactors: ["correctionFactors"] as const,
-};
-
 export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
   const view = initialView;
   const taskGateway = useTaskGateway();
@@ -91,35 +81,17 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
     [projectGateway, eventGateway, taskGateway],
   );
 
-  const projectsQuery = useQuery({
-    queryKey: keys.projects,
-    queryFn: () => projectGateway.list(),
-  });
-  const tasksQuery = useQuery({
-    queryKey: keys.tasks,
-    queryFn: () => taskGateway.list(),
-  });
-  const eventsQuery = useQuery({
-    queryKey: keys.events,
-    queryFn: () => eventGateway.list(),
-  });
-
-  const projects = useMemo(() => projectsQuery.data ?? [], [projectsQuery.data]);
-  const tasks = useMemo(() => tasksQuery.data ?? [], [tasksQuery.data]);
-  const events = useMemo(() => eventsQuery.data ?? [], [eventsQuery.data]);
-
-  // P3-9 / #93: 見積もり補正倍率 (ADR 0024 / 0025)。
-  // 補正は augmentation (ADR 0013) なので未取得 / fetch 失敗は空配列扱い (= 全タスク補正なし)。
-  // staleTime を長めにして、タスク完了のたびに再取得しない (補正値の鋭敏な更新は不要)。
-  const correctionFactorsQuery = useQuery({
-    queryKey: keys.correctionFactors,
-    queryFn: () => taskGateway.listCorrectionFactors(),
-    staleTime: 5 * 60_000,
-  });
-  const correctionFactors = useMemo<readonly CorrectionFactor[]>(
-    () => correctionFactorsQuery.data ?? [],
-    [correctionFactorsQuery.data],
-  );
+  const {
+    projectsQuery,
+    tasksQuery,
+    eventsQuery,
+    projects,
+    tasks,
+    events,
+    correctionFactors,
+    pendingTasks,
+    doneTasks,
+  } = useDashboardQueries();
 
   const [detailId, setDetailId] = useState<string | null>(null);
   const [eventDetailId, setEventDetailId] = useState<string | null>(null);
@@ -503,8 +475,6 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
     }
   }, [seedGateways, queryClient]);
 
-  const pendingTasks = useMemo(() => tasks.filter((t) => !isDone(t)), [tasks]);
-  const doneTasks = useMemo(() => tasks.filter((t) => isDone(t)), [tasks]);
   const detailTask = detailId ? tasks.find((t) => t.id === detailId) : null;
   const projectDetail = projectDetailId
     ? (projects.find((p) => p.id === projectDetailId) ?? null)
@@ -753,14 +723,6 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
       </CorrectionFactorsProvider>
     </ProjectsProvider>
   );
-}
-
-async function invalidateAll(queryClient: QueryClient): Promise<void> {
-  await Promise.all([
-    queryClient.invalidateQueries({ queryKey: keys.projects }),
-    queryClient.invalidateQueries({ queryKey: keys.tasks }),
-    queryClient.invalidateQueries({ queryKey: keys.events }),
-  ]);
 }
 
 type StackViewProps = {

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { useCallback, useMemo, useState } from "react";
 
@@ -10,16 +10,12 @@ import {
   invalidateDashboardData as invalidateAll,
   useDashboardQueries,
 } from "./useDashboardQueries";
+import { useDashboardMutations } from "./useDashboardMutations";
 import { useNowClock } from "./useNowClock";
-import { ACTION_TYPES, log } from "@/entities/action-log/logger";
-import type { CreateEventInput, UpdateEventInput } from "@/entities/event/gateway";
 import type { Event } from "@/entities/event/types";
-import type { CreateProjectInput, UpdateProjectInput } from "@/entities/project/gateway";
 import { ProjectsProvider } from "@/entities/project/ProjectsContext";
-import type { Project } from "@/entities/project/types";
 import { CorrectionFactorsProvider } from "@/entities/task/CorrectionFactorsContext";
-import type { CreateTaskInput } from "@/entities/task/gateway";
-import type { Task, TaskCategory } from "@/entities/task/types";
+import type { Task } from "@/entities/task/types";
 import { AddButton } from "@/features/add-forms/AddButton";
 import { AddPanel } from "@/features/add-forms/AddPanel";
 import { DayTimeline } from "@/features/day-timeline/DayTimeline";
@@ -31,11 +27,7 @@ import { useCalendarSync } from "@/features/sync/useCalendarSync";
 import { useLazyCalendarSync } from "@/features/sync/useLazyCalendarSync";
 import { TaskDetailPanel } from "@/features/task-detail/TaskDetailPanel";
 import { PauseReasonModal } from "@/features/task-stack/PauseReasonModal";
-import { reorderTasksById } from "@/features/task-stack/reorderTasks";
 import { TaskStack, type TopTimerBinding } from "@/features/task-stack/TaskStack";
-import { triggerCategorize } from "@/features/task-stack/triggerCategorize";
-import { triggerDecompose } from "@/features/task-stack/triggerDecompose";
-import { triggerResplit } from "@/features/task-stack/triggerResplit";
 import { useTaskTimer } from "@/features/task-stack/useTaskTimer";
 import { computeProjectOrderForTree, mergeTreeProjects } from "@/features/tree-view/fallback";
 import { TreeView } from "@/features/tree-view/TreeView";
@@ -50,7 +42,6 @@ import {
   useTaskGateway,
 } from "@/shared/gateway/GatewayContext";
 import { writeSampleDataMode } from "@/shared/lib/sample-data";
-import { isDone } from "@/shared/lib/task";
 import { todayIso } from "@/shared/lib/time";
 
 type View = "stack" | "tree";
@@ -119,338 +110,24 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
     onSeeded,
   });
 
-  // ---- Mutations (optimistic) ---------------------------------------------
-
-  const toggleDoneMutation = useMutation({
-    mutationFn: (id: string) => {
-      const target = tasks.find((t) => t.id === id);
-      if (!target) throw new Error("task not found");
-      const nextDone = !isDone(target);
-      return taskGateway.update(id, {
-        status: nextDone ? "done" : "idle",
-        completedAt: nextDone ? new Date().toISOString() : null,
-      });
-    },
-    onMutate: async (id) => {
-      await queryClient.cancelQueries({ queryKey: keys.tasks });
-      const previous = queryClient.getQueryData<Task[]>(keys.tasks);
-      const target = previous?.find((t) => t.id === id);
-      if (target && !isDone(target)) {
-        log(ACTION_TYPES.TASK_COMPLETED, { task_id: id });
-      }
-      queryClient.setQueryData<Task[]>(keys.tasks, (prev) =>
-        (prev ?? []).map((t) =>
-          t.id === id
-            ? {
-                ...t,
-                status: isDone(t) ? "idle" : "done",
-                completedAt: isDone(t) ? null : new Date().toISOString(),
-              }
-            : t,
-        ),
-      );
-      return { previous };
-    },
-    onError: (_err, _id, ctx) => {
-      if (ctx?.previous) queryClient.setQueryData(keys.tasks, ctx.previous);
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: keys.tasks });
-    },
-  });
-
-  const updateBodyMutation = useMutation({
-    mutationFn: ({ id, body }: { id: string; body: string }) => taskGateway.update(id, { body }),
-    onMutate: async ({ id, body }) => {
-      await queryClient.cancelQueries({ queryKey: keys.tasks });
-      const previous = queryClient.getQueryData<Task[]>(keys.tasks);
-      queryClient.setQueryData<Task[]>(keys.tasks, (prev) =>
-        (prev ?? []).map((t) => (t.id === id ? { ...t, body } : t)),
-      );
-      return { previous };
-    },
-    onError: (_err, _vars, ctx) => {
-      if (ctx?.previous) queryClient.setQueryData(keys.tasks, ctx.previous);
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: keys.tasks });
-    },
-  });
-
-  // P2-5 (#53): タスクの依存イベント設定。set / cleared を action_log に残し、
-  // Phase 4 で「依存設定が着手順に効いたか」の分析データに使う。
-  const updateDependencyMutation = useMutation({
-    mutationFn: ({ id, dependsOnEventId }: { id: string; dependsOnEventId: string | null }) =>
-      taskGateway.update(id, { dependsOnEventId }),
-    onMutate: async ({ id, dependsOnEventId }) => {
-      await queryClient.cancelQueries({ queryKey: keys.tasks });
-      const previous = queryClient.getQueryData<Task[]>(keys.tasks);
-      const target = previous?.find((t) => t.id === id);
-      const was = target?.dependsOnEventId ?? null;
-      if (was !== dependsOnEventId) {
-        if (dependsOnEventId) {
-          log(ACTION_TYPES.TASK_DEPENDENCY_SET, {
-            task_id: id,
-            event_id: dependsOnEventId,
-            was,
-          });
-        } else if (was) {
-          log(ACTION_TYPES.TASK_DEPENDENCY_CLEARED, { task_id: id, was });
-        }
-      }
-      queryClient.setQueryData<Task[]>(keys.tasks, (prev) =>
-        (prev ?? []).map((t) => (t.id === id ? { ...t, dependsOnEventId } : t)),
-      );
-      return { previous };
-    },
-    onError: (_err, _vars, ctx) => {
-      if (ctx?.previous) queryClient.setQueryData(keys.tasks, ctx.previous);
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: keys.tasks });
-    },
-  });
-
-  // P3-5 (#90) / ADR 0015: 詳細パネルからの task_category override。
-  // AddPanel には出さず、AI 初期ラベル → 人間 override のフローで暗黙的フィードバック
-  // (task_category_changed) を残す。Phase 4 のラベリング精度改善ループの入力源。
-  const updateCategoryMutation = useMutation({
-    mutationFn: ({ id, taskCategory }: { id: string; taskCategory: TaskCategory | null }) =>
-      taskGateway.update(id, { taskCategory }),
-    onMutate: async ({ id, taskCategory }) => {
-      await queryClient.cancelQueries({ queryKey: keys.tasks });
-      const previous = queryClient.getQueryData<Task[]>(keys.tasks);
-      const target = previous?.find((t) => t.id === id);
-      const from = target?.taskCategory ?? null;
-      // override 時のみ log。next === null (= 「未分類」へ戻す) は ADR 0015 の
-      // metadata.to: string と矛盾するので log を抑制する (DB は更新する)。
-      // Phase 4 のラベリング精度分析は「人間が AI ラベルを別の値で上書きした」事象を
-      // 拾えれば十分なので、null に戻す操作の追跡は今は持たない。
-      if (from !== taskCategory && taskCategory !== null) {
-        log(ACTION_TYPES.TASK_CATEGORY_CHANGED, {
-          task_id: id,
-          from,
-          to: taskCategory,
-        });
-      }
-      queryClient.setQueryData<Task[]>(keys.tasks, (prev) =>
-        (prev ?? []).map((t) => (t.id === id ? { ...t, taskCategory } : t)),
-      );
-      return { previous };
-    },
-    onError: (_err, _vars, ctx) => {
-      if (ctx?.previous) queryClient.setQueryData(keys.tasks, ctx.previous);
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: keys.tasks });
-    },
-  });
-
-  const reorderMutation = useMutation({
-    mutationFn: (entries: { id: string; stackOrder: number | null }[]) =>
-      taskGateway.reorder(entries),
-    // DnD は optimistic で UI 側は onMutate で即反映、サーバー同期は背面で進める。
-  });
-
-  const createTaskMutation = useMutation({
-    mutationFn: (input: CreateTaskInput) => taskGateway.create(input),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: keys.tasks });
-    },
-  });
-
-  const createEventMutation = useMutation({
-    mutationFn: (input: CreateEventInput) => eventGateway.create(input),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: keys.events });
-    },
-  });
-
-  // ADR 0010 / P2-4: google_calendar イベントは project_id だけ kozutsumi 側で
-  // 編集可。optimistic に反映し、失敗したら roll back する。
-  const updateEventProjectMutation = useMutation({
-    mutationFn: ({ id, projectId }: { id: string; projectId: string | null }) =>
-      eventGateway.update(id, { projectId }),
-    onMutate: async ({ id, projectId }) => {
-      await queryClient.cancelQueries({ queryKey: keys.events });
-      const previous = queryClient.getQueryData<Event[]>(keys.events);
-      queryClient.setQueryData<Event[]>(keys.events, (prev) =>
-        (prev ?? []).map((e) => (e.id === id ? { ...e, projectId } : e)),
-      );
-      return { previous };
-    },
-    onError: (_err, _vars, ctx) => {
-      if (ctx?.previous) queryClient.setQueryData(keys.events, ctx.previous);
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: keys.events });
-    },
-  });
-
-  // ADR 0010: manual イベントの全フィールド編集 (title / start_time / end_time /
-  // meet_url / project_id / description)。optimistic に反映し、失敗したら roll
-  // back する。SupabaseEventGateway.update 側で source='google_calendar' の行は
-  // Google 側属性を弾くので、UI が誤ってここに google_calendar を流しても DB
-  // 書き込みは守られる (ADR 0010 の defense in depth)。
-  const updateEventMutation = useMutation({
-    mutationFn: ({ id, patch }: { id: string; patch: UpdateEventInput }) =>
-      eventGateway.update(id, patch),
-    onMutate: async ({ id, patch }) => {
-      await queryClient.cancelQueries({ queryKey: keys.events });
-      const previous = queryClient.getQueryData<Event[]>(keys.events);
-      queryClient.setQueryData<Event[]>(keys.events, (prev) =>
-        (prev ?? []).map((e) =>
-          e.id === id
-            ? {
-                ...e,
-                ...(patch.title !== undefined ? { title: patch.title } : {}),
-                ...(patch.startTime !== undefined ? { startTime: patch.startTime } : {}),
-                ...(patch.endTime !== undefined ? { endTime: patch.endTime } : {}),
-                ...(patch.projectId !== undefined ? { projectId: patch.projectId } : {}),
-                ...(patch.meetUrl !== undefined ? { meetUrl: patch.meetUrl } : {}),
-                ...(patch.hasAttachments !== undefined
-                  ? { hasAttachments: patch.hasAttachments }
-                  : {}),
-                ...(patch.description !== undefined ? { description: patch.description } : {}),
-              }
-            : e,
-        ),
-      );
-      return { previous };
-    },
-    onError: (_err, _vars, ctx) => {
-      if (ctx?.previous) queryClient.setQueryData(keys.events, ctx.previous);
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: keys.events });
-    },
-  });
-
-  // ADR 0010: manual イベントだけが UI から削除可能。google_calendar は
-  // SupabaseEventGateway.delete が source を見て弾く。
-  const deleteEventMutation = useMutation({
-    mutationFn: (id: string) => eventGateway.delete(id),
-    onMutate: async (id) => {
-      await queryClient.cancelQueries({ queryKey: keys.events });
-      const previous = queryClient.getQueryData<Event[]>(keys.events);
-      queryClient.setQueryData<Event[]>(keys.events, (prev) =>
-        (prev ?? []).filter((e) => e.id !== id),
-      );
-      return { previous };
-    },
-    onError: (_err, _id, ctx) => {
-      if (ctx?.previous) queryClient.setQueryData(keys.events, ctx.previous);
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: keys.events });
-    },
-  });
-
-  const createProjectMutation = useMutation({
-    mutationFn: (input: CreateProjectInput) => projectGateway.create(input),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: keys.projects });
-    },
-  });
-
-  const updateProjectMutation = useMutation({
-    mutationFn: ({ id, patch }: { id: string; patch: UpdateProjectInput }) =>
-      projectGateway.update(id, patch),
-    onMutate: async ({ id, patch }) => {
-      await queryClient.cancelQueries({ queryKey: keys.projects });
-      const previous = queryClient.getQueryData<Project[]>(keys.projects);
-      queryClient.setQueryData<Project[]>(keys.projects, (prev) =>
-        (prev ?? []).map((p) => (p.id === id ? { ...p, ...patch } : p)),
-      );
-      return { previous };
-    },
-    onError: (_err, _vars, ctx) => {
-      if (ctx?.previous) queryClient.setQueryData(keys.projects, ctx.previous);
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: keys.projects });
-    },
-  });
-
-  // schema 上 `ON DELETE SET NULL` で tasks.project_id / events.project_id が
-  // null 化される。UI 側はそれを反映するため tasks / events も invalidate する。
-  const deleteProjectMutation = useMutation({
-    mutationFn: (id: string) => projectGateway.delete(id),
-    onMutate: async (id) => {
-      await queryClient.cancelQueries({ queryKey: keys.projects });
-      const previous = queryClient.getQueryData<Project[]>(keys.projects);
-      queryClient.setQueryData<Project[]>(keys.projects, (prev) =>
-        (prev ?? []).filter((p) => p.id !== id),
-      );
-      return { previous };
-    },
-    onError: (_err, _id, ctx) => {
-      if (ctx?.previous) queryClient.setQueryData(keys.projects, ctx.previous);
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: keys.projects });
-      queryClient.invalidateQueries({ queryKey: keys.tasks });
-      queryClient.invalidateQueries({ queryKey: keys.events });
-    },
-  });
-
-  // タスク削除は TASK_DELETED action_log も記録する (SupabaseTaskGateway.delete 内)。
-  const deleteTaskMutation = useMutation({
-    mutationFn: (id: string) => taskGateway.delete(id),
-    onMutate: async (id) => {
-      await queryClient.cancelQueries({ queryKey: keys.tasks });
-      const previous = queryClient.getQueryData<Task[]>(keys.tasks);
-      queryClient.setQueryData<Task[]>(keys.tasks, (prev) =>
-        (prev ?? []).filter((t) => t.id !== id),
-      );
-      return { previous };
-    },
-    onError: (_err, _id, ctx) => {
-      if (ctx?.previous) queryClient.setQueryData(keys.tasks, ctx.previous);
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: keys.tasks });
-    },
-  });
-
-  const toggleDone = useCallback(
-    (id: string) => toggleDoneMutation.mutate(id),
-    [toggleDoneMutation],
-  );
-
-  const updateBody = useCallback(
-    (id: string, body: string) => updateBodyMutation.mutate({ id, body }),
-    [updateBodyMutation],
-  );
-
-  const reorder = useCallback(
-    (fromId: string, toId: string) => {
-      if (fromId === toId) return;
-      const cached = queryClient.getQueryData<Task[]>(keys.tasks) ?? [];
-      const pending = cached.filter((t) => !isDone(t));
-      const done = cached.filter((t) => isDone(t));
-      const fromIdx = pending.findIndex((t) => t.id === fromId);
-      const toIdx = pending.findIndex((t) => t.id === toId);
-      if (fromIdx < 0 || toIdx < 0) return;
-      const reordered = reorderTasksById(pending, fromId, toId);
-      queryClient.setQueryData<Task[]>(keys.tasks, [...reordered, ...done]);
-      log(ACTION_TYPES.TASK_REORDERED, {
-        task_id: fromId,
-        from_position: fromIdx,
-        to_position: toIdx,
-      });
-      reorderMutation.mutate(
-        reordered.map((t) => ({ id: t.id, stackOrder: t.stackOrder })),
-        {
-          onError: () => {
-            // 失敗したら再取得して辻褄を合わせる (UI は一瞬戻るが DB 正とする)
-            queryClient.invalidateQueries({ queryKey: keys.tasks });
-          },
-        },
-      );
-    },
-    [queryClient, reorderMutation],
-  );
+  const {
+    toggleDone,
+    updateBody,
+    updateDependency,
+    updateCategory,
+    reorder,
+    createTaskWithAi,
+    createEvent,
+    updateEventProject,
+    updateEvent,
+    deleteEvent,
+    createProject,
+    updateProject,
+    deleteProject,
+    deleteTask,
+    triggerDecomposeWithOptimistic,
+    triggerResplitWithOptimistic,
+  } = useDashboardMutations();
 
   const resetSample = useCallback(async () => {
     try {
@@ -596,43 +273,14 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
               onClose={() => setDetailId(null)}
               onUpdate={updateBody}
               onToggleDone={toggleDone}
-              onDelete={(id) => deleteTaskMutation.mutate(id)}
-              onChangeDependency={(id, dependsOnEventId) =>
-                updateDependencyMutation.mutate({ id, dependsOnEventId })
-              }
-              onChangeCategory={(id, taskCategory) =>
-                updateCategoryMutation.mutate({ id, taskCategory })
-              }
+              onDelete={deleteTask}
+              onChangeDependency={updateDependency}
+              onChangeCategory={updateCategory}
               aiEnabled={aiEnabled}
               latestDecomposeLog={decomposeLogQuery.data ?? null}
               isDecomposeLogLoading={decomposeLogQuery.isPending}
-              onTriggerDecompose={(id) => {
-                // P3-15 / ADR 0021 §4: optimistic に decomposing pill を出しつつ fire-and-forget。
-                // server 側でも `decompose_status='decomposing'` に倒す (重複設定は無害)。
-                queryClient.setQueryData<Task[]>(keys.tasks, (prev) =>
-                  (prev ?? []).map((t) =>
-                    t.id === id ? { ...t, decomposeStatus: "decomposing" } : t,
-                  ),
-                );
-                // 既存 log は陳腐化するので invalidate (新たな試行が完了したら再 fetch される)
-                queryClient.invalidateQueries({ queryKey: keys.decomposeLog(id) });
-                triggerDecompose(id);
-              }}
-              onTriggerResplit={(id) => {
-                // Issue #121 / ADR 0027: 子の再分解。optimistic に decomposing pill を出す。
-                queryClient.setQueryData<Task[]>(keys.tasks, (prev) =>
-                  (prev ?? []).map((t) =>
-                    t.id === id ? { ...t, decomposeStatus: "decomposing" } : t,
-                  ),
-                );
-                queryClient.invalidateQueries({ queryKey: keys.decomposeLog(id) });
-                // server 側で target が delete される + 新規子が insert されるので、
-                // 完了後 (成功 / 失敗 / skipped 問わず) に tasks を invalidate して refetch する。
-                // .finally は fire-and-forget の void 返却と互換 (例外は triggerResplit 内で潰している)。
-                void triggerResplit(id).finally(() => {
-                  queryClient.invalidateQueries({ queryKey: keys.tasks });
-                });
-              }}
+              onTriggerDecompose={triggerDecomposeWithOptimistic}
+              onTriggerResplit={triggerResplitWithOptimistic}
             />
           )}
 
@@ -643,15 +291,9 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
                 <EventDetailPanel
                   event={ev}
                   onClose={() => setEventDetailId(null)}
-                  onChangeProject={(id, projectId) =>
-                    updateEventProjectMutation.mutate({ id, projectId })
-                  }
-                  onUpdate={async (id, patch) => {
-                    await updateEventMutation.mutateAsync({ id, patch });
-                  }}
-                  onDelete={async (id) => {
-                    await deleteEventMutation.mutateAsync(id);
-                  }}
+                  onChangeProject={updateEventProject}
+                  onUpdate={updateEvent}
+                  onDelete={deleteEvent}
                 />
               ) : null;
             })()}
@@ -663,39 +305,9 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
               projects={projects}
               events={events}
               onClose={() => setAddOpen(false)}
-              onCreateTask={async (input) => {
-                // stackOrder は末尾に割り当て (pending 件数)
-                const stackOrder = pendingTasks.length;
-                const created = await createTaskMutation.mutateAsync({ ...input, stackOrder });
-                // P3-6 / ADR 0017: タスク作成成功後に AI 分解を fire-and-forget で投げる。
-                // server 側でも `decompose_status='decomposing'` に倒すが、UI に分解中 pill を
-                // 即時出すため optimistic に cache を書き換える。AI_ENABLED=false / 失敗時は
-                // server が `none` に戻す (decompose-server の guard 経路)。
-                // 既に invalidateQueries で refetch 中の cache に対しては map で上書き、
-                // refetch 前で entry が無ければ末尾に append する。
-                queryClient.setQueryData<Task[]>(keys.tasks, (prev) => {
-                  const list = prev ?? [];
-                  const found = list.some((t) => t.id === created.id);
-                  const updated = { ...created, decomposeStatus: "decomposing" as const };
-                  return found
-                    ? list.map((t) =>
-                        t.id === created.id ? { ...t, decomposeStatus: "decomposing" } : t,
-                      )
-                    : [...list, updated];
-                });
-                triggerDecompose(created.id);
-                // P3-4 / ADR 0015: AI 初期ラベリングも同経路で fire-and-forget。
-                // 失敗 / AI_ENABLED=false は server が `task_category=null` のまま残す
-                // (ADR 0013 augmentation only)。client 側の optimistic 反映はしない —
-                // category は UX 上「気づいたら埋まっている」体験で良い。
-                triggerCategorize(created.id);
-              }}
-              onCreateEvent={async (input) => {
-                await createEventMutation.mutateAsync(input);
-              }}
-              onCreateProject={async (input) => {
-                await createProjectMutation.mutateAsync(input);
-              }}
+              onCreateTask={(input) => createTaskWithAi(input, pendingTasks.length)}
+              onCreateEvent={createEvent}
+              onCreateProject={createProject}
               onOpenProject={setProjectDetailId}
             />
           ) : null}
@@ -704,12 +316,8 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
             <ProjectDetailPanel
               project={projectDetail}
               onClose={() => setProjectDetailId(null)}
-              onUpdate={async (id, patch) => {
-                await updateProjectMutation.mutateAsync({ id, patch });
-              }}
-              onDelete={async (id) => {
-                await deleteProjectMutation.mutateAsync(id);
-              }}
+              onUpdate={updateProject}
+              onDelete={deleteProject}
             />
           )}
 

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -2,8 +2,10 @@
 
 import { useMutation, useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import Link from "next/link";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
+import { useAutoSeed } from "./useAutoSeed";
+import { useNowClock } from "./useNowClock";
 import { ACTION_TYPES, log } from "@/entities/action-log/logger";
 import type { CreateEventInput, UpdateEventInput } from "@/entities/event/gateway";
 import type { Event } from "@/entities/event/types";
@@ -31,6 +33,7 @@ import { triggerCategorize } from "@/features/task-stack/triggerCategorize";
 import { triggerDecompose } from "@/features/task-stack/triggerDecompose";
 import { triggerResplit } from "@/features/task-stack/triggerResplit";
 import { useTaskTimer } from "@/features/task-stack/useTaskTimer";
+import { computeProjectOrderForTree, mergeTreeProjects } from "@/features/tree-view/fallback";
 import { TreeView } from "@/features/tree-view/TreeView";
 import { UserMenu } from "@/features/user-menu/UserMenu";
 import type { PauseReason } from "@/entities/task/time-entries";
@@ -42,7 +45,7 @@ import {
   useProjectGateway,
   useTaskGateway,
 } from "@/shared/gateway/GatewayContext";
-import { readSampleDataMode, writeSampleDataMode } from "@/shared/lib/sample-data";
+import { writeSampleDataMode } from "@/shared/lib/sample-data";
 import { isDone } from "@/shared/lib/task";
 import { todayIso } from "@/shared/lib/time";
 
@@ -133,57 +136,16 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
     },
     enabled: detailId !== null,
   });
-  // ms 表現の「今」。SSR は 0 placeholder で hydration mismatch を回避し、
-  // mount 後に実時刻へ差し替える。nowMin (タイムライン用) と依存イベント比較用に共用する。
-  const [nowMs, setNowMs] = useState<number>(0);
+  const { nowMs, nowMin } = useNowClock();
   const today = useMemo(() => todayIso(), []);
 
-  useEffect(() => {
-    // マウント後にローカル時刻と同期する。SSR 時 nowMinutesOfDay() はブラウザ API 依存のため不可。
-    /* eslint-disable react-hooks/set-state-in-effect */
-    setNowMs(Date.now());
-    /* eslint-enable react-hooks/set-state-in-effect */
-    const id = window.setInterval(() => setNowMs(Date.now()), 60_000);
-    return () => window.clearInterval(id);
-  }, []);
-
-  const nowMin = useMemo(() => {
-    if (nowMs === 0) return 9 * 60;
-    const d = new Date(nowMs);
-    return d.getHours() * 60 + d.getMinutes();
-  }, [nowMs]);
-
-  // 初回ログイン時に自動 seed: 全テーブル空かつ「cleared」フラグ無しなら投入する。
-  // ref ガードでストリクトモードでの 2 重 fire を防ぎつつ、ローディング完了後 1 回だけ実行。
-  const seedingRef = useRef(false);
-  useEffect(() => {
-    if (seedingRef.current) return;
-    if (!projectsQuery.isSuccess || !tasksQuery.isSuccess || !eventsQuery.isSuccess) {
-      return;
-    }
-    if (readSampleDataMode() === "cleared") return;
-    if (projects.length > 0 || tasks.length > 0 || events.length > 0) return;
-    seedingRef.current = true;
-    seedSampleData(seedGateways)
-      .then(() => {
-        writeSampleDataMode("default");
-        return invalidateAll(queryClient);
-      })
-      .catch((err) => {
-        // 失敗時に再試行ループへ入らないよう seedingRef は立てたまま。
-        // ユーザー明示操作「サンプル再投入」で再試行できる。
-        console.error("[seed] failed", err);
-      });
-  }, [
-    projectsQuery.isSuccess,
-    tasksQuery.isSuccess,
-    eventsQuery.isSuccess,
-    projects.length,
-    tasks.length,
-    events.length,
-    seedGateways,
-    queryClient,
-  ]);
+  const onSeeded = useCallback(() => invalidateAll(queryClient), [queryClient]);
+  useAutoSeed({
+    ready: projectsQuery.isSuccess && tasksQuery.isSuccess && eventsQuery.isSuccess,
+    isEmpty: projects.length === 0 && tasks.length === 0 && events.length === 0,
+    gateways: seedGateways,
+    onSeeded,
+  });
 
   // ---- Mutations (optimistic) ---------------------------------------------
 
@@ -585,13 +547,11 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
 
   // Tree View は Phase 1 PoC では現行 mock history をそのまま描画する。
   // 将来: tasks where status='done' から生成する (docs/specs/phase1.md Tree View)
-  const projectOrderForTree = useMemo(() => {
-    if (projects.length === 0) {
-      // history mock の projectId (slug) を fallback として並べる
-      return Array.from(new Set(historyData.map((h) => h.projectId)));
-    }
-    return projects.map((p) => p.id);
-  }, [projects]);
+  const projectOrderForTree = useMemo(
+    () => computeProjectOrderForTree(projects, historyData),
+    [projects],
+  );
+  const treeProjects = useMemo(() => mergeTreeProjects(projects, historyData), [projects]);
 
   const tabs: { key: View; label: string; href: string }[] = [
     { key: "stack", label: "Stack", href: "/" },
@@ -599,7 +559,7 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
   ];
 
   return (
-    <ProjectsProvider projects={mergeTreeProjects(projects, historyData)}>
+    <ProjectsProvider projects={treeProjects}>
       <CorrectionFactorsProvider factors={correctionFactors}>
         <div className="relative select-none">
           {/* Header */}
@@ -802,47 +762,6 @@ async function invalidateAll(queryClient: QueryClient): Promise<void> {
     queryClient.invalidateQueries({ queryKey: keys.events }),
   ]);
 }
-
-/**
- * Tree View の mock history が参照する旧 slug (`career` 等) を、
- * 同名シードが DB にある場合はその Project として、
- * 無い場合は PROJECT_SEEDS 由来の fallback Project として補完する。
- */
-function mergeTreeProjects(
-  projects: readonly Project[],
-  history: readonly { projectId: string }[],
-): Project[] {
-  const known = new Set(projects.map((p) => p.id));
-  const missing = Array.from(
-    new Set(history.map((h) => h.projectId).filter((id) => !known.has(id))),
-  );
-  const result = [...projects];
-  for (const slug of missing) {
-    const seed = TREE_FALLBACK_BY_SLUG.get(slug);
-    result.push(
-      seed ?? {
-        id: slug,
-        name: slug,
-        color: "#52525b",
-        isPrimary: false,
-        createdAt: "",
-      },
-    );
-  }
-  return result;
-}
-
-// PROJECT_SEEDS を import すると循環が見えにくくなるので、slug→Project をここで簡易定義。
-// history (mock) に現れる slug 群だけ埋めれば十分。
-const TREE_FALLBACK_BY_SLUG: ReadonlyMap<string, Project> = new Map([
-  ["career", { id: "career", name: "転職活動", color: "#E85D04", isPrimary: false, createdAt: "" }],
-  [
-    "loadtest",
-    { id: "loadtest", name: "負荷試験", color: "#0096C7", isPrimary: false, createdAt: "" },
-  ],
-  ["slo", { id: "slo", name: "SLO推進", color: "#2D9F45", isPrimary: true, createdAt: "" }],
-  ["tasuki", { id: "tasuki", name: "Tasuki", color: "#9B5DE5", isPrimary: false, createdAt: "" }],
-]);
 
 type StackViewProps = {
   events: Event[];

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -12,6 +12,7 @@ import {
 } from "./useDashboardQueries";
 import { useDashboardMutations } from "./useDashboardMutations";
 import { useNowClock } from "./useNowClock";
+import { useTopTaskTimer } from "./useTopTaskTimer";
 import type { Event } from "@/entities/event/types";
 import { ProjectsProvider } from "@/entities/project/ProjectsContext";
 import { CorrectionFactorsProvider } from "@/entities/task/CorrectionFactorsContext";
@@ -28,11 +29,9 @@ import { useLazyCalendarSync } from "@/features/sync/useLazyCalendarSync";
 import { TaskDetailPanel } from "@/features/task-detail/TaskDetailPanel";
 import { PauseReasonModal } from "@/features/task-stack/PauseReasonModal";
 import { TaskStack, type TopTimerBinding } from "@/features/task-stack/TaskStack";
-import { useTaskTimer } from "@/features/task-stack/useTaskTimer";
 import { computeProjectOrderForTree, mergeTreeProjects } from "@/features/tree-view/fallback";
 import { TreeView } from "@/features/tree-view/TreeView";
 import { UserMenu } from "@/features/user-menu/UserMenu";
-import type { PauseReason } from "@/entities/task/time-entries";
 import { historyData } from "@/mocks/history";
 import { clearAllUserData, seedSampleData } from "@/mocks/seed";
 import {
@@ -159,38 +158,12 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
 
   // タスクスタックのトップタスク = タイマー対象。
   // pendingTasks は stack_order 昇順なので [0] がトップ。
-  const topTask = pendingTasks[0] ?? null;
-  const timer = useTaskTimer(topTask);
-  const [pauseModalOpen, setPauseModalOpen] = useState(false);
+  const { topTimer, pauseModalOpen, setPauseModalOpen, handlePauseSelect } = useTopTaskTimer(
+    pendingTasks[0] ?? null,
+  );
 
   const calendarSync = useCalendarSync();
   useLazyCalendarSync({ triggerSync: calendarSync.triggerSync });
-
-  const topTimer = useMemo<TopTimerBinding>(
-    () => ({
-      elapsedSeconds: timer.elapsedSeconds,
-      pauseReason: timer.pauseReason,
-      onStart: () => {
-        void timer.start();
-      },
-      onPauseRequest: () => setPauseModalOpen(true),
-      onResume: () => {
-        void timer.resume();
-      },
-      onComplete: () => {
-        void timer.complete();
-      },
-    }),
-    [timer],
-  );
-
-  const handlePauseSelect = useCallback(
-    (reason: PauseReason) => {
-      setPauseModalOpen(false);
-      void timer.pause(reason);
-    },
-    [timer],
-  );
 
   // Tree View は Phase 1 PoC では現行 mock history をそのまま描画する。
   // 将来: tasks where status='done' から生成する (docs/specs/phase1.md Tree View)

--- a/src/app/useAutoSeed.ts
+++ b/src/app/useAutoSeed.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { type SeedGateways, seedSampleData } from "@/mocks/seed";
+import { readSampleDataMode, writeSampleDataMode } from "@/shared/lib/sample-data";
+
+type UseAutoSeedArgs = {
+  /** 全 query (projects/tasks/events) が success に到達したか。false の間は何もしない。 */
+  ready: boolean;
+  /** projects / tasks / events が全て空か。false なら何もしない。 */
+  isEmpty: boolean;
+  gateways: SeedGateways;
+  /** seed 完了後に呼ぶ (AppShell では projects/tasks/events を invalidate する)。 */
+  onSeeded: () => Promise<void>;
+};
+
+/**
+ * 初回ログイン時の自動サンプル seed を担う effect hook。
+ *
+ * - 全テーブル空かつ「cleared」フラグが立っていない場合のみ投入
+ * - ref ガードでストリクトモードでの 2 重 fire を防ぐ
+ * - 失敗時は再試行ループに入らないよう ref を立てたまま (ユーザー明示操作で再試行できる)
+ */
+export function useAutoSeed({ ready, isEmpty, gateways, onSeeded }: UseAutoSeedArgs): void {
+  const seedingRef = useRef(false);
+
+  useEffect(() => {
+    if (seedingRef.current) return;
+    if (!ready) return;
+    if (readSampleDataMode() === "cleared") return;
+    if (!isEmpty) return;
+    seedingRef.current = true;
+    seedSampleData(gateways)
+      .then(() => {
+        writeSampleDataMode("default");
+        return onSeeded();
+      })
+      .catch((err) => {
+        console.error("[seed] failed", err);
+      });
+  }, [ready, isEmpty, gateways, onSeeded]);
+}

--- a/src/app/useDashboardMutations.ts
+++ b/src/app/useDashboardMutations.ts
@@ -1,0 +1,480 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+
+import { dashboardKeys } from "./useDashboardQueries";
+import { ACTION_TYPES, log } from "@/entities/action-log/logger";
+import type { CreateEventInput, UpdateEventInput } from "@/entities/event/gateway";
+import type { Event } from "@/entities/event/types";
+import type { CreateProjectInput, UpdateProjectInput } from "@/entities/project/gateway";
+import type { Project } from "@/entities/project/types";
+import type { CreateTaskInput } from "@/entities/task/gateway";
+import type { Task, TaskCategory } from "@/entities/task/types";
+import { reorderTasksById } from "@/features/task-stack/reorderTasks";
+import { triggerCategorize } from "@/features/task-stack/triggerCategorize";
+import { triggerDecompose } from "@/features/task-stack/triggerDecompose";
+import { triggerResplit } from "@/features/task-stack/triggerResplit";
+import {
+  useEventGateway,
+  useProjectGateway,
+  useTaskGateway,
+} from "@/shared/gateway/GatewayContext";
+import { isDone } from "@/shared/lib/task";
+
+export type DashboardMutations = {
+  /** スタックトップでもどこからでも、タスクの完了 / 未完了をトグル。action_log: TASK_COMPLETED。 */
+  toggleDone: (id: string) => void;
+  /** タスク本文の編集 (詳細パネル markdown editor)。 */
+  updateBody: (id: string, body: string) => void;
+  /** P2-5 (#53): タスクの依存イベント設定。action_log: TASK_DEPENDENCY_SET / _CLEARED。 */
+  updateDependency: (id: string, dependsOnEventId: string | null) => void;
+  /** P3-5 (#90) / ADR 0015: 詳細パネルからの task_category override。action_log: TASK_CATEGORY_CHANGED。 */
+  updateCategory: (id: string, taskCategory: TaskCategory | null) => void;
+  /** DnD でのタスク並び替え。action_log: TASK_REORDERED。 */
+  reorder: (fromId: string, toId: string) => void;
+  /**
+   * AddPanel からのタスク作成。タスク insert 後に AI 分解 + AI category 推論を
+   * fire-and-forget で投げる (P3-4 / P3-6, ADR 0015 / 0017)。
+   */
+  createTaskWithAi: (input: CreateTaskInput, stackOrder: number) => Promise<void>;
+  createEvent: (input: CreateEventInput) => Promise<void>;
+  /** ADR 0010: google_calendar event の project_id だけ kozutsumi 側で編集可。 */
+  updateEventProject: (id: string, projectId: string | null) => void;
+  /** ADR 0010: manual event の全フィールド編集。 */
+  updateEvent: (id: string, patch: UpdateEventInput) => Promise<void>;
+  /** ADR 0010: manual event の削除。google_calendar は gateway 側で弾く。 */
+  deleteEvent: (id: string) => Promise<void>;
+  createProject: (input: CreateProjectInput) => Promise<void>;
+  updateProject: (id: string, patch: UpdateProjectInput) => Promise<void>;
+  /** schema 上 ON DELETE SET NULL なので tasks/events も invalidate する。 */
+  deleteProject: (id: string) => Promise<void>;
+  /** タスク削除。SupabaseTaskGateway 側で TASK_DELETED action_log を記録する。 */
+  deleteTask: (id: string) => void;
+  /**
+   * 詳細パネルの「再分解」ボタン。optimistic に decomposing pill を出して
+   * `/api/ai/decompose` を fire-and-forget で叩く (P3-15 / ADR 0021 §4)。
+   */
+  triggerDecomposeWithOptimistic: (id: string) => void;
+  /**
+   * 子タスクの再分解 (issue #121 / ADR 0027)。optimistic に decomposing pill を
+   * 出し、完了後 (成功 / 失敗 / skipped 問わず) tasks を invalidate する。
+   */
+  triggerResplitWithOptimistic: (id: string) => void;
+};
+
+/**
+ * AppShell の主データ書き込み (12 mutation + AI trigger 派生 callback) を集約した hook。
+ *
+ * 各 mutation は optimistic update + onError でロールバック + onSettled で
+ * invalidate する基本パターン (`dashboardKeys.*` を共有)。
+ */
+export function useDashboardMutations(): DashboardMutations {
+  const taskGateway = useTaskGateway();
+  const projectGateway = useProjectGateway();
+  const eventGateway = useEventGateway();
+  const queryClient = useQueryClient();
+
+  const toggleDoneMutation = useMutation({
+    mutationFn: (id: string) => {
+      const target = queryClient
+        .getQueryData<Task[]>(dashboardKeys.tasks)
+        ?.find((t) => t.id === id);
+      if (!target) throw new Error("task not found");
+      const nextDone = !isDone(target);
+      return taskGateway.update(id, {
+        status: nextDone ? "done" : "idle",
+        completedAt: nextDone ? new Date().toISOString() : null,
+      });
+    },
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: dashboardKeys.tasks });
+      const previous = queryClient.getQueryData<Task[]>(dashboardKeys.tasks);
+      const target = previous?.find((t) => t.id === id);
+      if (target && !isDone(target)) {
+        log(ACTION_TYPES.TASK_COMPLETED, { task_id: id });
+      }
+      queryClient.setQueryData<Task[]>(dashboardKeys.tasks, (prev) =>
+        (prev ?? []).map((t) =>
+          t.id === id
+            ? {
+                ...t,
+                status: isDone(t) ? "idle" : "done",
+                completedAt: isDone(t) ? null : new Date().toISOString(),
+              }
+            : t,
+        ),
+      );
+      return { previous };
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(dashboardKeys.tasks, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.tasks });
+    },
+  });
+
+  const updateBodyMutation = useMutation({
+    mutationFn: ({ id, body }: { id: string; body: string }) => taskGateway.update(id, { body }),
+    onMutate: async ({ id, body }) => {
+      await queryClient.cancelQueries({ queryKey: dashboardKeys.tasks });
+      const previous = queryClient.getQueryData<Task[]>(dashboardKeys.tasks);
+      queryClient.setQueryData<Task[]>(dashboardKeys.tasks, (prev) =>
+        (prev ?? []).map((t) => (t.id === id ? { ...t, body } : t)),
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(dashboardKeys.tasks, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.tasks });
+    },
+  });
+
+  // P2-5 (#53): タスクの依存イベント設定。set / cleared を action_log に残し、
+  // Phase 4 で「依存設定が着手順に効いたか」の分析データに使う。
+  const updateDependencyMutation = useMutation({
+    mutationFn: ({ id, dependsOnEventId }: { id: string; dependsOnEventId: string | null }) =>
+      taskGateway.update(id, { dependsOnEventId }),
+    onMutate: async ({ id, dependsOnEventId }) => {
+      await queryClient.cancelQueries({ queryKey: dashboardKeys.tasks });
+      const previous = queryClient.getQueryData<Task[]>(dashboardKeys.tasks);
+      const target = previous?.find((t) => t.id === id);
+      const was = target?.dependsOnEventId ?? null;
+      if (was !== dependsOnEventId) {
+        if (dependsOnEventId) {
+          log(ACTION_TYPES.TASK_DEPENDENCY_SET, {
+            task_id: id,
+            event_id: dependsOnEventId,
+            was,
+          });
+        } else if (was) {
+          log(ACTION_TYPES.TASK_DEPENDENCY_CLEARED, { task_id: id, was });
+        }
+      }
+      queryClient.setQueryData<Task[]>(dashboardKeys.tasks, (prev) =>
+        (prev ?? []).map((t) => (t.id === id ? { ...t, dependsOnEventId } : t)),
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(dashboardKeys.tasks, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.tasks });
+    },
+  });
+
+  // P3-5 (#90) / ADR 0015: 詳細パネルからの task_category override。
+  // AddPanel には出さず、AI 初期ラベル → 人間 override のフローで暗黙的フィードバック
+  // (task_category_changed) を残す。Phase 4 のラベリング精度改善ループの入力源。
+  const updateCategoryMutation = useMutation({
+    mutationFn: ({ id, taskCategory }: { id: string; taskCategory: TaskCategory | null }) =>
+      taskGateway.update(id, { taskCategory }),
+    onMutate: async ({ id, taskCategory }) => {
+      await queryClient.cancelQueries({ queryKey: dashboardKeys.tasks });
+      const previous = queryClient.getQueryData<Task[]>(dashboardKeys.tasks);
+      const target = previous?.find((t) => t.id === id);
+      const from = target?.taskCategory ?? null;
+      // override 時のみ log。next === null (= 「未分類」へ戻す) は ADR 0015 の
+      // metadata.to: string と矛盾するので log を抑制する (DB は更新する)。
+      // Phase 4 のラベリング精度分析は「人間が AI ラベルを別の値で上書きした」事象を
+      // 拾えれば十分なので、null に戻す操作の追跡は今は持たない。
+      if (from !== taskCategory && taskCategory !== null) {
+        log(ACTION_TYPES.TASK_CATEGORY_CHANGED, {
+          task_id: id,
+          from,
+          to: taskCategory,
+        });
+      }
+      queryClient.setQueryData<Task[]>(dashboardKeys.tasks, (prev) =>
+        (prev ?? []).map((t) => (t.id === id ? { ...t, taskCategory } : t)),
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(dashboardKeys.tasks, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.tasks });
+    },
+  });
+
+  const reorderMutation = useMutation({
+    mutationFn: (entries: { id: string; stackOrder: number | null }[]) =>
+      taskGateway.reorder(entries),
+    // DnD は optimistic で UI 側は onMutate で即反映、サーバー同期は背面で進める。
+  });
+
+  const createTaskMutation = useMutation({
+    mutationFn: (input: CreateTaskInput) => taskGateway.create(input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.tasks });
+    },
+  });
+
+  const createEventMutation = useMutation({
+    mutationFn: (input: CreateEventInput) => eventGateway.create(input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.events });
+    },
+  });
+
+  // ADR 0010 / P2-4: google_calendar イベントは project_id だけ kozutsumi 側で
+  // 編集可。optimistic に反映し、失敗したら roll back する。
+  const updateEventProjectMutation = useMutation({
+    mutationFn: ({ id, projectId }: { id: string; projectId: string | null }) =>
+      eventGateway.update(id, { projectId }),
+    onMutate: async ({ id, projectId }) => {
+      await queryClient.cancelQueries({ queryKey: dashboardKeys.events });
+      const previous = queryClient.getQueryData<Event[]>(dashboardKeys.events);
+      queryClient.setQueryData<Event[]>(dashboardKeys.events, (prev) =>
+        (prev ?? []).map((e) => (e.id === id ? { ...e, projectId } : e)),
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(dashboardKeys.events, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.events });
+    },
+  });
+
+  // ADR 0010: manual イベントの全フィールド編集 (title / start_time / end_time /
+  // meet_url / project_id / description)。optimistic に反映し、失敗したら roll
+  // back する。SupabaseEventGateway.update 側で source='google_calendar' の行は
+  // Google 側属性を弾くので、UI が誤ってここに google_calendar を流しても DB
+  // 書き込みは守られる (ADR 0010 の defense in depth)。
+  const updateEventMutation = useMutation({
+    mutationFn: ({ id, patch }: { id: string; patch: UpdateEventInput }) =>
+      eventGateway.update(id, patch),
+    onMutate: async ({ id, patch }) => {
+      await queryClient.cancelQueries({ queryKey: dashboardKeys.events });
+      const previous = queryClient.getQueryData<Event[]>(dashboardKeys.events);
+      queryClient.setQueryData<Event[]>(dashboardKeys.events, (prev) =>
+        (prev ?? []).map((e) =>
+          e.id === id
+            ? {
+                ...e,
+                ...(patch.title !== undefined ? { title: patch.title } : {}),
+                ...(patch.startTime !== undefined ? { startTime: patch.startTime } : {}),
+                ...(patch.endTime !== undefined ? { endTime: patch.endTime } : {}),
+                ...(patch.projectId !== undefined ? { projectId: patch.projectId } : {}),
+                ...(patch.meetUrl !== undefined ? { meetUrl: patch.meetUrl } : {}),
+                ...(patch.hasAttachments !== undefined
+                  ? { hasAttachments: patch.hasAttachments }
+                  : {}),
+                ...(patch.description !== undefined ? { description: patch.description } : {}),
+              }
+            : e,
+        ),
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(dashboardKeys.events, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.events });
+    },
+  });
+
+  // ADR 0010: manual イベントだけが UI から削除可能。google_calendar は
+  // SupabaseEventGateway.delete が source を見て弾く。
+  const deleteEventMutation = useMutation({
+    mutationFn: (id: string) => eventGateway.delete(id),
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: dashboardKeys.events });
+      const previous = queryClient.getQueryData<Event[]>(dashboardKeys.events);
+      queryClient.setQueryData<Event[]>(dashboardKeys.events, (prev) =>
+        (prev ?? []).filter((e) => e.id !== id),
+      );
+      return { previous };
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(dashboardKeys.events, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.events });
+    },
+  });
+
+  const createProjectMutation = useMutation({
+    mutationFn: (input: CreateProjectInput) => projectGateway.create(input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.projects });
+    },
+  });
+
+  const updateProjectMutation = useMutation({
+    mutationFn: ({ id, patch }: { id: string; patch: UpdateProjectInput }) =>
+      projectGateway.update(id, patch),
+    onMutate: async ({ id, patch }) => {
+      await queryClient.cancelQueries({ queryKey: dashboardKeys.projects });
+      const previous = queryClient.getQueryData<Project[]>(dashboardKeys.projects);
+      queryClient.setQueryData<Project[]>(dashboardKeys.projects, (prev) =>
+        (prev ?? []).map((p) => (p.id === id ? { ...p, ...patch } : p)),
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(dashboardKeys.projects, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.projects });
+    },
+  });
+
+  // schema 上 `ON DELETE SET NULL` で tasks.project_id / events.project_id が
+  // null 化される。UI 側はそれを反映するため tasks / events も invalidate する。
+  const deleteProjectMutation = useMutation({
+    mutationFn: (id: string) => projectGateway.delete(id),
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: dashboardKeys.projects });
+      const previous = queryClient.getQueryData<Project[]>(dashboardKeys.projects);
+      queryClient.setQueryData<Project[]>(dashboardKeys.projects, (prev) =>
+        (prev ?? []).filter((p) => p.id !== id),
+      );
+      return { previous };
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(dashboardKeys.projects, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.projects });
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.tasks });
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.events });
+    },
+  });
+
+  // タスク削除は TASK_DELETED action_log も記録する (SupabaseTaskGateway.delete 内)。
+  const deleteTaskMutation = useMutation({
+    mutationFn: (id: string) => taskGateway.delete(id),
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: dashboardKeys.tasks });
+      const previous = queryClient.getQueryData<Task[]>(dashboardKeys.tasks);
+      queryClient.setQueryData<Task[]>(dashboardKeys.tasks, (prev) =>
+        (prev ?? []).filter((t) => t.id !== id),
+      );
+      return { previous };
+    },
+    onError: (_err, _id, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(dashboardKeys.tasks, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.tasks });
+    },
+  });
+
+  const reorder = useCallback(
+    (fromId: string, toId: string) => {
+      if (fromId === toId) return;
+      const cached = queryClient.getQueryData<Task[]>(dashboardKeys.tasks) ?? [];
+      const pending = cached.filter((t) => !isDone(t));
+      const done = cached.filter((t) => isDone(t));
+      const fromIdx = pending.findIndex((t) => t.id === fromId);
+      const toIdx = pending.findIndex((t) => t.id === toId);
+      if (fromIdx < 0 || toIdx < 0) return;
+      const reordered = reorderTasksById(pending, fromId, toId);
+      queryClient.setQueryData<Task[]>(dashboardKeys.tasks, [...reordered, ...done]);
+      log(ACTION_TYPES.TASK_REORDERED, {
+        task_id: fromId,
+        from_position: fromIdx,
+        to_position: toIdx,
+      });
+      reorderMutation.mutate(
+        reordered.map((t) => ({ id: t.id, stackOrder: t.stackOrder })),
+        {
+          onError: () => {
+            // 失敗したら再取得して辻褄を合わせる (UI は一瞬戻るが DB 正とする)
+            queryClient.invalidateQueries({ queryKey: dashboardKeys.tasks });
+          },
+        },
+      );
+    },
+    [queryClient, reorderMutation],
+  );
+
+  const createTaskWithAi = useCallback(
+    async (input: CreateTaskInput, stackOrder: number) => {
+      const created = await createTaskMutation.mutateAsync({ ...input, stackOrder });
+      // P3-6 / ADR 0017: タスク作成成功後に AI 分解を fire-and-forget で投げる。
+      // server 側でも `decompose_status='decomposing'` に倒すが、UI に分解中 pill を
+      // 即時出すため optimistic に cache を書き換える。AI_ENABLED=false / 失敗時は
+      // server が `none` に戻す (decompose-server の guard 経路)。
+      // 既に invalidateQueries で refetch 中の cache に対しては map で上書き、
+      // refetch 前で entry が無ければ末尾に append する。
+      queryClient.setQueryData<Task[]>(dashboardKeys.tasks, (prev) => {
+        const list = prev ?? [];
+        const found = list.some((t) => t.id === created.id);
+        const updated = { ...created, decomposeStatus: "decomposing" as const };
+        return found
+          ? list.map((t) => (t.id === created.id ? { ...t, decomposeStatus: "decomposing" } : t))
+          : [...list, updated];
+      });
+      triggerDecompose(created.id);
+      // P3-4 / ADR 0015: AI 初期ラベリングも同経路で fire-and-forget。
+      // 失敗 / AI_ENABLED=false は server が `task_category=null` のまま残す
+      // (ADR 0013 augmentation only)。client 側の optimistic 反映はしない —
+      // category は UX 上「気づいたら埋まっている」体験で良い。
+      triggerCategorize(created.id);
+    },
+    [createTaskMutation, queryClient],
+  );
+
+  const triggerDecomposeWithOptimistic = useCallback(
+    (id: string) => {
+      // P3-15 / ADR 0021 §4: optimistic に decomposing pill を出しつつ fire-and-forget。
+      // server 側でも `decompose_status='decomposing'` に倒す (重複設定は無害)。
+      queryClient.setQueryData<Task[]>(dashboardKeys.tasks, (prev) =>
+        (prev ?? []).map((t) => (t.id === id ? { ...t, decomposeStatus: "decomposing" } : t)),
+      );
+      // 既存 log は陳腐化するので invalidate (新たな試行が完了したら再 fetch される)
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.decomposeLog(id) });
+      triggerDecompose(id);
+    },
+    [queryClient],
+  );
+
+  const triggerResplitWithOptimistic = useCallback(
+    (id: string) => {
+      // Issue #121 / ADR 0027: 子の再分解。optimistic に decomposing pill を出す。
+      queryClient.setQueryData<Task[]>(dashboardKeys.tasks, (prev) =>
+        (prev ?? []).map((t) => (t.id === id ? { ...t, decomposeStatus: "decomposing" } : t)),
+      );
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.decomposeLog(id) });
+      // server 側で target が delete される + 新規子が insert されるので、
+      // 完了後 (成功 / 失敗 / skipped 問わず) に tasks を invalidate して refetch する。
+      // .finally は fire-and-forget の void 返却と互換 (例外は triggerResplit 内で潰している)。
+      void triggerResplit(id).finally(() => {
+        queryClient.invalidateQueries({ queryKey: dashboardKeys.tasks });
+      });
+    },
+    [queryClient],
+  );
+
+  return {
+    toggleDone: (id) => toggleDoneMutation.mutate(id),
+    updateBody: (id, body) => updateBodyMutation.mutate({ id, body }),
+    updateDependency: (id, dependsOnEventId) =>
+      updateDependencyMutation.mutate({ id, dependsOnEventId }),
+    updateCategory: (id, taskCategory) => updateCategoryMutation.mutate({ id, taskCategory }),
+    reorder,
+    createTaskWithAi,
+    createEvent: (input) => createEventMutation.mutateAsync(input).then(() => undefined),
+    updateEventProject: (id, projectId) => updateEventProjectMutation.mutate({ id, projectId }),
+    updateEvent: (id, patch) =>
+      updateEventMutation.mutateAsync({ id, patch }).then(() => undefined),
+    deleteEvent: (id) => deleteEventMutation.mutateAsync(id).then(() => undefined),
+    createProject: (input) => createProjectMutation.mutateAsync(input).then(() => undefined),
+    updateProject: (id, patch) =>
+      updateProjectMutation.mutateAsync({ id, patch }).then(() => undefined),
+    deleteProject: (id) => deleteProjectMutation.mutateAsync(id).then(() => undefined),
+    deleteTask: (id) => deleteTaskMutation.mutate(id),
+    triggerDecomposeWithOptimistic,
+    triggerResplitWithOptimistic,
+  };
+}

--- a/src/app/useDashboardQueries.ts
+++ b/src/app/useDashboardQueries.ts
@@ -1,0 +1,120 @@
+"use client";
+
+import { type QueryClient, useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import type { Event } from "@/entities/event/types";
+import type { Project } from "@/entities/project/types";
+import type { CorrectionFactor } from "@/entities/task/correction";
+import type { Task } from "@/entities/task/types";
+import {
+  useEventGateway,
+  useProjectGateway,
+  useTaskGateway,
+} from "@/shared/gateway/GatewayContext";
+import { isDone } from "@/shared/lib/task";
+
+/**
+ * Query key と「どの queryClient から書き換えるか」をここに集約する。
+ * 各ミューテーションは optimistic update を同じキーに対して適用する。
+ */
+export const dashboardKeys = {
+  projects: ["projects"] as const,
+  tasks: ["tasks"] as const,
+  events: ["events"] as const,
+  /** 詳細パネル (P3-15) で fetch する AI 分解の最新試行ログ。タスク id 単位で分離する。 */
+  decomposeLog: (taskId: string) => ["actionLog", "decompose", taskId] as const,
+  /** 見積もり補正倍率 (P3-9 / #93、ADR 0025): user-scoped、view 経由で取る。 */
+  correctionFactors: ["correctionFactors"] as const,
+};
+
+export type DashboardQueries = {
+  projectsQuery: ReturnType<typeof useQuery<Project[]>>;
+  tasksQuery: ReturnType<typeof useQuery<Task[]>>;
+  eventsQuery: ReturnType<typeof useQuery<Event[]>>;
+  correctionFactorsQuery: ReturnType<typeof useQuery<readonly CorrectionFactor[]>>;
+  /** projectsQuery.data ?? [] (参照安定) */
+  projects: Project[];
+  /** tasksQuery.data ?? [] (参照安定) */
+  tasks: Task[];
+  /** eventsQuery.data ?? [] (参照安定) */
+  events: Event[];
+  /** correctionFactorsQuery.data ?? [] (参照安定、未取得・失敗時は空配列 = 全タスク補正なし) */
+  correctionFactors: readonly CorrectionFactor[];
+  pendingTasks: Task[];
+  doneTasks: Task[];
+};
+
+/**
+ * AppShell の主データ fetch を集約した hook。
+ *
+ * - projects / tasks / events: 主要 3 リソース。各 mutation の optimistic update 先。
+ * - correctionFactors: 見積もり補正倍率 (ADR 0024 / 0025)。augmentation なので空 = 補正なし。
+ * - pendingTasks / doneTasks: tasks の派生。
+ *
+ * decomposeLogQuery は詳細パネル open 時のみ fetch する性質 (detailId 依存) のため
+ * AppShell 側に残し、ここでは key だけ提供する (`dashboardKeys.decomposeLog(id)`)。
+ */
+export function useDashboardQueries(): DashboardQueries {
+  const taskGateway = useTaskGateway();
+  const projectGateway = useProjectGateway();
+  const eventGateway = useEventGateway();
+
+  const projectsQuery = useQuery({
+    queryKey: dashboardKeys.projects,
+    queryFn: () => projectGateway.list(),
+  });
+  const tasksQuery = useQuery({
+    queryKey: dashboardKeys.tasks,
+    queryFn: () => taskGateway.list(),
+  });
+  const eventsQuery = useQuery({
+    queryKey: dashboardKeys.events,
+    queryFn: () => eventGateway.list(),
+  });
+
+  // P3-9 / #93: 見積もり補正倍率 (ADR 0024 / 0025)。
+  // 補正は augmentation (ADR 0013) なので未取得 / fetch 失敗は空配列扱い (= 全タスク補正なし)。
+  // staleTime を長めにして、タスク完了のたびに再取得しない (補正値の鋭敏な更新は不要)。
+  const correctionFactorsQuery = useQuery({
+    queryKey: dashboardKeys.correctionFactors,
+    queryFn: () => taskGateway.listCorrectionFactors(),
+    staleTime: 5 * 60_000,
+  });
+
+  const projects = useMemo(() => projectsQuery.data ?? [], [projectsQuery.data]);
+  const tasks = useMemo(() => tasksQuery.data ?? [], [tasksQuery.data]);
+  const events = useMemo(() => eventsQuery.data ?? [], [eventsQuery.data]);
+  const correctionFactors = useMemo<readonly CorrectionFactor[]>(
+    () => correctionFactorsQuery.data ?? [],
+    [correctionFactorsQuery.data],
+  );
+
+  const pendingTasks = useMemo(() => tasks.filter((t) => !isDone(t)), [tasks]);
+  const doneTasks = useMemo(() => tasks.filter((t) => isDone(t)), [tasks]);
+
+  return {
+    projectsQuery,
+    tasksQuery,
+    eventsQuery,
+    correctionFactorsQuery,
+    projects,
+    tasks,
+    events,
+    correctionFactors,
+    pendingTasks,
+    doneTasks,
+  };
+}
+
+/**
+ * projects / tasks / events を一括で invalidate する。
+ * 自動 seed 完了後 / sample data の reset / clearAll 後に呼ぶ。
+ */
+export async function invalidateDashboardData(queryClient: QueryClient): Promise<void> {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: dashboardKeys.projects }),
+    queryClient.invalidateQueries({ queryKey: dashboardKeys.tasks }),
+    queryClient.invalidateQueries({ queryKey: dashboardKeys.events }),
+  ]);
+}

--- a/src/app/useNowClock.ts
+++ b/src/app/useNowClock.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+/**
+ * SSR / mount 前の placeholder として使う「分単位の今」。朝 9 時を仮置きし、
+ * `nowMin` を初期描画時に DayTimeline 等に渡しても極端に違和感が出ないようにする。
+ * mount 後は実際の `Date.now()` で上書きされるため、最終 UI に残らない。
+ */
+const SSR_PLACEHOLDER_MIN_OF_DAY = 9 * 60;
+
+/** 1 分間隔の tick (ms)。DayTimeline の「今」位置が分単位で動けば十分。 */
+const TICK_INTERVAL_MS = 60_000;
+
+export type NowClock = {
+  /** ms epoch。SSR 時は 0、mount 後は実時刻。hydration mismatch 回避用に 0 sentinel を使う。 */
+  nowMs: number;
+  /** 0:00 起算の分数 (HH*60+MM)。SSR 時は SSR_PLACEHOLDER_MIN_OF_DAY。 */
+  nowMin: number;
+};
+
+/**
+ * SSR セーフな「今」hook。mount 前は 0/`9 * 60` の placeholder を返し、mount 後は
+ * 1 分ごとに実時刻に追従する。AppShell が `nowMs` を依存イベント比較・タイマー bind に、
+ * `nowMin` をタイムライン描画に使う。
+ */
+export function useNowClock(): NowClock {
+  const [nowMs, setNowMs] = useState<number>(0);
+
+  useEffect(() => {
+    /* eslint-disable react-hooks/set-state-in-effect */
+    setNowMs(Date.now());
+    /* eslint-enable react-hooks/set-state-in-effect */
+    const id = window.setInterval(() => setNowMs(Date.now()), TICK_INTERVAL_MS);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const nowMin = useMemo(() => {
+    if (nowMs === 0) return SSR_PLACEHOLDER_MIN_OF_DAY;
+    const d = new Date(nowMs);
+    return d.getHours() * 60 + d.getMinutes();
+  }, [nowMs]);
+
+  return { nowMs, nowMin };
+}

--- a/src/app/useTopTaskTimer.ts
+++ b/src/app/useTopTaskTimer.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+
+import type { PauseReason } from "@/entities/task/time-entries";
+import type { Task } from "@/entities/task/types";
+import type { TopTimerBinding } from "@/features/task-stack/TaskStack";
+import { useTaskTimer } from "@/features/task-stack/useTaskTimer";
+
+export type UseTopTaskTimerResult = {
+  /** TaskStack の TopTaskCard に渡すタイマー結線 props bundle。 */
+  topTimer: TopTimerBinding;
+  /** PauseReasonModal の表示状態。 */
+  pauseModalOpen: boolean;
+  setPauseModalOpen: (open: boolean) => void;
+  /** PauseReasonModal の選択 callback。modal を閉じて pause を開始する。 */
+  handlePauseSelect: (reason: PauseReason) => void;
+};
+
+/**
+ * スタックのトップタスクをタイマー対象としたタイマー hook。
+ *
+ * - `useTaskTimer` の上に被せて TopTimerBinding に整形する
+ * - pause 操作は modal で reason を取るため、bridge state (`pauseModalOpen`) を内包する
+ *
+ * `useTaskTimer` の戻り値が安定 (#151 で useMemo 化済み) なので、`topTimer` の
+ * useMemo 依存配列は `[timer]` でも spurious re-create は起きない。
+ */
+export function useTopTaskTimer(topTask: Task | null): UseTopTaskTimerResult {
+  const timer = useTaskTimer(topTask);
+  const [pauseModalOpen, setPauseModalOpen] = useState(false);
+
+  const topTimer = useMemo<TopTimerBinding>(
+    () => ({
+      elapsedSeconds: timer.elapsedSeconds,
+      pauseReason: timer.pauseReason,
+      onStart: () => {
+        void timer.start();
+      },
+      onPauseRequest: () => setPauseModalOpen(true),
+      onResume: () => {
+        void timer.resume();
+      },
+      onComplete: () => {
+        void timer.complete();
+      },
+    }),
+    [timer],
+  );
+
+  const handlePauseSelect = useCallback(
+    (reason: PauseReason) => {
+      setPauseModalOpen(false);
+      void timer.pause(reason);
+    },
+    [timer],
+  );
+
+  return { topTimer, pauseModalOpen, setPauseModalOpen, handlePauseSelect };
+}

--- a/src/features/tree-view/fallback.test.ts
+++ b/src/features/tree-view/fallback.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "vitest";
+
+import type { Project } from "@/entities/project/types";
+
+import { computeProjectOrderForTree, mergeTreeProjects } from "./fallback";
+
+const project = (id: string, overrides: Partial<Project> = {}): Project => ({
+  id,
+  name: id,
+  color: "#000",
+  isPrimary: false,
+  createdAt: "",
+  ...overrides,
+});
+
+describe("mergeTreeProjects", () => {
+  test("既知 slug は fallback で補完される", () => {
+    const result = mergeTreeProjects([], [{ projectId: "career" }, { projectId: "slo" }]);
+    expect(result.map((p) => p.id)).toEqual(["career", "slo"]);
+    expect(result.find((p) => p.id === "career")?.name).toBe("転職活動");
+    expect(result.find((p) => p.id === "slo")?.name).toBe("SLO推進");
+  });
+
+  test("未知 slug は素の id で補完される", () => {
+    const result = mergeTreeProjects([], [{ projectId: "unknown-slug" }]);
+    expect(result.map((p) => p.id)).toEqual(["unknown-slug"]);
+    expect(result[0]?.name).toBe("unknown-slug");
+  });
+
+  test("DB にある projects はそのまま、足りない slug だけ末尾に追加される", () => {
+    const dbProjects = [project("real")];
+    const result = mergeTreeProjects(dbProjects, [{ projectId: "real" }, { projectId: "career" }]);
+    expect(result.map((p) => p.id)).toEqual(["real", "career"]);
+  });
+
+  test("history の重複 projectId は重複追加しない", () => {
+    const result = mergeTreeProjects(
+      [],
+      [{ projectId: "career" }, { projectId: "career" }, { projectId: "slo" }],
+    );
+    expect(result.map((p) => p.id)).toEqual(["career", "slo"]);
+  });
+});
+
+describe("computeProjectOrderForTree", () => {
+  test("DB に projects があればその id 順", () => {
+    const dbProjects = [project("a"), project("b"), project("c")];
+    expect(computeProjectOrderForTree(dbProjects, [{ projectId: "z" }])).toEqual(["a", "b", "c"]);
+  });
+
+  test("DB が空なら history の projectId 順 (重複排除)", () => {
+    const order = computeProjectOrderForTree(
+      [],
+      [{ projectId: "career" }, { projectId: "slo" }, { projectId: "career" }],
+    );
+    expect(order).toEqual(["career", "slo"]);
+  });
+});

--- a/src/features/tree-view/fallback.ts
+++ b/src/features/tree-view/fallback.ts
@@ -1,0 +1,61 @@
+import type { Project } from "@/entities/project/types";
+
+/**
+ * Tree View の mock history が参照する旧 slug (`career` 等) の名称・色を、
+ * DB に該当 Project が無い場合の fallback として埋めるためのマップ。
+ * PROJECT_SEEDS を import すると循環が見えにくくなるので、ここで簡易定義する。
+ * history (mock) に現れる slug 群だけ埋めれば十分。
+ */
+const TREE_FALLBACK_BY_SLUG: ReadonlyMap<string, Project> = new Map([
+  ["career", { id: "career", name: "転職活動", color: "#E85D04", isPrimary: false, createdAt: "" }],
+  [
+    "loadtest",
+    { id: "loadtest", name: "負荷試験", color: "#0096C7", isPrimary: false, createdAt: "" },
+  ],
+  ["slo", { id: "slo", name: "SLO推進", color: "#2D9F45", isPrimary: true, createdAt: "" }],
+  ["tasuki", { id: "tasuki", name: "Tasuki", color: "#9B5DE5", isPrimary: false, createdAt: "" }],
+]);
+
+/**
+ * Tree View の mock history が参照する旧 slug を、
+ * 同名シードが DB にある場合はその Project として、無い場合は fallback として補完する。
+ * ProjectsProvider に渡す projects 配列を生成するための helper。
+ */
+export function mergeTreeProjects(
+  projects: readonly Project[],
+  history: readonly { projectId: string }[],
+): Project[] {
+  const known = new Set(projects.map((p) => p.id));
+  const missing = Array.from(
+    new Set(history.map((h) => h.projectId).filter((id) => !known.has(id))),
+  );
+  const result = [...projects];
+  for (const slug of missing) {
+    const seed = TREE_FALLBACK_BY_SLUG.get(slug);
+    result.push(
+      seed ?? {
+        id: slug,
+        name: slug,
+        color: "#52525b",
+        isPrimary: false,
+        createdAt: "",
+      },
+    );
+  }
+  return result;
+}
+
+/**
+ * Tree View に渡す projectOrder を返す。
+ * - DB にプロジェクトがあればその id 順
+ * - 無ければ mock history の projectId 順 (= 旧 PoC の挙動)
+ */
+export function computeProjectOrderForTree(
+  projects: readonly Project[],
+  history: readonly { projectId: string }[],
+): string[] {
+  if (projects.length === 0) {
+    return Array.from(new Set(history.map((h) => h.projectId)));
+  }
+  return projects.map((p) => p.id);
+}


### PR DESCRIPTION
## Summary

issue #152 の解消。AppShell.tsx (旧 889 行) を hook / helper に責務分離し、calendar 機能拡張 (#144 / #145 / #146) で増える mutation の差分が読みやすくなる土台を整えた。

**AppShell.tsx: 889 → 351 行 (-60%)**

挙動は一切変えていない。機械的な抽出のみ。

## なぜ今やるか

calendar 拡張で来るのは大量の mutation 系（subscribe / unsubscribe / auto-promote toggle / event promote / demote / external account add / remove…）。AppShell に追加し続けると優に 1500 行を超えて、PR diff が常に巨大ファイルに埋もれる。今ここで mutation を hook 化しておけば、calendar 拡張の各 PR は新 mutation を hook ファイルに append するだけで済む。

## 抽出した hook / helper

| 新ファイル | 役割 | 行数 |
|---|---|---|
| `src/app/useDashboardMutations.ts` | **本命**。12 mutation + AI trigger 派生 callback 2 個。各 mutation の optimistic update + onError ロールバック + onSettled invalidate + action_log 記録パターンを集約 | 480 |
| `src/app/useDashboardQueries.ts` | 4 query (projects / tasks / events / correctionFactors) + 派生 (pendingTasks / doneTasks)。`dashboardKeys` と `invalidateDashboardData` も export | 120 |
| `src/app/useTopTaskTimer.ts` | `useTaskTimer` の上に被せて TopTimerBinding に整形 + pause modal の bridge state | 60 |
| `src/app/useNowClock.ts` | SSR-safe な「今」hook。magic number `9 * 60` を `SSR_PLACEHOLDER_MIN_OF_DAY` に named const 化 | 45 |
| `src/app/useAutoSeed.ts` | 初回ログイン時の自動 sample seed effect | 43 |
| `src/features/tree-view/fallback.ts` | `mergeTreeProjects` / `computeProjectOrderForTree` / `TREE_FALLBACK_BY_SLUG` を Tree View 配下に移動 | 61 |
| `src/features/tree-view/fallback.test.ts` | 上記 helper の unit test (新規) | 58 |

## Before → After

```
Before: AppShell.tsx 1 ファイルに query / mutation / timer / seed / SSR placeholder /
        tree fallback が同居 (846 行)。新 mutation 追加は AppShell 巨大化を直撃。

After:  AppShell.tsx は hook 呼び出し + UI 状態 (panel 4 つ) + JSX に専念 (351 行)。
        mutation 追加は useDashboardMutations.ts への append。
        個別 hook は renderHook で unit test 可能な土台。
```

## Chunk 分割（commit 履歴）

リスク濃度ベースで 4 chunk に分けて段階的に push、各 chunk で CI green を確認してから次へ。

- `7539f02` Chunk 1: helpers + nowClock + autoSeed + tree-view/fallback 抽出
- `07e8d0a` Chunk 2: useDashboardQueries
- `1c37b30` Chunk 3 (本命): useDashboardMutations
- `b3a87a2` Chunk 4: useTopTaskTimer
- `281a633` Merge main (calendar 拡張 DB migration #164 を取り込み、コンフリクトなし)

## 関連 Issue

Closes #152

## Test plan

- [x] typecheck (`npm run typecheck`)
- [x] lint (`npm run lint`)
- [x] format (`npm run format:check`)
- [x] unit test (`npm test` — 501 passed)
- [x] build (`npm run build`)
- [x] e2e CI (chunk 単位で push → 各 chunk green 確認済み: shard 1/2 + 2/2)
- [x] Vercel preview deploy 成功（SSR / hydration 周り問題なし）