### PR TITLE
ci(supabase): migration diff の構造化対象に functions / triggers を追加 (Closes #177)

### DIFF
--- a/docs/adr/0023-pr-migration-diff-auto-comment.md
+++ b/docs/adr/0023-pr-migration-diff-auto-comment.md
@@ -37,7 +37,12 @@ sticky コメントとして PR に投稿する。
   取った構造化スナップショットの diff の両方を出す
 - 構造化スナップショットの対象: tables (relkind in `r`/`v`/`m` を `kind` で識別) /
   columns / constraints / foreign_keys / indexes / policies / enums / views
-  (definition + `security_invoker` / `security_barrier` reloptions)
+  (definition + `security_invoker` / `security_barrier` reloptions) /
+  functions (`pg_proc` から `args` / `return_type` / `body` / `security_definer` /
+  `volatility` / `comment`、`pronamespace = public` のみ。同名異シグネチャは key に
+  `args` を含めて別物として扱う) /
+  triggers (`pg_trigger` から `tgisinternal = false` でユーザー定義のみ。
+  `timing` / `event` / `level` / `function_name` を `tgtype` bitmask から分解)
 - 規約チェック (`❌` / `⚠️` / `✅`):
   - `❌` `public` の新テーブルに RLS が有効化されていない
   - `❌` カラム追加で NOT NULL かつ default なし（既存行で fail）
@@ -45,6 +50,10 @@ sticky コメントとして PR に投稿する。
   - `❌` 新規 view / matview に `security_invoker = true` が指定されていない（postgres の view は
     未指定だと **definer 権限で評価され RLS をバイパス**するため、kozutsumi では原則必須）
   - `❌` 既存 view の `security_invoker` が `true → false` に変更された（RLS 迂回経路ができる）
+  - `❌` 新規 function に `SECURITY DEFINER` がついている（`prosecdef = true`）。
+    所有者権限で実行され RLS をバイパスするため、kozutsumi の関数は `SECURITY INVOKER`
+    （または SECURITY 句省略 = postgres default INVOKER）が原則
+  - `⚠️` 既存 function の `prosecdef` が `false → true` に変更された（RLS 迂回経路ができる）
   - `❌` main にあって HEAD に無い migration がある（rebase 不在 / PR ブランチが古い）
   - `⚠️` `public` の新テーブルで owner-only ポリシー 4 種（select / insert / update / delete）が揃っていない
   - `⚠️` 外部キーの ON DELETE policy が未指定（`NO ACTION` のまま）
@@ -84,8 +93,8 @@ sticky コメントとして PR に投稿する。
 - **CI 時間が +2〜3 分**。`supabase start` が支配的（2 分強）。`supabase/migrations/**` を
   変更する PR でしか走らないので、頻度は低い
 - **構造化スナップショットのカバレッジは限定的**。本 ADR では columns / tables / constraints /
-  foreign_keys / indexes / policies / enums / views(definition + reloptions) のみ対象。
-  functions / triggers / sequences は生 diff のみ（必要になったら別 ADR で拡張）
+  foreign_keys / indexes / policies / enums / views(definition + reloptions) /
+  functions / triggers のみ対象。sequences は生 diff のみ（必要になったら別 ADR で拡張）
 - **規約チェックは false positive を起こしうる**。例外的に RLS を意図的に外したい場合の
   override 機構は持たない（必要になったら別 ADR で扱う）
 - **fork PR からの実行**は制限される。`pull_request` トリガーで `pull-requests: write` 権限を
@@ -136,7 +145,9 @@ rebase 不在 (missing migrations) を `❌` 扱いにする根拠: CI フロー
 - 本 ADR は **migration の可視化と自動レビュー** が目的。本番への適用フローは ADR-0019 の
   手動 workflow に従う（自動適用に寄せる ADR ではない）
 - 将来見直す条件:
-  - 構造化スナップショットの対象を functions / triggers に広げたくなった
+  - 構造化スナップショットの対象を sequences に広げたくなった
+  - triggers の規約チェック（命名 / SECURITY DEFINER 含む trigger 関数の検出強化等）を
+    入れたくなった（kozutsumi 規約として固まってから）
   - `⚠️` レベルの違反も fail にしたくなった（例: RLS policy 不足を厳格化）
   - Supabase CLI の `db diff` が pg_dump diff を超える品質になった
 - 改訂履歴:
@@ -157,6 +168,15 @@ rebase 不在 (missing migrations) を `❌` 扱いにする根拠: CI フロー
       （main にあって HEAD に無い migration を検出してリスト表示）
     - 生 diff 比較前に pg_dump 17 の `\restrict` / `\unrestrict` ランダムトークンを除去
       （差分ゼロでも 2 行ノイズが出る問題の解消）
+  - **2026-05-04 改訂** (Closes #177):
+    - **構造化スナップショットに functions / triggers を追加**。PR #176 の function-only
+      migration (`fn_set_subscription_auto_promote` 追加) で構造化サマリが「全カテゴリ変更なし」
+      になった問題への対応。`pg_proc` から `args` / `return_type` / `body` /
+      `security_definer` / `volatility` / `comment`、`pg_trigger` から `timing` / `event` /
+      `level` / `function_name` を取得し、サマリ表に「関数」「トリガー」行と新規詳細セクションを追加
+    - **`SECURITY DEFINER` 検査を追加**。新規 function に `prosecdef = true` がついていれば
+      `❌` で fail（views の `security_invoker` と同じく RLS 迂回経路を塞ぐ規約）。既存
+      function の `false → true` は `⚠️` warning（merge 即破壊ではないが ADR 根拠を要求する）
   - **2026-05-04 改訂** (Closes #178):
     - **本番 deploy 経路の再生に変更**: 旧実装は PR / base 両方とも `supabase db reset --no-seed`
       で fresh 適用してから snapshot を取っていた。これは diff 比較目的としては正しいが、

--- a/scripts/db-migration-diff/compare.mjs
+++ b/scripts/db-migration-diff/compare.mjs
@@ -95,6 +95,18 @@ function buildReport(before, after) {
     enums: diffEnums(before.enums, after.enums),
     // views は view / matview 専用 (definition / security_invoker / security_barrier を含む)
     views: diffByKey(before.views ?? [], after.views ?? [], (v) => `${v.schema}.${v.name}`),
+    // functions: 同名異シグネチャを別物として扱うため key に args を含める
+    functions: diffByKey(
+      before.functions ?? [],
+      after.functions ?? [],
+      (f) => `${f.schema}.${f.name}(${f.args ?? ""})`,
+    ),
+    // triggers: 同一テーブル内で trigger 名はユニーク
+    triggers: diffByKey(
+      before.triggers ?? [],
+      after.triggers ?? [],
+      (t) => `${t.schema}.${t.table}.${t.name}`,
+    ),
   };
 }
 
@@ -261,6 +273,35 @@ function runAssertions(report, prSnapshot, missingMigrations = []) {
     }
   }
 
+  // ❌ 新規 function に SECURITY DEFINER がついている
+  // SECURITY DEFINER だと所有者 (= postgres) 権限で実行され、呼び出し元の RLS をバイパスする。
+  // kozutsumi の関数は SECURITY INVOKER (postgres default) が原則。
+  for (const f of report.functions.added) {
+    if (f.schema !== "public") continue;
+    if (f.security_definer) {
+      errors.push({
+        kind: "function-security-definer",
+        message: `\`${f.schema}.${f.name}(${f.args ?? ""})\` が \`SECURITY DEFINER\` で定義されています`,
+        fix: "`CREATE FUNCTION ... SECURITY INVOKER AS $$ ... $$;` で定義（または SECURITY 句を省略）。RLS を迂回する必要がある場合は ADR で根拠を残す",
+      });
+    } else {
+      oks.push(
+        `\`${f.schema}.${f.name}(${f.args ?? ""})\` は \`SECURITY INVOKER\` で定義されている`,
+      );
+    }
+  }
+
+  // ⚠️ 既存 function の security_definer が false → true に変更された (RLS 迂回経路ができる)
+  for (const m of report.functions.modified) {
+    if (!m.before.security_definer && m.after.security_definer) {
+      warnings.push({
+        kind: "function-security-definer-added",
+        message: `\`${m.after.schema}.${m.after.name}(${m.after.args ?? ""})\` で \`SECURITY DEFINER\` が付与されました (false → true)`,
+        fix: "RLS 迂回経路ができるため原則 INVOKER を維持する。意図的に付ける場合は ADR で根拠を残す",
+      });
+    }
+  }
+
   // ⚠️ 新規 public テーブルに owner-only ポリシー 4 種が揃っていない (table のみ対象)
   const policiesByTable = new Map();
   for (const p of prSnapshot.policies ?? []) {
@@ -358,6 +399,8 @@ function renderMarkdown({ report, assertions, schemaDiff, newMigrations, missing
   lines.push(`| インデックス | ${summarizeSimple(report.indexes)} |`);
   lines.push(`| RLS / ポリシー | ${summarizePolicies(tablesOnly, report.policies)} |`);
   lines.push(`| 制約 | ${summarizeConstraints(report.constraints, report.foreignKeys)} |`);
+  lines.push(`| 関数 | ${summarizeFunctions(report.functions)} |`);
+  lines.push(`| トリガー | ${summarizeTriggers(report.triggers)} |`);
   lines.push("");
 
   // ---- 新規テーブル詳細 (view は除外) ----
@@ -413,6 +456,31 @@ function renderMarkdown({ report, assertions, schemaDiff, newMigrations, missing
         lines.push("");
       }
     }
+  }
+
+  // ---- 新規 function 詳細 ----
+  if (report.functions.added.length > 0) {
+    lines.push("### 新規関数の詳細");
+    lines.push("");
+    for (const f of report.functions.added) {
+      lines.push(...renderNewFunctionSection(f));
+      lines.push("");
+    }
+  }
+
+  // ---- 新規 trigger 詳細 ----
+  if (report.triggers.added.length > 0) {
+    lines.push("### 新規トリガーの詳細");
+    lines.push("");
+    lines.push("| テーブル | トリガー名 | timing | event | level | 関数 |");
+    lines.push("|---|---|---|---|---|---|");
+    for (const t of report.triggers.added) {
+      const events = (t.event ?? []).join(" / ");
+      lines.push(
+        `| \`${t.schema}.${t.table}\` | \`${t.name}\` | ${t.timing} | ${events} | ${t.level} | \`${t.function_name}\` |`,
+      );
+    }
+    lines.push("");
   }
 
   // ---- 既存テーブルへのカラム追加詳細 (view 由来は除外) ----
@@ -570,6 +638,36 @@ function summarizePolicies(tablesOnly, policies) {
   return parts.length ? parts.join(" / ") : "変更なし";
 }
 
+function summarizeFunctions({ added, removed, modified }) {
+  const parts = [];
+  if (added.length)
+    parts.push(`${added.length} 件追加 (${added.map((f) => `\`${f.name}\``).join(", ")})`);
+  if (removed.length)
+    parts.push(`⚠️ ${removed.length} 件削除 (${removed.map((f) => `\`${f.name}\``).join(", ")})`);
+  if (modified.length)
+    parts.push(
+      `${modified.length} 件変更 (${modified.map((m) => `\`${m.after.name}\``).join(", ")})`,
+    );
+  return parts.length ? parts.join(" / ") : "変更なし";
+}
+
+function summarizeTriggers({ added, removed, modified }) {
+  const parts = [];
+  if (added.length)
+    parts.push(
+      `${added.length} 件追加 (${added.map((t) => `\`${t.table}.${t.name}\``).join(", ")})`,
+    );
+  if (removed.length)
+    parts.push(
+      `⚠️ ${removed.length} 件削除 (${removed.map((t) => `\`${t.table}.${t.name}\``).join(", ")})`,
+    );
+  if (modified.length)
+    parts.push(
+      `${modified.length} 件変更 (${modified.map((m) => `\`${m.after.table}.${m.after.name}\``).join(", ")})`,
+    );
+  return parts.length ? parts.join(" / ") : "変更なし";
+}
+
 function summarizeConstraints(constraints, foreignKeys) {
   const parts = [];
   const fkAdded = foreignKeys.added.length;
@@ -688,6 +786,28 @@ function renderNewViewSection(v, report) {
     lines.push("");
   }
 
+  return lines;
+}
+
+// ---- New function detail ----
+
+function renderNewFunctionSection(f) {
+  const lines = [];
+  lines.push(`#### \`${f.schema}.${f.name}(${f.args ?? ""})\` → \`${f.return_type ?? ""}\``);
+  lines.push("");
+  lines.push("**属性**:");
+  lines.push(`- \`security\`: ${f.security_definer ? "❌ DEFINER (RLS 迂回)" : "✅ INVOKER"}`);
+  lines.push(`- \`volatility\`: \`${f.volatility ?? "(unknown)"}\``);
+  if (f.comment) lines.push(`- \`comment\`: ${f.comment}`);
+  lines.push("");
+  if (f.body) {
+    lines.push("**本体**:");
+    lines.push("");
+    lines.push("```sql");
+    lines.push(truncateForComment(f.body, 4000));
+    lines.push("```");
+    lines.push("");
+  }
   return lines;
 }
 

--- a/scripts/db-migration-diff/snapshot.sql
+++ b/scripts/db-migration-diff/snapshot.sql
@@ -13,7 +13,9 @@
 --     "indexes":     [{ schema, table, name, definition }],
 --     "policies":    [{ schema, table, name, permissive, roles, command, using, with_check }],
 --     "enums":       [{ schema, name, values }],
---     "views":       [{ schema, name, kind, definition, security_invoker, security_barrier }]
+--     "views":       [{ schema, name, kind, definition, security_invoker, security_barrier }],
+--     "functions":   [{ schema, name, args, return_type, body, security_definer, volatility, comment }],
+--     "triggers":    [{ schema, table, name, function_name, timing, event, level, comment }]
 --   }
 --
 -- `tables` は relkind in ('r','v','m') を含むので「table / view / matview を一律
