### PR TITLE
fix(ai): AI 分解の状態遷移を fire-and-forget 完了で必ず invalidate

### DIFF
--- a/e2e/phase3-ai-bypass-invariants.spec.ts
+++ b/e2e/phase3-ai-bypass-invariants.spec.ts
@@ -1,4 +1,11 @@
-import { createAdminClient, getTasksForUser, seedProject, seedTask } from "./db";
+import {
+  createAdminClient,
+  getProjectByName,
+  getTaskByTitle,
+  getTasksForUser,
+  seedProject,
+  seedTask,
+} from "./db";
 import { expect, test } from "./fixtures";
 
 /**
@@ -160,6 +167,107 @@ test.describe("Variant E core path 不変条件 (ADR 0016)", () => {
 
     // ⤷ 親タスク名が下ゾーンに継承される (ADR 0016 §6 の親 dep 継承と並ぶ表示原則)。
     await expect(topItem.getByText(`⤷ ${parent.title}`)).toBeVisible();
+  });
+
+  test("AddPanel タスク追加 → 楽観 'AI 分解中' pill が即時可視化、decompose 完了で親消えて子フラット表示 (リロード不要 / issue #167)", async ({
+    signedInPageWithProject: page,
+    projectName,
+    testUserId: userId,
+  }) => {
+    // 旧実装は (a) `createTaskMutation.onSuccess` の invalidate が起こす
+    // in-flight refetch が直後の `setQueryData('decomposing')` を上書きし、
+    // (b) `triggerDecompose` が fire-and-forget で `.finally` invalidate を
+    // 持たないため、server 側の decompose 完了が手動リロードまで反映されなかった。
+    //
+    // この test は両方の経路を semantic locator + `page.route` モックで踏む:
+    // 1. AddPanel から追加 → 'AI 分解中' pill が *即時* 可視化されること
+    // 2. mock 経由で server 側の DB 結果 (子 insert + 親 `decomposed`) を仕込んだ
+    //    あとに `/api/ai/decompose` が response → client `.finally` invalidate →
+    //    refetch → 親が Stack から消え、子 2 件がフラットに並ぶこと
+    //
+    // mock route は `AI_ENABLED=true` 相当の挙動 (server が DB を書く + 200 を返す)
+    // を最小限に再現する。実 AI 経路の中身 (Gemini 呼び出し / parser) は
+    // src/entities/task/decompose-server.test.ts のユニットでカバー済み (ADR 0014)。
+    const admin = createAdminClient();
+    const project = await getProjectByName(admin, userId, projectName);
+    const taskTitle = "AI 分解対象 (issue 167)";
+    const childTitles = ["分解された子 1", "分解された子 2"];
+
+    // decompose / categorize の両方を block する。release されるまで response を
+    // 返さない。これによって楽観 pill のフェーズと、完了後の遷移フェーズを
+    // テスト側で時間的に分離して観測できる。
+    let releaseProceed: () => void = () => {};
+    const proceed = new Promise<void>((resolve) => {
+      releaseProceed = resolve;
+    });
+
+    await page.route("**/api/ai/decompose", async (route) => {
+      await proceed;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, outcome: { kind: "decomposed", childIds: [] } }),
+      });
+    });
+    await page.route("**/api/ai/categorize", async (route) => {
+      // categorize は本テストの主役ではないが、`.finally(invalidate)` が両方の
+      // 経路から走るので、decompose と同じ proceed gate に揃えて競合させない。
+      await proceed;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ skipped: true, reason: "ai_disabled" }),
+      });
+    });
+
+    await page.getByRole("button", { name: "新規追加" }).click();
+    const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+    await addDialog.getByRole("tab", { name: "タスク" }).click();
+    await addDialog.getByLabel("タイトル").fill(taskTitle);
+    await addDialog.getByLabel("プロジェクト").selectOption({ label: projectName });
+    await addDialog.getByRole("button", { name: "追加" }).click();
+    await expect(addDialog).toHaveCount(0);
+
+    const stack = page.getByRole("list", { name: "タスクスタック" });
+    const top = stack.getByRole("listitem").filter({ hasText: taskTitle });
+    await expect(top).toBeVisible();
+
+    // Stage A (issue #167 の片方の修正): `createTaskWithAi` が
+    // `cancelQueries` → `setQueryData('decomposing')` の順で書くようになり、
+    // 並走する refetch に楽観値を上書きされず、'AI 分解中' pill が即時表示される。
+    // StatusPill は `role=status` + `aria-live=polite` で読み上げ対象 (a11y)。
+    await expect(top.getByRole("status").filter({ hasText: "AI 分解中" })).toBeVisible();
+
+    // server 側の最終状態を仕込む: 子 2 件 insert + 親 `decompose_status='decomposed'`。
+    // mock route 内ではなくテスト側で行うのは、Stage A の楽観 pill 観測中は
+    // 親が `decomposing` (cache) のまま見えていてほしいため。
+    const parent = await getTaskByTitle(admin, userId, taskTitle);
+    for (let i = 0; i < childTitles.length; i++) {
+      await seedTask(admin, {
+        userId,
+        projectId: project.id,
+        title: childTitles[i],
+        stackOrder: (parent.stack_order ?? 0) + i + 1,
+        parentTaskId: parent.id,
+      });
+    }
+    const { error: updateError } = await admin
+      .from("tasks")
+      .update({ decompose_status: "decomposed" })
+      .eq("id", parent.id);
+    expect(updateError).toBeNull();
+
+    // mock を release → /api/ai/decompose 200 → client `.finally(invalidate)` →
+    // tasks refetch → 親 (decomposed) が buildStackItems で除外され、子がフラットに並ぶ。
+    releaseProceed();
+
+    // Stage B (issue #167 のもう片方の修正): `triggerDecompose` の `.finally(invalidate)`
+    // が server 側完了後に refetch を投げる経路。これがないと cache が `decomposing`
+    // で固まり、手動リロードまで親が Stack に残る。
+    await expect(stack.getByRole("listitem").filter({ hasText: taskTitle })).toHaveCount(0);
+    for (const t of childTitles) {
+      await expect(stack.getByRole("listitem").filter({ hasText: t })).toBeVisible();
+    }
   });
 
   test("Top-only complete: 行カードに『完了』ボタンが無い / Top で完了すると Done リストに移る", async ({

--- a/e2e/phase3-ai-bypass-invariants.spec.ts
+++ b/e2e/phase3-ai-bypass-invariants.spec.ts
@@ -264,10 +264,18 @@ test.describe("Variant E core path 不変条件 (ADR 0016)", () => {
     // Stage B (issue #167 のもう片方の修正): `triggerDecompose` の `.finally(invalidate)`
     // が server 側完了後に refetch を投げる経路。これがないと cache が `decomposing`
     // で固まり、手動リロードまで親が Stack に残る。
-    await expect(stack.getByRole("listitem").filter({ hasText: taskTitle })).toHaveCount(0);
+    //
+    // 親 (decomposed) は Stack から消え、子 2 件だけがフラットに並ぶ。
+    // listitem 数 = 2 と各子の可視性 + `AI 分解中` pill 非可視で「親が listitem として
+    // 描画されていない」が担保される。子の下ゾーンには `⤷ ${taskTitle}` が出るので
+    // 親 title での filter は使えない (上の decomposed 親 + 子 3 件テストと同じ理由)。
+    await expect(stack.getByRole("listitem")).toHaveCount(childTitles.length);
     for (const t of childTitles) {
       await expect(stack.getByRole("listitem").filter({ hasText: t })).toBeVisible();
     }
+    // 楽観 pill (`role=status` 'AI 分解中') が消える = 親が Stack から外れた / cache が
+    // server 側完了状態に追従した、の二重確認 (子は decomposing pill を持たない)。
+    await expect(stack.getByRole("status").filter({ hasText: "AI 分解中" })).toHaveCount(0);
   });
 
   test("Top-only complete: 行カードに『完了』ボタンが無い / Top で完了すると Done リストに移る", async ({

--- a/src/app/useDashboardMutations.ts
+++ b/src/app/useDashboardMutations.ts
@@ -208,11 +208,13 @@ export function useDashboardMutations(): DashboardMutations {
     // DnD は optimistic で UI 側は onMutate で即反映、サーバー同期は背面で進める。
   });
 
+  // createTaskWithAi が cache を append + AI trigger 完了後に .finally invalidate
+  // するので、ここでは onSuccess invalidate を持たない (issue #167)。旧実装では
+  // onSuccess の invalidate がトリガする in-flight refetch と直後の
+  // setQueryData('decomposing') が競合し、refetch レスポンス (status='none')
+  // で楽観 pill が即座に上書きされていた。
   const createTaskMutation = useMutation({
     mutationFn: (input: CreateTaskInput) => taskGateway.create(input),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: dashboardKeys.tasks });
-    },
   });
 
   const createEventMutation = useMutation({
@@ -405,8 +407,11 @@ export function useDashboardMutations(): DashboardMutations {
       // server 側でも `decompose_status='decomposing'` に倒すが、UI に分解中 pill を
       // 即時出すため optimistic に cache を書き換える。AI_ENABLED=false / 失敗時は
       // server が `none` に戻す (decompose-server の guard 経路)。
-      // 既に invalidateQueries で refetch 中の cache に対しては map で上書き、
-      // refetch 前で entry が無ければ末尾に append する。
+      //
+      // issue #167: cancelQueries を挟むことで「他経路で in-flight な tasks refetch
+      // (例: focus 戻り後の自動 refetch / 並走するイベント refetch) が
+      // setQueryData('decomposing') を上書きする」競合を防ぐ。
+      await queryClient.cancelQueries({ queryKey: dashboardKeys.tasks });
       queryClient.setQueryData<Task[]>(dashboardKeys.tasks, (prev) => {
         const list = prev ?? [];
         const found = list.some((t) => t.id === created.id);
@@ -415,12 +420,20 @@ export function useDashboardMutations(): DashboardMutations {
           ? list.map((t) => (t.id === created.id ? { ...t, decomposeStatus: "decomposing" } : t))
           : [...list, updated];
       });
-      triggerDecompose(created.id);
+      // issue #167: server 側 decompose 完了後 (成功 / 失敗 / skipped 問わず) に
+      // tasks を invalidate して refetch する。これがないと cache が `decomposing`
+      // で固まり、親 `decomposed` への遷移と子フラット化が手動リロードまで反映されない。
+      // `triggerResplitWithOptimistic` と同じパターン (ADR 0027)。
+      void triggerDecompose(created.id).finally(() => {
+        queryClient.invalidateQueries({ queryKey: dashboardKeys.tasks });
+      });
       // P3-4 / ADR 0015: AI 初期ラベリングも同経路で fire-and-forget。
       // 失敗 / AI_ENABLED=false は server が `task_category=null` のまま残す
-      // (ADR 0013 augmentation only)。client 側の optimistic 反映はしない —
-      // category は UX 上「気づいたら埋まっている」体験で良い。
-      triggerCategorize(created.id);
+      // (ADR 0013 augmentation only)。client 側の optimistic 反映はしないが、
+      // 完了後に invalidate して AI ラベルを refetch で反映する (issue #167)。
+      void triggerCategorize(created.id).finally(() => {
+        queryClient.invalidateQueries({ queryKey: dashboardKeys.tasks });
+      });
     },
     [createTaskMutation, queryClient],
   );
@@ -434,7 +447,14 @@ export function useDashboardMutations(): DashboardMutations {
       );
       // 既存 log は陳腐化するので invalidate (新たな試行が完了したら再 fetch される)
       queryClient.invalidateQueries({ queryKey: dashboardKeys.decomposeLog(id) });
-      triggerDecompose(id);
+      // issue #167: server 側完了後 (成功 / 失敗 / skipped) に tasks / decomposeLog を
+      // invalidate して refetch する。これがないと「再分解」を押した後 UI が
+      // `decomposing` で固まり、親 `decomposed` 遷移と子フラット化、最新試行ログが
+      // 手動リロードまで反映されない (`createTaskWithAi` と同じ pattern)。
+      void triggerDecompose(id).finally(() => {
+        queryClient.invalidateQueries({ queryKey: dashboardKeys.tasks });
+        queryClient.invalidateQueries({ queryKey: dashboardKeys.decomposeLog(id) });
+      });
     },
     [queryClient],
   );

--- a/src/features/task-stack/triggerCategorize.ts
+++ b/src/features/task-stack/triggerCategorize.ts
@@ -4,18 +4,23 @@
  * AppShell の onCreateTask 成功後にこれを呼ぶ。await しない:
  * - latency をタスク追加 UX に乗せない (ADR 0013 augmentation only)
  * - AI 失敗 / `AI_ENABLED=false` で 200 skipped が返っても呼び出し元は知らない
- * - `task_category` は server 側で fire-and-forget に書かれる。UI には数秒後の
- *   refetch (action_log invalidate / TanStack Query refetchOnFocus 等) で反映される
+ * - `task_category` は server 側で fire-and-forget に書かれる
  *
- * 戻り値は無し。例外も握り潰す (fire-and-forget の契約)。
+ * 戻り値が `Promise<void>` なのは、呼び出し元が `.finally(...)` で
+ * tasks query invalidate (= AI ラベルの refetch トリガ) を起こすため (issue #167)。
+ * await しないのは契約通り (latency を UI に乗せない)。例外も握り潰す。
  */
-export function triggerCategorize(taskId: string): void {
-  void fetch("/api/ai/categorize", {
+export function triggerCategorize(taskId: string): Promise<void> {
+  return fetch("/api/ai/categorize", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ task_id: taskId }),
-  }).catch((err) => {
-    // 失敗しても core は止まらない。dev では console に出して気付けるようにする
-    console.error("[ai/categorize] fire-and-forget failed", err);
-  });
+  })
+    .then(() => {
+      // outcome は使わない。完了タイミングだけが意味を持つ (ADR 0013)。
+    })
+    .catch((err) => {
+      // 失敗しても core は止まらない。dev では console に出して気付けるようにする
+      console.error("[ai/categorize] fire-and-forget failed", err);
+    });
 }

--- a/src/features/task-stack/triggerDecompose.ts
+++ b/src/features/task-stack/triggerDecompose.ts
@@ -9,16 +9,24 @@
  * UI に分解中 pill を即時出したい場合は呼び出し元で optimistic update を別途行うこと
  * (ADR 0017 Notes / Variant E status pill / P3-7)。
  *
- * 戻り値は無し。例外も握り潰す (fire-and-forget の契約)。
+ * 戻り値が `Promise<void>` なのは、呼び出し元 (`createTaskWithAi` /
+ * `triggerDecomposeWithOptimistic`) が `.finally(...)` で server 側完了後の
+ * tasks query invalidate (= 親 `decomposed` への遷移と子フラット化の refetch トリガ)
+ * を起こすため (issue #167)。await しないのは契約通り (latency を UI に乗せない)。
+ * 例外も握り潰す。
  */
-export function triggerDecompose(taskId: string): void {
-  // void で結果を捨てる。catch で error も握り潰す
-  void fetch("/api/ai/decompose", {
+export function triggerDecompose(taskId: string): Promise<void> {
+  return fetch("/api/ai/decompose", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ task_id: taskId }),
-  }).catch((err) => {
-    // 失敗しても core は止まらない。dev では console に出して気付けるようにする
-    console.error("[ai/decompose] fire-and-forget failed", err);
-  });
+  })
+    .then(() => {
+      // outcome (decomposed / skipped / failed) は使わない。完了したことだけが
+      // 呼び出し元の `.finally` invalidate で意味を持つ (ADR 0013)。
+    })
+    .catch((err) => {
+      // 失敗しても core は止まらない。dev では console に出して気付けるようにする
+      console.error("[ai/decompose] fire-and-forget failed", err);
+    });
 }


