### PR TITLE
feat(task): TaskForm を body + task_size + project 任意化に再構成

### DIFF
--- a/e2e/action-log-time-entry.spec.ts
+++ b/e2e/action-log-time-entry.spec.ts
@@ -44,7 +44,9 @@ test.describe("行動データ整合 (action_logs / task_time_entries / tasks.st
     const addDialog2 = page.getByRole("dialog", { name: "追加メニュー" });
     await addDialog2.getByRole("tab", { name: "タスク" }).click();
     await addDialog2.getByLabel("タイトル").fill(taskTitle);
-    await addDialog2.getByLabel("プロジェクト").selectOption({ label: projectName });
+    // #170 / ADR 0038: task_size は登録時必須。テスト範囲外なので任意の値 (30分) を選ぶ。
+    await addDialog2.getByRole("radio", { name: "30分" }).click();
+    await addDialog2.getByLabel("プロジェクト (任意)").selectOption({ label: projectName });
     await addDialog2.getByRole("button", { name: "追加" }).click();
     await expect(addDialog2).toHaveCount(0);
 

--- a/e2e/db.ts
+++ b/e2e/db.ts
@@ -145,6 +145,7 @@ export type TaskRow = {
   stack_order: number | null;
   depends_on_event_id: string | null;
   task_category: "coding" | "doc" | "research" | "admin" | "other" | null;
+  task_size: "15m" | "30m" | "1h" | "2h" | "4h" | "1d" | "large" | null;
   parent_task_id: string | null;
   decompose_status: DecomposeStatus;
   completed_at: string | null;

--- a/e2e/dependency-event.spec.ts
+++ b/e2e/dependency-event.spec.ts
@@ -43,7 +43,9 @@ test.describe("依存イベント設定 (TaskDetailPanel → DB → バッジ)",
     const addTask = page.getByRole("dialog", { name: "追加メニュー" });
     await addTask.getByRole("tab", { name: "タスク" }).click();
     await addTask.getByLabel("タイトル").fill(taskTitle);
-    await addTask.getByLabel("プロジェクト").selectOption({ label: projectName });
+    // #170 / ADR 0038: task_size は登録時必須。テスト範囲外なので任意の値 (30分) を選ぶ。
+    await addTask.getByRole("radio", { name: "30分" }).click();
+    await addTask.getByLabel("プロジェクト (任意)").selectOption({ label: projectName });
     await addTask.getByRole("button", { name: "追加" }).click();
     await expect(addTask).toHaveCount(0);
 
@@ -149,7 +151,9 @@ test.describe("依存イベント設定 (TaskDetailPanel → DB → バッジ)",
       const addTask = page.getByRole("dialog", { name: "追加メニュー" });
       await addTask.getByRole("tab", { name: "タスク" }).click();
       await addTask.getByLabel("タイトル").fill(title);
-      await addTask.getByLabel("プロジェクト").selectOption({ label: projectName });
+      // #170 / ADR 0038: task_size は登録時必須。テスト範囲外なので任意の値 (30分) を選ぶ。
+      await addTask.getByRole("radio", { name: "30分" }).click();
+      await addTask.getByLabel("プロジェクト (任意)").selectOption({ label: projectName });
       await addTask.getByRole("button", { name: "追加" }).click();
       await expect(addTask).toHaveCount(0);
     }

--- a/e2e/golden-path.spec.ts
+++ b/e2e/golden-path.spec.ts
@@ -95,7 +95,7 @@ test("Phase 1 golden path", async ({ signedInPage: page }) => {
 
 /**
  * AddPanel 経由でタスクを作るヘルパー。
- * プロジェクト名で select し、見積もりは空のまま追加する。
+ * #170 / ADR 0038: task_size 必須。テスト範囲外なので 30分 を選ぶ。
  */
 async function createTask(
   page: import("@playwright/test").Page,
@@ -106,7 +106,8 @@ async function createTask(
   const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
   await addDialog.getByRole("tab", { name: "タスク" }).click();
   await addDialog.getByLabel("タイトル").fill(title);
-  await addDialog.getByLabel("プロジェクト").selectOption({ label: projectName });
+  await addDialog.getByRole("radio", { name: "30分" }).click();
+  await addDialog.getByLabel("プロジェクト (任意)").selectOption({ label: projectName });
   await addDialog.getByRole("button", { name: "追加" }).click();
   await expect(addDialog).toHaveCount(0);
 }

--- a/e2e/pause-reason.spec.ts
+++ b/e2e/pause-reason.spec.ts
@@ -88,7 +88,9 @@ async function createTask(page: Page, title: string, projectName: string): Promi
   const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
   await addDialog.getByRole("tab", { name: "タスク" }).click();
   await addDialog.getByLabel("タイトル").fill(title);
-  await addDialog.getByLabel("プロジェクト").selectOption({ label: projectName });
+  // #170 / ADR 0038: task_size は登録時必須。
+  await addDialog.getByRole("radio", { name: "30分" }).click();
+  await addDialog.getByLabel("プロジェクト (任意)").selectOption({ label: projectName });
   await addDialog.getByRole("button", { name: "追加" }).click();
   await expect(addDialog).toHaveCount(0);
 }

--- a/e2e/phase3-ai-bypass-invariants.spec.ts
+++ b/e2e/phase3-ai-bypass-invariants.spec.ts
@@ -46,7 +46,9 @@ test.describe("AI 経路バイパス (ADR 0014)", () => {
     const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
     await addDialog.getByRole("tab", { name: "タスク" }).click();
     await addDialog.getByLabel("タイトル").fill(taskTitle);
-    await addDialog.getByLabel("プロジェクト").selectOption({ label: projectName });
+    // #170 / ADR 0038: task_size は登録時必須。
+    await addDialog.getByRole("radio", { name: "30分" }).click();
+    await addDialog.getByLabel("プロジェクト (任意)").selectOption({ label: projectName });
     await addDialog.getByRole("button", { name: "追加" }).click();
     await expect(addDialog).toHaveCount(0);
 
@@ -224,7 +226,9 @@ test.describe("Variant E core path 不変条件 (ADR 0016)", () => {
     const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
     await addDialog.getByRole("tab", { name: "タスク" }).click();
     await addDialog.getByLabel("タイトル").fill(taskTitle);
-    await addDialog.getByLabel("プロジェクト").selectOption({ label: projectName });
+    // #170 / ADR 0038: task_size は登録時必須。
+    await addDialog.getByRole("radio", { name: "30分" }).click();
+    await addDialog.getByLabel("プロジェクト (任意)").selectOption({ label: projectName });
     await addDialog.getByRole("button", { name: "追加" }).click();
     await expect(addDialog).toHaveCount(0);
 

--- a/e2e/project-event-crud.spec.ts
+++ b/e2e/project-event-crud.spec.ts
@@ -324,7 +324,9 @@ test.describe("プロジェクト削除 (cascade SET NULL)", () => {
     let addDialog = page.getByRole("dialog", { name: "追加メニュー" });
     await addDialog.getByRole("tab", { name: "タスク" }).click();
     await addDialog.getByLabel("タイトル").fill(taskTitle);
-    await addDialog.getByLabel("プロジェクト").selectOption({ label: projectName });
+    // #170 / ADR 0038: task_size は登録時必須。
+    await addDialog.getByRole("radio", { name: "30分" }).click();
+    await addDialog.getByLabel("プロジェクト (任意)").selectOption({ label: projectName });
     await addDialog.getByRole("button", { name: "追加" }).click();
     await expect(addDialog).toHaveCount(0);
 

--- a/e2e/task-category-override.spec.ts
+++ b/e2e/task-category-override.spec.ts
@@ -44,7 +44,9 @@ test.describe("task_category override (TaskDetailPanel → DB → action_log)", 
     const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
     await addDialog.getByRole("tab", { name: "タスク" }).click();
     await addDialog.getByLabel("タイトル").fill(taskTitle);
-    await addDialog.getByLabel("プロジェクト").selectOption({ label: projectName });
+    // #170 / ADR 0038: task_size は登録時必須。
+    await addDialog.getByRole("radio", { name: "30分" }).click();
+    await addDialog.getByLabel("プロジェクト (任意)").selectOption({ label: projectName });
     await addDialog.getByRole("button", { name: "追加" }).click();
     await expect(addDialog).toHaveCount(0);
 
@@ -104,7 +106,9 @@ test.describe("task_category override (TaskDetailPanel → DB → action_log)", 
     const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
     await addDialog.getByRole("tab", { name: "タスク" }).click();
     await addDialog.getByLabel("タイトル").fill(taskTitle);
-    await addDialog.getByLabel("プロジェクト").selectOption({ label: projectName });
+    // #170 / ADR 0038: task_size は登録時必須。
+    await addDialog.getByRole("radio", { name: "30分" }).click();
+    await addDialog.getByLabel("プロジェクト (任意)").selectOption({ label: projectName });
     await addDialog.getByRole("button", { name: "追加" }).click();
     await expect(addDialog).toHaveCount(0);
 

--- a/e2e/task-crud.spec.ts
+++ b/e2e/task-crud.spec.ts
@@ -9,23 +9,28 @@ import {
 import { expect, test } from "./fixtures";
 
 /**
- * Issue #67 🟧 / ADR 0001:
- *   タスク作成フローの DB 整合 (tasks 行 + projects FK + estimated_minutes)。
+ * Issue #67 🟧 / Issue #170 / ADR 0001 / 0036 / 0037 / 0038 / 0039:
+ *   タスク作成フローの DB 整合 (tasks 行 + projects FK + body + task_size)。
  *
  * golden-path.spec はタスク作成を踏むが UI 側しか見ていない。ここでは
- * 「title / project_id / estimated_minutes / status=idle / stack_order」が
+ * 「title / project_id / body / task_size / status=idle / stack_order」が
  * tasks 行に正しく落ちることを service_role で踏む。
- * estimated_minutes は DB 制約 (tasks_estimated_minutes_positive) で守られて
- * いるが、Form は分単位で受けて DB も分単位で保存する (gateway の素通し)。
+ *
+ * #170 / ADR 0038: TaskForm の見積もり入力は分単位 number input から 7 段階 task_size
+ * ボタン (15m / 30m / 1h / 2h / 4h / 1d / large) に置き換わった。estimated_minutes は
+ * 登録時に取らず NULL のまま入る (補正は AI 推定 / 子分解の経路に倒す, ADR 0038)。
+ *
+ * #170 / ADR 0037: body は TaskForm 1 画面で書き切れるようになった (任意入力)。
+ * #170 / ADR 0039: project は登録時に任意。未指定なら project_id=NULL で入る。
  */
 test.describe("タスク作成 (tasks 行整合)", () => {
-  test("title / project / 見積もり時間 が tasks 行に正しく落ちる", async ({
+  test("title / body / task_size / project が tasks 行に正しく落ちる (#170)", async ({
     signedInPageWithProject: page,
     projectName,
     testUserId: userId,
   }) => {
-    const taskTitle = "見積もり付きタスク";
-    const estimatedMinutes = 45;
+    const taskTitle = "サイズ付きタスク";
+    const taskBody = "## 進め方\n- 一通り読む\n- メモを残す";
 
     const admin = createAdminClient();
 
@@ -35,8 +40,9 @@ test.describe("タスク作成 (tasks 行整合)", () => {
     const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
     await addDialog.getByRole("tab", { name: "タスク" }).click();
     await addDialog.getByLabel("タイトル").fill(taskTitle);
-    await addDialog.getByLabel("プロジェクト").selectOption({ label: projectName });
-    await addDialog.getByLabel("見積もり (分)").fill(String(estimatedMinutes));
+    await addDialog.getByLabel("詳細 (任意)").fill(taskBody);
+    await addDialog.getByRole("radio", { name: "1時間" }).click();
+    await addDialog.getByLabel("プロジェクト (任意)").selectOption({ label: projectName });
     await addDialog.getByRole("button", { name: "追加" }).click();
     await expect(addDialog).toHaveCount(0);
 
@@ -46,8 +52,11 @@ test.describe("タスク作成 (tasks 行整合)", () => {
     const task = await getTaskByTitle(admin, userId, taskTitle);
     expect(task.title).toBe(taskTitle);
     expect(task.project_id).toBe(project.id);
-    expect(task.estimated_minutes).toBe(estimatedMinutes);
-    expect(task.body).toBe("");
+    expect(task.body).toBe(taskBody);
+    expect(task.task_size).toBe("1h");
+    // ADR 0038: 主観サイズと AI 推定 (estimated_minutes) は別軸。登録時は task_size のみで
+    // estimated_minutes は NULL のまま (AI 分解 / 補正の責務)。
+    expect(task.estimated_minutes).toBeNull();
     expect(task.status).toBe("idle");
     // AppShell.onCreateTask は pending 件数を stackOrder に渡す。
     // 直前まで pending タスクは 0 件だったので 0 が入るはず。
@@ -58,6 +67,31 @@ test.describe("タスク作成 (tasks 行整合)", () => {
     // 他の action_log が混入していないことだけ軽く担保しておく。
     const logs = await getActionLogs(admin, userId);
     expect(logs.filter((l) => l.task_id === task.id)).toHaveLength(0);
+  });
+
+  test("project 未指定 / body 空でも登録でき project_id=NULL / body='' で入る (#170 / ADR 0039)", async ({
+    signedInPage: page,
+    testUserId: userId,
+  }) => {
+    const taskTitle = "Inbox 的タスク";
+    const admin = createAdminClient();
+
+    await page.getByRole("button", { name: "新規追加" }).click();
+    const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+    await addDialog.getByRole("tab", { name: "タスク" }).click();
+    await addDialog.getByLabel("タイトル").fill(taskTitle);
+    await addDialog.getByRole("radio", { name: "30分" }).click();
+    // project は未指定のまま (default の「未指定 (後で決める)」を維持)
+    await addDialog.getByRole("button", { name: "追加" }).click();
+    await expect(addDialog).toHaveCount(0);
+
+    const task = await getTaskByTitle(admin, userId, taskTitle);
+    expect(task.title).toBe(taskTitle);
+    expect(task.project_id).toBeNull();
+    expect(task.body).toBe("");
+    expect(task.task_size).toBe("30m");
+    expect(task.estimated_minutes).toBeNull();
+    expect(task.status).toBe("idle");
   });
 });
 
@@ -84,7 +118,9 @@ test.describe("タスク編集 (TaskDetailPanel body)", () => {
     const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
     await addDialog.getByRole("tab", { name: "タスク" }).click();
     await addDialog.getByLabel("タイトル").fill(taskTitle);
-    await addDialog.getByLabel("プロジェクト").selectOption({ label: projectName });
+    // #170 / ADR 0038: task_size は登録時必須。テスト範囲外なので任意の値 (30分) を選ぶ。
+    await addDialog.getByRole("radio", { name: "30分" }).click();
+    await addDialog.getByLabel("プロジェクト (任意)").selectOption({ label: projectName });
     await addDialog.getByRole("button", { name: "追加" }).click();
     await expect(addDialog).toHaveCount(0);
 
@@ -145,7 +181,9 @@ test.describe("タスク削除 (task_deleted + cascade)", () => {
     const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
     await addDialog.getByRole("tab", { name: "タスク" }).click();
     await addDialog.getByLabel("タイトル").fill(taskTitle);
-    await addDialog.getByLabel("プロジェクト").selectOption({ label: projectName });
+    // #170 / ADR 0038: task_size は登録時必須。テスト範囲外なので任意の値 (30分) を選ぶ。
+    await addDialog.getByRole("radio", { name: "30分" }).click();
+    await addDialog.getByLabel("プロジェクト (任意)").selectOption({ label: projectName });
     await addDialog.getByRole("button", { name: "追加" }).click();
     await expect(addDialog).toHaveCount(0);
 

--- a/e2e/task-reorder.spec.ts
+++ b/e2e/task-reorder.spec.ts
@@ -116,7 +116,9 @@ async function createTask(page: Page, title: string, projectName: string): Promi
   const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
   await addDialog.getByRole("tab", { name: "タスク" }).click();
   await addDialog.getByLabel("タイトル").fill(title);
-  await addDialog.getByLabel("プロジェクト").selectOption({ label: projectName });
+  // #170 / ADR 0038: task_size は登録時必須。
+  await addDialog.getByRole("radio", { name: "30分" }).click();
+  await addDialog.getByLabel("プロジェクト (任意)").selectOption({ label: projectName });
   await addDialog.getByRole("button", { name: "追加" }).click();
   await expect(addDialog).toHaveCount(0);
 }

--- a/e2e/timer-restore.spec.ts
+++ b/e2e/timer-restore.spec.ts
@@ -28,7 +28,9 @@ test.describe("タイマーのリロード復元 (DB 由来 / tick 継続)", () 
     const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
     await addDialog.getByRole("tab", { name: "タスク" }).click();
     await addDialog.getByLabel("タイトル").fill(taskTitle);
-    await addDialog.getByLabel("プロジェクト").selectOption({ label: projectName });
+    // #170 / ADR 0038: task_size は登録時必須。
+    await addDialog.getByRole("radio", { name: "30分" }).click();
+    await addDialog.getByLabel("プロジェクト (任意)").selectOption({ label: projectName });
     await addDialog.getByRole("button", { name: "追加" }).click();
     await expect(addDialog).toHaveCount(0);
 

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -117,6 +117,7 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
     updateBody,
     updateDependency,
     updateCategory,
+    updateSize,
     reorder,
     createTaskWithAi,
     createEvent,
@@ -254,6 +255,7 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
               onDelete={deleteTask}
               onChangeDependency={updateDependency}
               onChangeCategory={updateCategory}
+              onChangeSize={updateSize}
               aiEnabled={aiEnabled}
               latestDecomposeLog={decomposeLogQuery.data ?? null}
               isDecomposeLogLoading={decomposeLogQuery.isPending}

--- a/src/app/useDashboardMutations.ts
+++ b/src/app/useDashboardMutations.ts
@@ -10,7 +10,7 @@ import type { Event } from "@/entities/event/types";
 import type { CreateProjectInput, UpdateProjectInput } from "@/entities/project/gateway";
 import type { Project } from "@/entities/project/types";
 import type { CreateTaskInput } from "@/entities/task/gateway";
-import type { Task, TaskCategory } from "@/entities/task/types";
+import type { Task, TaskCategory, TaskSize } from "@/entities/task/types";
 import { reorderTasksById } from "@/features/task-stack/reorderTasks";
 import { triggerCategorize } from "@/features/task-stack/triggerCategorize";
 import { triggerDecompose } from "@/features/task-stack/triggerDecompose";
@@ -31,6 +31,12 @@ export type DashboardMutations = {
   updateDependency: (id: string, dependsOnEventId: string | null) => void;
   /** P3-5 (#90) / ADR 0015: 詳細パネルからの task_category override。action_log: TASK_CATEGORY_CHANGED。 */
   updateCategory: (id: string, taskCategory: TaskCategory | null) => void;
+  /**
+   * #170 / ADR 0038: 詳細パネルからの task_size 編集。AI 推定の estimated_minutes
+   * とは独立した主観サイズ軸を上書きする。logging は今は持たない (action_log の
+   * payload schema を別 issue で確定する必要があるため)。
+   */
+  updateSize: (id: string, taskSize: TaskSize | null) => void;
   /** DnD でのタスク並び替え。action_log: TASK_REORDERED。 */
   reorder: (fromId: string, toId: string) => void;
   /**
@@ -191,6 +197,28 @@ export function useDashboardMutations(): DashboardMutations {
       }
       queryClient.setQueryData<Task[]>(dashboardKeys.tasks, (prev) =>
         (prev ?? []).map((t) => (t.id === id ? { ...t, taskCategory } : t)),
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(dashboardKeys.tasks, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.tasks });
+    },
+  });
+
+  // #170 / ADR 0038: 主観サイズ (task_size) の上書き。AI が初期値を入れるルートと、
+  // ユーザーが詳細パネルで上書きするルートが両方あり、どちらも `tasks.task_size` 同列に
+  // 落ちる。category と異なり action_log は今は持たない (Phase 4 で必要になったら追加)。
+  const updateSizeMutation = useMutation({
+    mutationFn: ({ id, taskSize }: { id: string; taskSize: TaskSize | null }) =>
+      taskGateway.update(id, { taskSize }),
+    onMutate: async ({ id, taskSize }) => {
+      await queryClient.cancelQueries({ queryKey: dashboardKeys.tasks });
+      const previous = queryClient.getQueryData<Task[]>(dashboardKeys.tasks);
+      queryClient.setQueryData<Task[]>(dashboardKeys.tasks, (prev) =>
+        (prev ?? []).map((t) => (t.id === id ? { ...t, taskSize } : t)),
       );
       return { previous };
     },
@@ -482,6 +510,7 @@ export function useDashboardMutations(): DashboardMutations {
     updateDependency: (id, dependsOnEventId) =>
       updateDependencyMutation.mutate({ id, dependsOnEventId }),
     updateCategory: (id, taskCategory) => updateCategoryMutation.mutate({ id, taskCategory }),
+    updateSize: (id, taskSize) => updateSizeMutation.mutate({ id, taskSize }),
     reorder,
     createTaskWithAi,
     createEvent: (input) => createEventMutation.mutateAsync(input).then(() => undefined),

--- a/src/entities/task/gateway.ts
+++ b/src/entities/task/gateway.ts
@@ -2,7 +2,11 @@ import type { CorrectionFactor } from "./correction";
 import type { DecomposeStatus, Task, TaskCategory, TaskSize } from "./types";
 
 export type CreateTaskInput = {
-  projectId: string;
+  /**
+   * 所属プロジェクト (#170, ADR 0039)。null は「未指定 (Inbox 的)」。
+   * DB 上 `tasks.project_id` は NULLABLE で、TaskForm の project 入力を任意化する方針に対応する。
+   */
+  projectId: string | null;
   title: string;
   body?: string;
   estimatedMinutes?: number | null;
@@ -16,7 +20,10 @@ export type CreateTaskInput = {
 };
 
 export type UpdateTaskInput = {
-  projectId?: string;
+  /**
+   * project の付け替え / 未設定化 (#170, ADR 0039)。null で「未指定」に戻せる。
+   */
+  projectId?: string | null;
   title?: string;
   body?: string;
   estimatedMinutes?: number | null;

--- a/src/entities/task/supabase-gateway.ts
+++ b/src/entities/task/supabase-gateway.ts
@@ -54,7 +54,9 @@ export class SupabaseTaskGateway implements TaskGateway {
     const user_id = await getUserId(this.supabase);
     const payload: TablesInsert<"tasks"> = {
       user_id,
-      project_id: input.projectId,
+      // #170 / ADR 0039: project は任意化された。null / 空文字 / undefined は
+      // 「未指定 (Inbox 的)」として project_id=NULL で insert する。
+      project_id: input.projectId ? input.projectId : null,
       title: input.title,
       body: input.body ?? "",
       estimated_minutes: input.estimatedMinutes ?? null,

--- a/src/entities/task/task-size.ts
+++ b/src/entities/task/task-size.ts
@@ -22,3 +22,20 @@ export const TASK_SIZE_TO_MINUTES: Record<TaskSizeValue, number | null> = {
   "1d": 480,
   large: null,
 };
+
+/**
+ * task_size の UI 表示ラベル (#170, ADR 0038)。
+ *
+ * TaskForm の 7 段階ボタン / TaskDetailPanel の編集 select / 一覧表示で使う。
+ * `large` は「1 日では括れない大物」を表すため、他の段階と並んだときに「半日超」
+ * と分かる文言にする (ADR 0038 Notes 「`large` の表示文言は実装で詰める」)。
+ */
+export const TASK_SIZE_LABELS: Record<TaskSizeValue, string> = {
+  "15m": "15分",
+  "30m": "30分",
+  "1h": "1時間",
+  "2h": "2時間",
+  "4h": "半日",
+  "1d": "1日",
+  large: "1日超",
+};

--- a/src/features/add-forms/AddPanel.tsx
+++ b/src/features/add-forms/AddPanel.tsx
@@ -87,16 +87,14 @@ export function AddPanel({
 
         <div className="flex-1 overflow-auto px-5 pb-6 pt-4">
           {tab === "task" ? (
-            projects.length === 0 ? (
-              <EmptyProjectsNotice onSwitch={() => setTab("project")} />
-            ) : (
-              <TaskForm
-                projects={projects}
-                events={events}
-                onSubmit={onCreateTask}
-                onClose={onClose}
-              />
-            )
+            // #170 / ADR 0039: project は任意化された。projects.length === 0 でも
+            // タスクは未指定 (Inbox 的) で登録できる。
+            <TaskForm
+              projects={projects}
+              events={events}
+              onSubmit={onCreateTask}
+              onClose={onClose}
+            />
           ) : null}
           {tab === "event" ? (
             <EventForm projects={projects} onSubmit={onCreateEvent} onClose={onClose} />
@@ -151,21 +149,6 @@ function ProjectList({
           </li>
         ))}
       </ul>
-    </div>
-  );
-}
-
-function EmptyProjectsNotice({ onSwitch }: { onSwitch: () => void }) {
-  return (
-    <div className="flex flex-col items-center gap-3 py-6 text-center">
-      <p className="font-jp text-[12px] text-fg-muted">タスクにはプロジェクトが必要です。</p>
-      <button
-        type="button"
-        onClick={onSwitch}
-        className="rounded bg-accent-blue px-4 py-1.5 font-jp text-[11px] font-semibold text-fg-invert"
-      >
-        プロジェクトを先に作る
-      </button>
     </div>
   );
 }

--- a/src/features/add-forms/TaskForm.tsx
+++ b/src/features/add-forms/TaskForm.tsx
@@ -3,9 +3,11 @@
 import { useMemo, useState } from "react";
 
 import type { CreateTaskInput } from "@/entities/task/gateway";
+import { TASK_SIZE_LABELS } from "@/entities/task/task-size";
 import type { Event } from "@/entities/event/types";
 import type { Project } from "@/entities/project/types";
 import { formatRelativeTime } from "@/shared/lib/time";
+import { TASK_SIZE_VALUES, type TaskSizeValue } from "@/shared/types/database";
 
 type TaskFormProps = {
   projects: readonly Project[];
@@ -15,13 +17,19 @@ type TaskFormProps = {
 };
 
 /**
- * Phase 1 仕様 Step 3「タスク追加フォーム（タイトル、プロジェクト選択、見積もり時間）」。
- * 依存イベントも任意で選べるようにしてある (feature-spec.md: event-gated タスク)。
+ * #170 / ADR 0036 / 0037 / 0038 / 0039: シンプル世界観の単一登録経路。
+ *
+ * - title 必須
+ * - body は任意 (ADR 0037 の AI 分解 prompt 入力 / 「秘書から相談」モードの起点)
+ * - task_size 必須 7 段階 (ADR 0038 の主観サイズ。AI 推定 estimated_minutes とは別軸)
+ * - project は任意 (ADR 0039 で後付け / 伝播 RPC 経由で修正可能になる前提)
+ * - estimated_minutes は登録時に取らない。AI 分解 / 補正の責務に倒す
  */
 export function TaskForm({ projects, events, onSubmit, onClose }: TaskFormProps) {
   const [title, setTitle] = useState("");
-  const [projectId, setProjectId] = useState<string>(projects[0]?.id ?? "");
-  const [minutes, setMinutes] = useState<string>("");
+  const [body, setBody] = useState("");
+  const [projectId, setProjectId] = useState<string>("");
+  const [taskSize, setTaskSize] = useState<TaskSizeValue | null>(null);
   const [dependsOnEventId, setDependsOnEventId] = useState<string>("");
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -45,23 +53,18 @@ export function TaskForm({ projects, events, onSubmit, onClose }: TaskFormProps)
       setError("タイトルは必須です");
       return;
     }
-    if (!projectId) {
-      setError("プロジェクトを選んでください");
+    if (taskSize === null) {
+      setError("サイズを選んでください");
       return;
     }
     setPending(true);
     setError(null);
     try {
-      const estimated = minutes.trim() === "" ? null : Number(minutes);
-      if (estimated !== null && (!Number.isFinite(estimated) || estimated <= 0)) {
-        setError("見積もり分数は正の整数で指定してください");
-        setPending(false);
-        return;
-      }
       await onSubmit({
-        projectId,
+        projectId: projectId || null,
         title: title.trim(),
-        estimatedMinutes: estimated,
+        body: body.trim() || undefined,
+        taskSize,
         dependsOnEventId: dependsOnEventId || null,
       });
       onClose();
@@ -86,31 +89,55 @@ export function TaskForm({ projects, events, onSubmit, onClose }: TaskFormProps)
       </label>
 
       <label className="flex flex-col gap-1">
-        <span className="font-jp text-[10px] text-fg-weak">プロジェクト</span>
+        <span className="font-jp text-[10px] text-fg-weak">詳細 (任意)</span>
+        <textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          rows={3}
+          className="resize-y rounded border border-bg-divider bg-bg-elevated px-3 py-2 font-mono text-[12px] leading-[1.5] text-fg-default outline-none focus:border-accent-blue"
+          placeholder="背景 / 進め方 / 完了条件など。AI 分解の文脈になります"
+        />
+      </label>
+
+      <fieldset className="flex flex-col gap-1">
+        <legend className="font-jp text-[10px] text-fg-weak">サイズ</legend>
+        <div role="radiogroup" aria-label="サイズ" className="flex flex-wrap gap-1.5">
+          {TASK_SIZE_VALUES.map((value) => {
+            const selected = taskSize === value;
+            return (
+              <button
+                key={value}
+                type="button"
+                role="radio"
+                aria-checked={selected}
+                onClick={() => setTaskSize(value)}
+                className={`rounded border px-2.5 py-1 font-jp text-[11px] ${
+                  selected
+                    ? "border-accent-blue bg-accent-blue/15 text-accent-blue"
+                    : "border-bg-divider bg-bg-elevated text-fg-subtle hover:border-fg-faint"
+                }`}
+              >
+                {TASK_SIZE_LABELS[value]}
+              </button>
+            );
+          })}
+        </div>
+      </fieldset>
+
+      <label className="flex flex-col gap-1">
+        <span className="font-jp text-[10px] text-fg-weak">プロジェクト (任意)</span>
         <select
           value={projectId}
           onChange={(e) => setProjectId(e.target.value)}
           className="rounded border border-bg-divider bg-bg-elevated px-3 py-2 text-[13px] text-fg-default outline-none focus:border-accent-blue"
         >
-          {projects.length === 0 ? <option value="">プロジェクトがありません</option> : null}
+          <option value="">未指定 (後で決める)</option>
           {projects.map((p) => (
             <option key={p.id} value={p.id}>
               {p.name}
             </option>
           ))}
         </select>
-      </label>
-
-      <label className="flex flex-col gap-1">
-        <span className="font-jp text-[10px] text-fg-weak">見積もり (分)</span>
-        <input
-          type="number"
-          min="1"
-          value={minutes}
-          onChange={(e) => setMinutes(e.target.value)}
-          className="rounded border border-bg-divider bg-bg-elevated px-3 py-2 text-[13px] text-fg-default outline-none focus:border-accent-blue"
-          placeholder="45"
-        />
       </label>
 
       <label className="flex flex-col gap-1">
@@ -130,7 +157,10 @@ export function TaskForm({ projects, events, onSubmit, onClose }: TaskFormProps)
       </label>
 
       {error ? (
-        <div className="rounded bg-[#ef444420] px-2 py-1.5 text-[11px] text-accent-red">
+        <div
+          role="alert"
+          className="rounded bg-[#ef444420] px-2 py-1.5 text-[11px] text-accent-red"
+        >
           {error}
         </div>
       ) : null}

--- a/src/features/task-detail/TaskDetailPanel.test.tsx
+++ b/src/features/task-detail/TaskDetailPanel.test.tsx
@@ -411,6 +411,96 @@ describe("TaskDetailPanel - task_category override (P3-5)", () => {
   });
 });
 
+// #170 / ADR 0038: 主観サイズ (task_size) の override UI。AI が初期値を入れた / 入れなかった
+// に関わらず、ユーザーが詳細パネルから上書きできる。logging は呼び出し側 (AppShell + mutation) の
+// 責務なので、ここでは callback 引数だけを担保する。category と同じ button → select パターン。
+describe("TaskDetailPanel - task_size override (#170 / ADR 0038)", () => {
+  test("onChangeSize 未指定なら size 編集 UI を出さない (旧呼び出し互換)", () => {
+    const { queryByText } = renderPanel();
+    expect(queryByText("サイズ")).toBeNull();
+    expect(queryByText(/未設定\s+を変更/)).toBeNull();
+  });
+
+  test("onChangeSize 指定時、デフォルトは「未設定 を変更」ボタン (taskSize=null)", () => {
+    const { getByText, queryByRole } = renderPanel({ onChangeSize: vi.fn() });
+    expect(getByText(/未設定\s+を変更/)).toBeTruthy();
+    expect(queryByRole("combobox")).toBeNull();
+  });
+
+  test("taskSize がある場合はボタン文言にその表示ラベルが入る", () => {
+    const { getByText } = renderPanel({
+      task: { ...baseTask, taskSize: "1h" },
+      onChangeSize: vi.fn(),
+    });
+    expect(getByText(/1時間\s+を変更/)).toBeTruthy();
+  });
+
+  test("ボタン押下で <select> に切り替わり、現在値が反映されている", () => {
+    const { getByText, getByRole } = renderPanel({
+      task: { ...baseTask, taskSize: "1h" },
+      onChangeSize: vi.fn(),
+    });
+    fireEvent.click(getByText(/1時間\s+を変更/));
+    const select = getByRole("combobox") as HTMLSelectElement;
+    expect(select.value).toBe("1h");
+  });
+
+  test("値変更で onChangeSize(taskId, value) を呼び、編集モードを抜ける", () => {
+    const onChangeSize = vi.fn();
+    const { getByText, getByRole, queryByRole } = renderPanel({
+      task: { ...baseTask, taskSize: "1h" },
+      onChangeSize,
+    });
+    fireEvent.click(getByText(/1時間\s+を変更/));
+    fireEvent.change(getByRole("combobox"), { target: { value: "2h" } });
+    expect(onChangeSize).toHaveBeenCalledWith("t1", "2h");
+    expect(queryByRole("combobox")).toBeNull();
+  });
+
+  test("「未設定」(空文字) を選ぶと onChangeSize(taskId, null) を呼ぶ", () => {
+    const onChangeSize = vi.fn();
+    const { getByText, getByRole } = renderPanel({
+      task: { ...baseTask, taskSize: "1h" },
+      onChangeSize,
+    });
+    fireEvent.click(getByText(/1時間\s+を変更/));
+    fireEvent.change(getByRole("combobox"), { target: { value: "" } });
+    expect(onChangeSize).toHaveBeenCalledWith("t1", null);
+  });
+
+  test("同じ値が選ばれた場合は onChangeSize を呼ばないが編集モードは抜ける", () => {
+    const onChangeSize = vi.fn();
+    const { getByText, getByRole, queryByRole } = renderPanel({
+      task: { ...baseTask, taskSize: "1h" },
+      onChangeSize,
+    });
+    fireEvent.click(getByText(/1時間\s+を変更/));
+    fireEvent.change(getByRole("combobox"), { target: { value: "1h" } });
+    expect(onChangeSize).not.toHaveBeenCalled();
+    expect(queryByRole("combobox")).toBeNull();
+  });
+
+  test("blur で編集モードを抜ける", () => {
+    const onChangeSize = vi.fn();
+    const { getByText, getByRole, queryByRole } = renderPanel({
+      task: { ...baseTask, taskSize: "1h" },
+      onChangeSize,
+    });
+    fireEvent.click(getByText(/1時間\s+を変更/));
+    fireEvent.blur(getByRole("combobox"));
+    expect(onChangeSize).not.toHaveBeenCalled();
+    expect(queryByRole("combobox")).toBeNull();
+  });
+
+  test("値域が UI に揃っている (15m / 30m / 1h / 2h / 4h / 1d / large + 未設定)", () => {
+    const { getByText, getByRole } = renderPanel({ onChangeSize: vi.fn() });
+    fireEvent.click(getByText(/未設定\s+を変更/));
+    const select = getByRole("combobox") as HTMLSelectElement;
+    const values = Array.from(select.options).map((o) => o.value);
+    expect(values).toEqual(["", "15m", "30m", "1h", "2h", "4h", "1d", "large"]);
+  });
+});
+
 // AI 分解情報エリア (P3-15 / ADR 0021 §3)。
 // 親が `latestDecomposeLog` か `onTriggerDecompose` を渡したときだけセクションが描画される。
 describe("TaskDetailPanel - AI 分解情報エリア (P3-15)", () => {

--- a/src/features/task-detail/TaskDetailPanel.tsx
+++ b/src/features/task-detail/TaskDetailPanel.tsx
@@ -6,11 +6,12 @@ import { getProject } from "../../entities/project/projects";
 import { useProjects } from "../../entities/project/ProjectsContext";
 import { useCorrectionFactors } from "../../entities/task/CorrectionFactorsContext";
 import { correctEstimate } from "../../entities/task/correction";
-import type { Task, TaskCategory } from "../../entities/task/types";
+import { TASK_SIZE_LABELS } from "../../entities/task/task-size";
+import type { Task, TaskCategory, TaskSize } from "../../entities/task/types";
 import { renderMarkdown } from "../../shared/lib/markdown";
 import { isDone } from "../../shared/lib/task";
 import { fmtDuration, formatRelativeTime } from "../../shared/lib/time";
-import { TASK_CATEGORY_VALUES } from "../../shared/types/database";
+import { TASK_CATEGORY_VALUES, TASK_SIZE_VALUES } from "../../shared/types/database";
 
 export type TaskDetailPanelProps = {
   task: Task;
@@ -33,6 +34,13 @@ export type TaskDetailPanelProps = {
    * 未指定なら category 編集 UI を出さない (旧呼び出し / テスト互換)。
    */
   onChangeCategory?: (id: string, category: TaskCategory | null) => void;
+  /**
+   * 主観サイズ (`tasks.task_size`) の編集 (#170 / ADR 0038)。
+   * AI 推定の estimated_minutes とは独立した軸で、ユーザーが「これくらい」と感じた
+   * 粗いサイズ感を上書きできる。null は未設定。
+   * 未指定なら size 編集 UI を出さない (旧呼び出し / テスト互換)。
+   */
+  onChangeSize?: (id: string, size: TaskSize | null) => void;
   /**
    * AI 分解の最新試行ログ (`task_decomposed` / `task_decompose_failed` /
    * `task_decompose_skipped` の最新 1 件)。なければ null。
@@ -66,6 +74,7 @@ export function TaskDetailPanel({
   onDelete,
   onChangeDependency,
   onChangeCategory,
+  onChangeSize,
   latestDecomposeLog,
   isDecomposeLogLoading,
   aiEnabled = true,
@@ -77,6 +86,7 @@ export function TaskDetailPanel({
   const [draft, setDraft] = useState(task.body || "");
   const [editingDep, setEditingDep] = useState(false);
   const [editingCategory, setEditingCategory] = useState(false);
+  const [editingSize, setEditingSize] = useState(false);
   // パネル open 時刻を「今」として固定する。パネル中に分跨ぎしても候補や相対時刻が
   // ばたつかないようにするのが目的 (相対時刻はあくまで判断補助)。
   const [openedAt] = useState<number>(() => now ?? Date.now());
@@ -209,6 +219,45 @@ export function TaskDetailPanel({
                 >
                   {dep ? `${formatRelativeTime(dep.startTime, nowDate)} ${dep.title}` : "なし"}{" "}
                   を変更
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+
+        {onChangeSize && (
+          <div className="px-5 pb-2">
+            <div className="flex items-center gap-2">
+              <span className="font-jp text-[10px] text-fg-weak">サイズ</span>
+              {editingSize ? (
+                <select
+                  autoFocus
+                  value={task.taskSize ?? ""}
+                  onChange={(e) => {
+                    const raw = e.target.value;
+                    const next = raw === "" ? null : (raw as TaskSize);
+                    if (next !== (task.taskSize ?? null)) {
+                      onChangeSize(task.id, next);
+                    }
+                    setEditingSize(false);
+                  }}
+                  onBlur={() => setEditingSize(false)}
+                  className="flex-1 rounded border border-bg-divider bg-bg-elevated px-2 py-1 text-[11px] text-fg-default outline-none focus:border-accent-blue"
+                >
+                  <option value="">未設定</option>
+                  {TASK_SIZE_VALUES.map((value) => (
+                    <option key={value} value={value}>
+                      {TASK_SIZE_LABELS[value]}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setEditingSize(true)}
+                  className="cursor-pointer rounded-[4px] border border-bg-divider bg-transparent px-2 py-[3px] font-jp text-[10px] text-fg-subtle"
+                >
+                  {task.taskSize ? TASK_SIZE_LABELS[task.taskSize] : "未設定"} を変更
                 </button>
               )}
             </div>


### PR DESCRIPTION
## 概要 (What)

ADR 0036 のシンプル世界観 (登録 → 上から順にやる) を TaskForm 1 画面で成立させる。`body` 欄追加 (ADR 0037) / 主観サイズの 7 段階 `task_size` 必須化 (ADR 0038) / `project` 任意化 (ADR 0039) を UI / gateway / e2e に同時に取り込む。

## 関連 Issue

Closes #170

## 背景 (Why)

[ADR 0036](https://github.com/y-oga-819/kozutsumi/blob/main/docs/adr/0036-simplify-task-registration-workflow.md) で確定した「default 経路は登録 → 上からやる」を実装に落とし込むタイミング。現状の TaskForm は次の 3 点で ADR の方針と乖離していた:

- `body` 入力欄が無く、AI 分解 (`buildDecomposePrompt`) に渡せる文脈が title だけ
- 見積もり入力が分単位 number input で、登録時の認知負荷が高い
- `project` 必須で、Inbox 的な「後で決める」運用が成立しない

これらを 1 画面で解消し、補正エンジン (ADR 0024〜0026) は `estimated_minutes` 軸のまま温存する (ADR 0038)。

派生 ADR: [0037](https://github.com/y-oga-819/kozutsumi/blob/main/docs/adr/0037-task-form-single-entry-with-body.md) / [0038](https://github.com/y-oga-819/kozutsumi/blob/main/docs/adr/0038-task-size-enum.md) / [0039](https://github.com/y-oga-819/kozutsumi/blob/main/docs/adr/0039-task-project-edit-and-cascade.md)。
DB / 型 / AI prompt 層は #169 (PR #175) で先行導入済み。

## Before → After (概念・フロー・メンタルモデル)

**Before:**
- 「タスク登録」の入力 IF が title / project / 分単位見積もり / 依存イベントの 4 軸
- 主観サイズと AI 推定が `estimated_minutes` 1 軸に潰れていて、Phase 4 で「ユーザーの見積もり傾向」と「AI 推定の精度」を別シグナルとして見られない
- project が必須で、Inbox 的に「後で決める」が成立せず、登録ミス時の手戻りは「削除 → 再登録」しかない
- AI 分解が登録経路で title しか文脈にできず、構造化された依頼 (例: 数百文字の手順 / 制約) を表現できない

**After:**
- 入力 IF は `title (必須)` / `body 任意` / `task_size 7 段階 (必須)` / `project 任意` / 依存イベント
- 主観サイズ (`task_size`) と AI 推定 (`estimated_minutes`) は別軸で並存。登録時は前者のみで、後者は AI 分解 / 補正の責務に倒す
- project は登録時任意。未指定なら `project_id=NULL` で入り、後から TaskDetailPanel 側で付け替えできる前提を作る (伝播 RPC 自体は #171 で実装)
- `body` を `buildDecomposePrompt` の文脈にできるので、構造化された依頼を AI 分解にそのまま流せる

## 追加したテスト (How verified)

- [x] `typecheck` / `lint` / `vitest run` (544 tests) すべて pass
- [x] TaskDetailPanel に `task_size` override の 8 ケース追加 (button → select / 値域 / null 戻し / blur / 同値選択時のスキップ)
- [x] e2e `task-crud.spec.ts` に「project 未指定 / body 空でも `project_id=NULL` / `body=''` で入る」ケース新規追加
- [x] e2e `task-crud.spec.ts` 既存「title / project / 見積もり」ケースを `task_size='1h'` / `body` 永続化 / `estimated_minutes=NULL` の検証に書き換え
- [x] e2e 全 task 作成経路 (10 ファイル) に `radio "30分"` クリックを差し込み、`プロジェクト (任意)` label 変更に追従

未カバー: e2e の TaskDetailPanel 側 `task_size` 編集経路 (今回は unit でカバー済 / dogfooding で詰める)。

## リリース前チェックリスト (When / Before merge)

- [x] DB migration 不要 (#169 / PR #175 で `tasks.task_size` 列は既に main にある)
- [x] 環境変数 / シークレット 追加なし
- [x] 既存タスク (`task_size IS NULL`) は引き続き読み書きでき、後方互換が保たれる
- [x] 既存ユーザーへの破壊的変更なし (登録 UI が変わるが、データ shape は #169 で既に整っている)

## このPRの範囲外 (Out of scope)

- TaskDetailPanel から `project_id` を編集する UI と、親 → 子 / 子 → 兄弟+親 への伝播 RPC ([ADR-0039](https://github.com/y-oga-819/kozutsumi/blob/main/docs/adr/0039-task-project-edit-and-cascade.md) の RPC 部分) — **#171 で別実装**
- 親共有タスク群のグルーピング操作 + 新規タスクの Top 直下挿入 ([ADR-0040](https://github.com/y-oga-819/kozutsumi/blob/main/docs/adr/0040-new-task-insert-position-top.md) / [ADR-0041](https://github.com/y-oga-819/kozutsumi/blob/main/docs/adr/0041-parent-shared-grouping-reorder.md)) — **#172 で別実装**
- `task_size` の Stack View 行カードへの badge 表示 (今は `estimated_minutes=NULL` の行は時間表示が出ない。dogfooding で違和感を観察してから別 issue 化判断)
- 「秘書から相談があります」モード ([#173](https://github.com/y-oga-819/kozutsumi/issues/173) / 将来構想)

https://claude.ai/code/session_01NuzXPr5q5BTs1aZBNr5e1y

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuzXPr5q5BTs1aZBNr5e1y)_