@@ -200,6 +202,69 @@ with
       where n.nspname = 'public'
       group by n.nspname, t.typname
     ) sub
+  ),
+  functions as (
+    -- 関数 / トリガー関数の定義 + 主要属性。security_definer は postgres の SECURITY DEFINER
+    -- フラグで、true だと所有者権限で実行され RLS を迂回する。kozutsumi では原則
+    -- SECURITY INVOKER (= prosecdef = false) を要求する。
+    -- 同名異シグネチャを別関数として扱うため key には pg_get_function_arguments を含める。
+    select coalesce(json_agg(f order by f->>'schema', f->>'name', f->>'args'), '[]'::json) as data
+    from (
+      select json_build_object(
+        'schema', n.nspname,
+        'name', p.proname,
+        'args', pg_get_function_arguments(p.oid),
+        'return_type', pg_get_function_result(p.oid),
+        'body', p.prosrc,
+        'security_definer', p.prosecdef,
+        'volatility', case p.provolatile
+          when 'i' then 'immutable'
+          when 's' then 'stable'
+          when 'v' then 'volatile'
+        end,
+        'comment', obj_description(p.oid, 'pg_proc')
+      ) as f
+      from pg_proc p
+      join pg_namespace n on n.oid = p.pronamespace
+      where n.nspname = 'public'
+    ) sub
+  ),
+  triggers as (
+    -- ユーザー定義 trigger のみ (tgisinternal = false で内部 FK trigger 等を除外)。
+    -- tgtype は bitmask: 1=ROW, 2=BEFORE, 4=INSERT, 8=DELETE, 16=UPDATE, 32=TRUNCATE, 64=INSTEAD OF
+    -- (BEFORE / INSTEAD OF どちらでもなければ AFTER)。event は複数同時指定可能なので配列で出す。
+    select coalesce(json_agg(t order by t->>'schema', t->>'table', t->>'name'), '[]'::json) as data
+    from (
+      select json_build_object(
+        'schema', n.nspname,
+        'table', cl.relname,
+        'name', tg.tgname,
+        'function_name', pn.nspname || '.' || pp.proname,
+        'timing', case
+          when (tg.tgtype & 64) <> 0 then 'INSTEAD OF'
+          when (tg.tgtype & 2) <> 0 then 'BEFORE'
+          else 'AFTER'
+        end,
+        'event', (
+          select coalesce(json_agg(ev order by ev), '[]'::json)
+          from (values
+            (case when (tg.tgtype & 4) <> 0 then 'INSERT' end),
+            (case when (tg.tgtype & 8) <> 0 then 'DELETE' end),
+            (case when (tg.tgtype & 16) <> 0 then 'UPDATE' end),
+            (case when (tg.tgtype & 32) <> 0 then 'TRUNCATE' end)
+          ) as v(ev)
+          where ev is not null
+        ),
+        'level', case when (tg.tgtype & 1) <> 0 then 'ROW' else 'STATEMENT' end,
+        'comment', obj_description(tg.oid, 'pg_trigger')
+      ) as t
+      from pg_trigger tg
+      join pg_class cl on cl.oid = tg.tgrelid
+      join pg_namespace n on n.oid = cl.relnamespace
+      join pg_proc pp on pp.oid = tg.tgfoid
+      join pg_namespace pn on pn.oid = pp.pronamespace
+      where n.nspname = 'public' and tg.tgisinternal = false
+    ) sub
   )
 select json_build_object(
   'tables', (select data from tables),
@@ -209,5 +274,7 @@ select json_build_object(
   'indexes', (select data from indexes),
   'policies', (select data from policies),
   'enums', (select data from enums),
-  'views', (select data from views)
+  'views', (select data from views),
+  'functions', (select data from functions),
+  'triggers', (select data from triggers)
 );


### PR DESCRIPTION
## 概要 (What)

PR migration diff の構造化スナップショット対象を **functions / triggers** に拡張し、新規 function の `SECURITY DEFINER` を `❌` で fail させる規約検査を追加する。

## 関連 Issue

Closes #177

## 背景 (Why)

PR #176 で function (`fn_set_subscription_auto_promote`) を追加したとき、ADR-0023 で導入した PR migration diff コメントの構造化サマリが**全カテゴリ「変更なし」**になった ([該当コメント](https://github.com/y-oga-819/kozutsumi/pull/176#issuecomment-4368834205))。生 diff には function 追加が出ていたが、構造化スナップショットが function を追跡していなかったのが原因。ADR-0023 Notes の「将来見直す条件」に「functions / triggers に広げたくなった」と明記していた、まさにそのタイミング。

加えて、views の `security_invoker` と同じ思想で、**新規 function の `SECURITY DEFINER` も RLS 迂回経路** なので CI で塞ぐ。

## Before → After (概念・フロー・メンタルモデル)

**Before:** 構造化スナップショットは tables / columns / constraints / FK / indexes / policies / enums / views までしか追跡していなかった。function-only / trigger-only の migration では構造化サマリが「全カテゴリ変更なし」になり、approve 判断のための差分が生 diff だけに頼ることになっていた。RLS 迂回パス（`SECURITY DEFINER`）も view 側しか検査していなかった。

**After:** snapshot に functions / triggers を含め、サマリ表に「関数」「トリガー」行と新規詳細セクションを表示する。新規 function に `SECURITY DEFINER` がついていれば `❌` で CI fail、既存 function の `false → true` 変更は `⚠️` で警告する。

## 追加したテスト (How verified)

- [x] ローカル smoke test 3 ケース
  - 新規 `SECURITY DEFINER` function → `❌` で `exit 1`
  - `SECURITY INVOKER` function + trigger → サマリ・詳細セクション正しく表示で `exit 0`
  - 既存 function が `false → true` に変更 → `⚠️` warning で `exit 0`
- [x] `prettier --check .` パス
- [ ] 実 Supabase 環境での CI 動作確認（この PR の `supabase` job 結果で `snapshot.sql` の新クエリが PostgreSQL 構文として通ること、サマリ行が表示されることを確認）
- [ ] `SECURITY DEFINER` 付き function を含むテスト用 migration ブランチで `❌` fail を実 CI で確認（この PR では migration を追加していないので別途）

## リリース前チェックリスト (When / Before merge)

- [x] ドキュメント (ADR-0023) を更新した（Decision の対象拡張 / 規約チェック節 / Notes / 改訂履歴）

## このPRの範囲外 (Out of scope)

- **sequences のサポート**: 頻度が低いので別 issue 候補（ADR Notes の見直し条件に残した）
- **triggers の規約チェック**: kozutsumi 規約として固まっていないので、今回は構造化サマリのみ
- **同名異シグネチャ function の追加対応**: diff key を `name + args` にしているので普通に added/removed として出る

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1zAoU6BxdpZyoRJCD7L6F)_