### PR DESCRIPTION
## 概要 (What)

タスク追加 / 再分解後、AI 分解の状態遷移 (`decomposing` → `decomposed` / 親消滅・子フラット化) が手動リロードまで UI に反映されない不具合を修正。あわせて楽観的「AI 分解中」pill が一瞬で消える race も解消。

## 関連 Issue

Closes #167

## 背景 (Why)

`refetchOnWindowFocus: false` 設定下で、AI fire-and-forget 経路が **server 側完了を tasks query に反映する手段を持っていなかった** のが核。

旧実装には2つの欠陥があった:

1. **楽観 pill が即座に消える**: `createTaskMutation.onSuccess` の `invalidateQueries` が起こす in-flight refetch が、直後の `setQueryData('decomposing')` をレスポンス (`status='none'`) で上書きする race。
2. **decomposing で固まる**: `triggerDecompose` は `void` 返却の fire-and-forget で、server 側が `decompose_status='decomposed'` に倒した後も client 側の cache が更新されない。`triggerResplitWithOptimistic` (ADR 0027) は `.finally(invalidate)` を持っていたが、`createTaskWithAi` / `triggerDecomposeWithOptimistic` には無かった。

結果として「AI 分解中 pill が出ない / 親が Stack に残り続ける / 手動リロードで初めて子フラット化が見える」という、Phase 3 で目指す「裏で勝手に整える」体験が破壊されていた。

