### PR TITLE
ci(supabase): 本番 deploy 経路を CI で再生して PK 衝突 / rebase 不在を早期 fail (Closes #178)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,11 +156,23 @@ jobs:
             -x studio,inbucket,storage-api,imgproxy,edge-runtime,logflare,vector,pgsodium,realtime
       - name: Lint SQL
         run: supabase db lint
-      - name: Reset DB (re-apply all migrations from scratch)
+      - name: Reset DB sanity check (re-apply all migrations from scratch)
+        # PR では下の本番 deploy 経路再生フローで base 適用 → migration up → snapshot を行うため、
+        # ここでの fresh re-apply は冗長。main への push でのみ走らせる sanity check として残す。
+        if: github.event_name != 'pull_request'
         run: supabase db reset --no-seed
 
       # ===== ADR 0023: PR migration diff comment =====
-      # 以下のステップは pull_request イベントのみで動かす (main への push では diff 元がない)。
+      # PR の場合は本番 `supabase db push` と同じ deploy 経路を再生する:
+      #   1. base migrations のみで `db reset` → production の現在状態を再現
+      #   2. snapshot (base) を取得
+      #   3. HEAD migrations を復元
+      #   4. `supabase migration up` で PR 新規分のみを追加適用
+      #      → ここで PK 衝突 (同 timestamp prefix) や out-of-order があれば
+      #        CLI が production と同じ error で fail し、CI も fail する
+      #   5. snapshot (PR) を取得 → diff / 規約検査 / コメント投稿
+      # `supabase start` 直後は HEAD migrations 適用済み状態だが、下の base 復元 + db reset で
+      # 上書きするので start 直後の状態には依存しない。
 
       # Supabase local stack は PG 17 を使うので、pg_dump も 17 を入れる。
       # Ubuntu runner default の 16 だと server version mismatch で aborting。
@@ -184,20 +196,12 @@ jobs:
           db_url=$(grep '^DB_URL=' /tmp/sb.env | cut -d= -f2- | tr -d '"')
           echo "DATABASE_URL=$db_url" >> "$GITHUB_ENV"
 
-      - name: Snapshot PR-state (HEAD migrations applied)
-        if: github.event_name == 'pull_request'
-        run: |
-          mkdir -p /tmp/migration-diff
-          bash scripts/db-migration-diff/snapshot.sh \
-            "$DATABASE_URL" /tmp/migration-diff/pr.json
-          pg_dump --schema-only --schema=public --no-owner --no-privileges \
-            --dbname="$DATABASE_URL" > /tmp/migration-diff/pr.sql
-
       - name: List new / missing migration files vs base
         if: github.event_name == 'pull_request'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
+          mkdir -p /tmp/migration-diff
           # 3-dot 構文 = fork point (merge base) からの差分。「PR ブランチで追加された」分。
           git diff --name-only --diff-filter=A "$BASE_SHA"...HEAD -- supabase/migrations/ \
             > /tmp/migration-diff/new_migrations.txt || true
@@ -211,7 +215,7 @@ jobs:
           echo "missing (need rebase) migrations:"
           cat /tmp/migration-diff/missing_migrations.txt || true
 
-      - name: Restore base migrations and reset DB
+      - name: Restore base migrations and reset DB to base state
         if: github.event_name == 'pull_request'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -235,6 +239,22 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           git checkout HEAD -- supabase/migrations/
+
+      - name: Apply PR migrations on top of base (production deploy path)
+        # 本番 `supabase db push` と同じ経路: base 適用済みの schema_migrations に対して、
+        # PR で追加された migration のみを `supabase migration up` で追加適用する。
+        # PK 衝突 (同 timestamp prefix) や out-of-order を CLI が拒否すれば、ここで CI が
+        # production と同じ error で fail する。失敗時は exit code がそのまま伝播し job が落ちる。
+        if: github.event_name == 'pull_request'
+        run: supabase migration up
+
+      - name: Snapshot PR-state (HEAD migrations applied)
+        if: github.event_name == 'pull_request'
+        run: |
+          bash scripts/db-migration-diff/snapshot.sh \
+            "$DATABASE_URL" /tmp/migration-diff/pr.json
+          pg_dump --schema-only --schema=public --no-owner --no-privileges \
+            --dbname="$DATABASE_URL" > /tmp/migration-diff/pr.sql
 
       - name: Compute schema diff
         if: github.event_name == 'pull_request'

--- a/docs/adr/0023-pr-migration-diff-auto-comment.md
+++ b/docs/adr/0023-pr-migration-diff-auto-comment.md
@@ -45,13 +45,19 @@ sticky コメントとして PR に投稿する。
   - `❌` 新規 view / matview に `security_invoker = true` が指定されていない（postgres の view は
     未指定だと **definer 権限で評価され RLS をバイパス**するため、kozutsumi では原則必須）
   - `❌` 既存 view の `security_invoker` が `true → false` に変更された（RLS 迂回経路ができる）
+  - `❌` main にあって HEAD に無い migration がある（rebase 不在 / PR ブランチが古い）
   - `⚠️` `public` の新テーブルで owner-only ポリシー 4 種（select / insert / update / delete）が揃っていない
   - `⚠️` 外部キーの ON DELETE policy が未指定（`NO ACTION` のまま）
 - `❌` が一つでもあれば workflow は fail（job exit code 非ゼロ）。`⚠️` は警告のみ
 - 比較は **PR の HEAD vs main の現 HEAD (`github.event.pull_request.base.sha`)** で行う。
   fork point ではなく現 HEAD と比較するのは **「今この PR を merge した時の最終スキーマ」を
-  示すため**。副次効果として、main にあって HEAD に無い migration があれば
-  「rebase が必要」シグナルとしてコメント冒頭に warning を出す（PR ブランチが古いことを検知できる）
+  示すため**
+- migration の適用は **本番 `supabase db push` と同じ deploy 経路を再生**する:
+  base migrations のみで `supabase db reset --no-seed` → base snapshot → HEAD migrations 復元
+  → `supabase migration up` で PR 新規分のみ追加適用 → PR snapshot。
+  両方を fresh `db reset` で取ると「base に PR 新規分を**追加適用**する」状況を再現できず、
+  PK 衝突（同 timestamp prefix）や out-of-order を CLI が拒否するケースが production まで
+  気づかない。`migration up` で本番経路を踏むことで CLI 自身が production と同じ error を吐く
 - main 状態への巻き戻しは `git restore --source="$BASE_SHA" --worktree --staged --
   supabase/migrations/` で行う（`git checkout <ref> --` は overlay モードで PR が追加した
   新規ファイルを消せないため、base 状態が再現できない）
@@ -92,9 +98,16 @@ sticky コメントとして PR に投稿する。
 既知の問題が混入するか」** で判定する:
 
 - `❌`: merge → workflow 手動 trigger で本番に流すと **必ず壊れる / セキュリティ違反になる**
-  （NOT NULL violation / RLS なし / enum 値削除）
+  （NOT NULL violation / RLS なし / enum 値削除 / rebase 不在で merge 後の本番 `db push` 順序破綻）
 - `⚠️`: 規約上望ましくないが、merge しても直ちに壊れない（owner policy 不足は他のクライアントが
   ないため即時の漏洩にはならない / ON DELETE 未指定は意図的なケースもありうる）
+
+rebase 不在 (missing migrations) を `❌` 扱いにする根拠: CI フロー側は base 適用 →
+`migration up` で PR 新規分のみ追加適用するため、PR ブランチに main 側の migration が
+欠けていても **CI 自体は通ってしまう**（PR ブランチの migration 集合だけで一貫しているため）。
+しかし merge 後の本番 `db push` は merge commit の `supabase/migrations/` をすべて適用するので、
+欠けていた main 側の migration が遅れて適用される = `schema_migrations.version` の順序が崩れる。
+本番に出てから気づく経路を CI で塞ぐため `❌` で fail させる。
 
 `⚠️` を fail に格上げするかどうかは運用しながら判断する（本 ADR では含めない）。
 
@@ -144,3 +157,16 @@ sticky コメントとして PR に投稿する。
       （main にあって HEAD に無い migration を検出してリスト表示）
     - 生 diff 比較前に pg_dump 17 の `\restrict` / `\unrestrict` ランダムトークンを除去
       （差分ゼロでも 2 行ノイズが出る問題の解消）
+  - **2026-05-04 改訂** (Closes #178):
+    - **本番 deploy 経路の再生に変更**: 旧実装は PR / base 両方とも `supabase db reset --no-seed`
+      で fresh 適用してから snapshot を取っていた。これは diff 比較目的としては正しいが、
+      本番 `supabase db push`（既存 schema_migrations に新規分のみ追加適用）の経路を再生できず、
+      PK 衝突（同 timestamp prefix）や out-of-order が production まで気づかない問題があった。
+      新フロー: base 適用 → base snapshot → HEAD migrations 復元 → `supabase migration up`
+      で PR 新規分のみ追加適用 → PR snapshot。`migration up` が CLI レベルで失敗すれば
+      production と同じ error で CI も fail する
+    - **rebase 不在（missing migrations）を `⚠️` → `❌` に格上げ**: 旧実装はコメント冒頭の
+      警告止まりで CI fail しなかった。merge 後の本番 `db push` で順序破綻リスクがあるため
+      CI 段階で止める。`compare.mjs` の `runAssertions` に `missing-migrations` error を追加
+    - main への push (`pull_request` 以外) では `db reset --no-seed` の sanity check を残す
+      （PR 経路の `migration up` は走らないため、fresh re-apply が壊れていないことの担保が必要）

--- a/scripts/db-migration-diff/compare.mjs
+++ b/scripts/db-migration-diff/compare.mjs
@@ -47,7 +47,7 @@ const missingMigrations = splitLines(missingMigrationsRaw);
 const isTable = (t) => (t.kind ?? "table") === "table";
 
 const report = buildReport(base, pr);
-const assertions = runAssertions(report, pr);
+const assertions = runAssertions(report, pr, missingMigrations);
 const md = renderMarkdown({
   report,
   assertions,
@@ -159,10 +159,24 @@ function shallowEqual(a, b) {
 
 // ---- Assertions (kozutsumi 規約チェック) ----
 
-function runAssertions(report, prSnapshot) {
+function runAssertions(report, prSnapshot, missingMigrations = []) {
   const errors = [];
   const warnings = [];
   const oks = [];
+
+  // ❌ main にあって PR ブランチに無い migration がある (rebase 不在)
+  // base 適用 → `supabase migration up` で PR 新規分のみ追加適用する CI フローでは、
+  // missing migration があっても apply 自体は通ってしまう (PR ブランチに含まれる migration の
+  // 集合だけで一貫しているため)。一方で merge 後の本番 `db push` は merge commit の
+  // supabase/migrations/ をすべて適用するため、欠けていた main 側の migration が遅れて
+  // 適用される = schema_migrations の version 順序が崩れる。これを CI で止める。
+  if (missingMigrations.length > 0) {
+    errors.push({
+      kind: "missing-migrations",
+      message: `main に ${missingMigrations.length} 件の migration があり、このブランチに含まれていません (rebase 不在)`,
+      fix: "main を取り込んで rebase する。main 側の migration を取り込んだ上で、自分の新規 migration の timestamp が main 最新より後になっているか確認する",
+    });
+  }
 
   // ❌ public の新テーブルに RLS が有効化されていない (view / matview は対象外)
   for (const t of report.tables.added) {
@@ -300,9 +314,10 @@ function renderMarkdown({ report, assertions, schemaDiff, newMigrations, missing
   lines.push("");
 
   // ---- rebase 警告 (main にあって HEAD に無い migration を検出) ----
+  // 検査セクションでも ❌ として出すが、最上部に出すことで PR を開いた時に最初に目に入る。
   if (missingMigrations.length > 0) {
     lines.push(
-      `> ⚠️ **main に ${missingMigrations.length} 件の migration があり、このブランチに含まれていません**。`,
+      `> ❌ **main に ${missingMigrations.length} 件の migration があり、このブランチに含まれていません**（CI fail）。`,
     );
     lines.push(">");
     lines.push(


### PR DESCRIPTION
## 概要 (What)

PR の CI で migration を **本番 `supabase db push` と同じ deploy 経路で再生**するよう step 順を変更し、PK 衝突 / out-of-order / rebase 不在を CI で先回り検知できるようにする。

## 関連 Issue

Closes #178

## 背景 (Why)

PR #176 のレビュー中に挙がった「DB migration が main と衝突する → マイグレーション実行するまで気づかない」問題への対応。

旧フローは PR / base の両方とも `supabase db reset --no-seed` で fresh 適用してから snapshot を取っており、これは ADR-0023 の diff 比較目的としては正しいが、**本番 `supabase db push`（既存 schema_migrations に新規分のみ追加適用）の経路を再生できていなかった**。そのため:

- (A) PK 衝突（同一 timestamp prefix のファイルが main と PR の両方で追加された場合）
- (B) Out-of-order（PR の新規 migration timestamp < main の最新 timestamp）

が production まで気づかない可能性があった。

加えて (C) rebase 不在（main にあって PR に無い migration）はコメント冒頭の `⚠️` 警告のみで CI fail せず、merge 後の本番 `db push` で順序破綻するリスクがあった。

詳しい議論経緯と判断粒度判定（ADR-0023 改訂で対応する根拠）は #178 を参照。

## Before → After (概念・フロー・メンタルモデル)

**Before:** CI は PR / base 両方を `db reset` で fresh 適用 → diff のみ取得。PK 衝突や順序破綻は production の `db push` まで気づかない。rebase 不在は `⚠️` 表示だけで pass。

**After:** CI は **本番 deploy 経路を再生**:

1. base migrations のみで `db reset --no-seed` (= production の現在状態)
2. base snapshot
3. HEAD migrations 復元
4. **`supabase migration up`** で PR 新規分のみ追加適用 (= 本番 `db push` と同経路)
5. PR snapshot → diff / 規約検査 / コメント投稿

step 4 で CLI が PK 衝突 / out-of-order を拒否すれば、CI が production と同じ error で fail する。検知ロジックを CI 側にカスタム実装せず、CLI 自身を真の判定者とすることで CLI バージョン更新にも自動追従する。

合わせて missing migrations を `⚠️` → `❌` に格上げ（compare.mjs の `runAssertions` に追加）。

## 追加したテスト (How verified)

- [x] `node --check scripts/db-migration-diff/compare.mjs` で構文確認
- [x] `npm run format:check` 通過
- [x] `compare.mjs` のローカル smoke test
  - missing migrations 1 件入力 → exit 1, ❌ at top + 検査セクションに表示
  - missing migrations なし → exit 0
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` で `.github/workflows/ci.yml` の YAML 構造を検証
- [ ] **本 PR の CI run 自体**で新フローが動くこと（migration 変更ナシなので `supabase` job は走らないが、main push 時の sanity check は変わらず動く）
- [ ] フォローアップ: 故意に同 timestamp / 過去 timestamp / 欠損ファイルを含む別ブランチを作って、`supabase migration up` 由来の error または compare.mjs の `❌` で CI が fail することを確認（issue #178 の動作確認項目）

## リリース前チェックリスト (When / Before merge)

- [x] ドキュメント (ADR-0023) を更新した — Decision 節に deploy 経路再生 + missing migrations `❌`、Consequences の線引きに格上げ根拠、改訂履歴に 2026-05-04 項目を追記

## このPRの範囲外 (Out of scope)

- functions / triggers の構造化スナップショット対応 → #177 で別 PR
- ローカル pre-push hook での migration 順序検知（main の最新を取り込まないと比較に意味が無いので CI 側に寄せる方針）
- Migration の自動適用化（ADR-0019 の手動 trigger + approval は維持）


---
_Generated by [Claude Code](https://claude.ai/code/session_01QCSnurX9aEVGppBARHmaHr)_