## Before → After (概念・フロー・メンタルモデル)

**Before:**

```
createTaskWithAi:
  await mutateAsync         # onSuccess invalidate → in-flight refetch 開始
  setQueryData('decomposing')  # ← refetch レスポンスで即上書き
  triggerDecompose(id)      # void、完了後の通知経路なし
  triggerCategorize(id)     # 同上

→ 楽観 pill が一瞬で消える / 永遠に decomposing
```

**After:**

```
createTaskWithAi:
  await mutateAsync         # onSuccess invalidate を撤去
  await cancelQueries       # 並走 refetch を抑止
  setQueryData('decomposing')  # 上書きされない
  triggerDecompose(id).finally(invalidate)  # 完了後に refetch
  triggerCategorize(id).finally(invalidate)

→ 楽観 pill 即時表示 / server 完了で自動遷移
```

`triggerDecompose` / `triggerCategorize` を `Promise<void>` に揃えたことで、`triggerResplit` (ADR 0027) と同じ `.finally(invalidate)` パターンに統一。AI fire-and-forget 経路の race guard pattern が3つで揃った。

## 追加したテスト (How verified)

- [x] `e2e/phase3-ai-bypass-invariants.spec.ts` に `page.route` モック経路を追加。AddPanel 追加 → 楽観「AI 分解中」pill (semantic locator: `role=status`) 即時可視化 → server 完了 (admin client で子 insert + 親 `decomposed` 化) → 親 Stack 消滅・子フラット化までを **リロードなし** で踏む。
- [x] 既存 unit tests 501 件 + lint + typecheck + format 全通過。
- [ ] e2e は local Supabase 必須のため push 後 CI で確認。

## リリース前チェックリスト (When / Before merge)

該当なし (DB / env / flag 変更なし)。

## このPRの範囲外 (Out of scope)

- 大量分解時の進捗バー UX (#166)
- AI 機能の race guard pattern を ADR で明文化する件 (#157 と合わせる予定): 今回は既存パターン (ADR 0027 と同形) を3経路に揃えただけなので、新規 ADR は起票しない判断。設計判断ではなく一貫性の修正。


---
_Generated by [Claude Code](https://claude.ai/code/session_01QS6cd8vyzb4fPrMMuD1V98)_