### PR TITLE
feat(calendar-ext): 予定管理ページと event 単位の visibility_override 操作 (Closes #145)

### DIFF
--- a/e2e/event-visibility-override.spec.ts
+++ b/e2e/event-visibility-override.spec.ts
@@ -1,0 +1,192 @@
+import { createAdminClient, waitForActionLog } from "./db";
+import { expect, test } from "./fixtures";
+
+/**
+ * Issue #145 / ADR 0031 Layer 3 / ADR 0032 / ADR 0035:
+ * 個別 event の予定化 / 解除 (visibility_override) を切り替える wiring を踏む。
+ *
+ * シナリオ:
+ *   1. service_role で external_account + subscription (auto_promote=true) + event を seed
+ *   2. /events ページに遷移して「予定管理」リストに event が出ることを確認
+ *   3. 「予定化解除」ボタンを押す
+ *   4. DB の events.visibility_override が 'hidden' に更新される
+ *   5. action_log に event_demoted (is_override_of_default=true) が記録される
+ *   6. ボタンが「予定化する」に切り替わり、押すと visibility_override='shown' に戻る
+ *
+ * tree → events への動線置換: stack ↔ events タブが Header に出ていることも確認する。
+ */
+test.describe("予定管理ページでの visibility_override 切替 (Issue #145)", () => {
+  test("event を予定化解除 → DB / action_log 反映 → 再度予定化", async ({
+    signedInPage: page,
+    testEmail,
+    testUserId,
+  }) => {
+    const eventTitle = "可視性切替テスト MTG";
+    const externalId = "ext-visibility-toggle-e2e";
+
+    const admin = createAdminClient();
+
+    // --- service_role で external_account + subscription + event を seed ---
+    const { data: account, error: accErr } = await admin
+      .from("external_accounts")
+      .upsert(
+        {
+          user_id: testUserId,
+          source: "google_calendar",
+          external_account_id: testEmail,
+          display_name: "(primary)",
+        },
+        { onConflict: "user_id,source,external_account_id" },
+      )
+      .select("id")
+      .single();
+    if (accErr) throw new Error(`[e2e] seed external_account failed: ${accErr.message}`);
+
+    const { error: subErr } = await admin.from("user_calendar_subscriptions").upsert(
+      {
+        user_id: testUserId,
+        external_account_id: account!.id,
+        source: "google_calendar",
+        external_calendar_id: "primary",
+        auto_promote_to_timeline: true,
+        display_name: "(primary)",
+      },
+      { onConflict: "user_id,external_account_id,external_calendar_id" },
+    );
+    if (subErr) throw new Error(`[e2e] seed subscription failed: ${subErr.message}`);
+
+    const start = todayAt(14, 0);
+    const end = todayAt(15, 0);
+    const { error: evErr } = await admin.from("events").insert({
+      user_id: testUserId,
+      title: eventTitle,
+      start_time: start.toISOString(),
+      end_time: end.toISOString(),
+      project_id: null,
+      meet_url: null,
+      has_attachments: false,
+      description: "",
+      source: "google_calendar",
+      external_id: externalId,
+      external_calendar_id: "primary",
+      visibility_override: "none",
+    });
+    if (evErr) throw new Error(`[e2e] seed event failed: ${evErr.message}`);
+
+    // --- /events ページに遷移 ---
+    await page.getByRole("link", { name: "予定" }).click();
+    await page.waitForURL((url) => url.pathname === "/events", { timeout: 10_000 });
+
+    const heading = page.getByRole("heading", { name: "予定管理" });
+    await expect(heading).toBeVisible();
+
+    // 当該 event の row が default で表示される (auto_promote=true なので 予定化中)
+    const row = page
+      .getByRole("listitem")
+      .filter({ hasText: eventTitle })
+      // 内側 li (date group) と紛らわしいので、ボタンを含む leaf を取る
+      .filter({ has: page.getByRole("button", { name: /予定化(解除|する)/ }) });
+    await expect(row).toBeVisible();
+    await expect(row.getByText("予定化中").first()).toBeVisible();
+
+    // --- 予定化解除を押す ---
+    const adminBefore = await admin
+      .from("events")
+      .select("visibility_override")
+      .eq("user_id", testUserId)
+      .eq("external_id", externalId)
+      .single();
+    expect(adminBefore.data?.visibility_override).toBe("none");
+
+    await row.getByRole("button", { name: "予定化解除" }).click();
+
+    // --- DB 反映を待つ ---
+    await expect
+      .poll(
+        async () => {
+          const { data } = await admin
+            .from("events")
+            .select("visibility_override")
+            .eq("user_id", testUserId)
+            .eq("external_id", externalId)
+            .single();
+          return data?.visibility_override;
+        },
+        { message: "visibility_override should flip to hidden", timeout: 5_000 },
+      )
+      .toBe("hidden");
+
+    // --- action_log: event_demoted (is_override_of_default=true) ---
+    const demoted = await waitForActionLog(
+      admin,
+      testUserId,
+      (r) =>
+        r.action_type === "event_demoted" &&
+        (r.metadata as Record<string, unknown>)["external_id"] === externalId,
+      { description: "event_demoted action_log" },
+    );
+    expect(demoted.metadata).toMatchObject({
+      source: "google_calendar",
+      external_calendar_id: "primary",
+      external_id: externalId,
+      from: "none",
+      to: "hidden",
+      subscription_auto_promote: true,
+      // auto_promote=true で hidden へは default 逸脱
+      is_override_of_default: true,
+    });
+
+    // --- UI 側でラベル / ボタン文言が切り替わる ---
+    await expect(row.getByText("予定化解除中").first()).toBeVisible();
+    await expect(row.getByRole("button", { name: "予定化する" })).toBeVisible();
+
+    // --- 再度予定化 → shown ---
+    await row.getByRole("button", { name: "予定化する" }).click();
+
+    await expect
+      .poll(
+        async () => {
+          const { data } = await admin
+            .from("events")
+            .select("visibility_override")
+            .eq("user_id", testUserId)
+            .eq("external_id", externalId)
+            .single();
+          return data?.visibility_override;
+        },
+        { message: "visibility_override should flip to shown", timeout: 5_000 },
+      )
+      .toBe("shown");
+
+    const promoted = await waitForActionLog(
+      admin,
+      testUserId,
+      (r) =>
+        r.action_type === "event_promoted" &&
+        (r.metadata as Record<string, unknown>)["external_id"] === externalId,
+      { description: "event_promoted action_log" },
+    );
+    expect(promoted.metadata).toMatchObject({
+      from: "hidden",
+      to: "shown",
+      subscription_auto_promote: true,
+      // auto_promote=true で shown は default 一致
+      is_override_of_default: false,
+    });
+  });
+
+  test("ヘッダーから tree 動線が消えて events 動線に置き換わっている", async ({
+    signedInPage: page,
+  }) => {
+    // 動線置換: stack / 予定 のみ (tree は無し)。
+    await expect(page.getByRole("link", { name: "Stack" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "予定" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Tree" })).toHaveCount(0);
+  });
+});
+
+function todayAt(hour: number, minute: number): Date {
+  const d = new Date();
+  d.setHours(hour, minute, 0, 0);
+  return d;
+}

--- a/e2e/event-visibility-override.spec.ts
+++ b/e2e/event-visibility-override.spec.ts
@@ -80,12 +80,9 @@ test.describe("予定管理ページでの visibility_override 切替 (Issue #14
     const heading = page.getByRole("heading", { name: "予定管理" });
     await expect(heading).toBeVisible();
 
-    // 当該 event の row が default で表示される (auto_promote=true なので 予定化中)
-    const row = page
-      .getByRole("listitem")
-      .filter({ hasText: eventTitle })
-      // 内側 li (date group) と紛らわしいので、ボタンを含む leaf を取る
-      .filter({ has: page.getByRole("button", { name: /予定化(解除|する)/ }) });
+    // 当該 event の row が default で表示される (auto_promote=true なので 予定化中)。
+    // 日付グループは <section> なので getByRole('listitem') は leaf 行だけが返る。
+    const row = page.getByRole("listitem").filter({ hasText: eventTitle });
     await expect(row).toBeVisible();
     await expect(row.getByText("予定化中").first()).toBeVisible();
 

--- a/e2e/golden-path.spec.ts
+++ b/e2e/golden-path.spec.ts
@@ -86,11 +86,12 @@ test("Phase 1 golden path", async ({ signedInPage: page }) => {
   await expect(stack.getByRole("listitem").filter({ hasText: taskA })).toBeVisible();
   await expect(stack.getByRole("listitem").filter({ hasText: taskB })).toHaveCount(0);
 
-  // --- Tree View に遷移 ----------------------------------------------------
-  await page.getByRole("link", { name: "Tree" }).click();
-  await page.waitForURL((url) => url.pathname === "/tree");
-  // Tree View でも header の kozu/tsumi ロゴは同じ位置に残る。
+  // --- 予定管理ページに遷移 (Issue #145: tree 動線 → events 動線) -----------
+  await page.getByRole("link", { name: "予定" }).click();
+  await page.waitForURL((url) => url.pathname === "/events");
+  // 予定管理ページでも header の kozu/tsumi ロゴは同じ位置に残る。
   await expect(page.getByText("kozu").first()).toBeVisible();
+  await expect(page.getByRole("heading", { name: "予定管理" })).toBeVisible();
 });
 
 /**

--- a/e2e/tree-view-history.spec.ts
+++ b/e2e/tree-view-history.spec.ts
@@ -14,8 +14,9 @@ import { expect, test } from "./fixtures";
 test("Tree View renders mock history grouped by date with project legend", async ({
   signedInPage: page,
 }) => {
-  // Tree View へ遷移 (golden-path と同じ semantic locator)。
-  await page.getByRole("link", { name: "Tree" }).click();
+  // Issue #145: Tree タブはヘッダー動線から外したので、direct URL で遷移する。
+  // /tree route 自体は維持しているため描画 regression は引き続き踏める。
+  await page.goto("/tree");
   await page.waitForURL((url) => url.pathname === "/tree");
 
   // TreeView 全体は role=region (aria-label="作業履歴") で scope する。

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -21,6 +21,7 @@ import { AddButton } from "@/features/add-forms/AddButton";
 import { AddPanel } from "@/features/add-forms/AddPanel";
 import { DayTimeline } from "@/features/day-timeline/DayTimeline";
 import { EventDetailPanel } from "@/features/event-detail/EventDetailPanel";
+import { EventManagement } from "@/features/event-management/EventManagement";
 import { ProjectDetailPanel } from "@/features/project-detail/ProjectDetailPanel";
 import { SettingsPanel } from "@/features/settings/SettingsPanel";
 import { CalendarSyncButton } from "@/features/sync/CalendarSyncButton";
@@ -44,7 +45,7 @@ import {
 import { writeSampleDataMode } from "@/shared/lib/sample-data";
 import { todayIso } from "@/shared/lib/time";
 
-type View = "stack" | "tree";
+type View = "stack" | "tree" | "events";
 
 type AppShellProps = {
   initialView: View;
@@ -123,6 +124,7 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
     updateEventProject,
     updateEvent,
     deleteEvent,
+    setEventVisibilityOverride,
     createProject,
     updateProject,
     deleteProject,
@@ -176,9 +178,11 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
   );
   const treeProjects = useMemo(() => mergeTreeProjects(projects, historyData), [projects]);
 
+  // Issue #145: tree タブ (Phase 1 PoC) は dogfooding でメンテされていないため
+  // 動線を「予定管理」に差し替える。/tree route 自体は残す (直接 URL では到達可能)。
   const tabs: { key: View; label: string; href: string }[] = [
     { key: "stack", label: "Stack", href: "/" },
-    { key: "tree", label: "Tree", href: "/tree" },
+    { key: "events", label: "予定", href: "/events" },
   ];
 
   return (
@@ -239,6 +243,13 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
               onOpenDetail={setDetailId}
               onOpenEvent={setEventDetailId}
             />
+          ) : view === "events" ? (
+            <EventManagement
+              events={events}
+              subscriptions={calendarSubscriptions}
+              onSetVisibilityOverride={setEventVisibilityOverride}
+              onOpenEvent={setEventDetailId}
+            />
           ) : (
             <TreeView historyData={historyData} projectOrder={projectOrderForTree} />
           )}
@@ -265,15 +276,23 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
           {eventDetailId &&
             (() => {
               const ev = events.find((e) => e.id === eventDetailId);
-              return ev ? (
+              if (!ev) return null;
+              const sub = calendarSubscriptions.find(
+                (s) => s.source === ev.source && s.externalCalendarId === ev.externalCalendarId,
+              );
+              // manual / orphan は subscription を持たないので default 表示扱い (ADR 0032)。
+              const subscriptionAutoPromote = sub ? sub.autoPromoteToTimeline : true;
+              return (
                 <EventDetailPanel
                   event={ev}
                   onClose={() => setEventDetailId(null)}
                   onChangeProject={updateEventProject}
                   onUpdate={updateEvent}
                   onDelete={deleteEvent}
+                  onSetVisibilityOverride={setEventVisibilityOverride}
+                  subscriptionAutoPromote={subscriptionAutoPromote}
                 />
-              ) : null;
+              );
             })()}
 
           <AddButton onClick={() => setAddOpen(true)} />
@@ -310,6 +329,8 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
             open={settingsOpen}
             onClose={() => setSettingsOpen(false)}
             primaryExternalAccountId={calendarSubscriptions[0]?.externalAccountId ?? null}
+            events={events}
+            onSetVisibilityOverride={setEventVisibilityOverride}
           />
         </div>
       </CorrectionFactorsProvider>

--- a/src/app/api/events/[id]/visibility-override/route.ts
+++ b/src/app/api/events/[id]/visibility-override/route.ts
@@ -1,0 +1,163 @@
+import { NextResponse } from "next/server";
+
+import { logServerSide } from "@/entities/action-log/server";
+import { SupabaseCalendarSubscriptionGateway } from "@/entities/calendar-subscription/supabase-gateway";
+import { SupabaseEventGateway } from "@/entities/event/supabase-gateway";
+import { EVENT_SOURCE, type EventVisibilityOverride } from "@/entities/event/types";
+import { createClient } from "@/shared/supabase/server";
+
+/**
+ * Issue #145 / ADR 0031 Layer 3 / ADR 0032 / ADR 0034 / ADR 0035:
+ * 個別 event の `visibility_override` を更新する。
+ *
+ * - PATCH /api/events/[id]/visibility-override
+ *   body: { value: 'shown' | 'hidden' | 'none' }
+ *
+ * 値ごとの action_log:
+ *   - 'shown'  → event_promoted (user actor)
+ *   - 'hidden' → event_demoted  (user actor)
+ *   - 'none'   → event_override_cleared (user actor) — 設定画面の override 一覧 reset 専用導線
+ *                (ADR 0032: 日常 UI から none への reset は不可)
+ *
+ * `is_override_of_default` の計算 (ADR 0035 §4 の event_promoted / event_demoted):
+ *   subscription.auto_promote_to_timeline と to の関係から、ユーザーが default に
+ *   逆らった操作だったかを判定する。Phase 4 学習素材の核シグナル。
+ *   - to='shown'  かつ auto_promote=true  → false (default に従っただけ)
+ *   - to='shown'  かつ auto_promote=false → true  (default に逆らった)
+ *   - to='hidden' かつ auto_promote=true  → true
+ *   - to='hidden' かつ auto_promote=false → false
+ *   manual event は subscription を持たないが、`auto_promote=true` (= default 表示)
+ *   と同等扱いにして同じ式を適用する (ADR 0032 で manual も visibility_override を持つ)。
+ */
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+type PatchBody = {
+  value?: string;
+};
+
+const VALID_VALUES = new Set<EventVisibilityOverride>(["none", "shown", "hidden"]);
+
+export async function PATCH(req: Request, ctx: RouteContext) {
+  const { id } = await ctx.params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  let body: PatchBody;
+  try {
+    body = (await req.json()) as PatchBody;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const next = body.value as EventVisibilityOverride | undefined;
+  if (!next || !VALID_VALUES.has(next)) {
+    return NextResponse.json(
+      { error: "invalid_input", message: "value は 'none' | 'shown' | 'hidden' のいずれか" },
+      { status: 400 },
+    );
+  }
+
+  // 現状の event を読む。RLS 違反 / 見つからない場合は 404 で早期 return。
+  const { data: row, error: readErr } = await supabase
+    .from("events")
+    .select("id, source, external_id, external_calendar_id, visibility_override, user_id")
+    .eq("id", id)
+    .maybeSingle();
+  if (readErr) {
+    console.error("[events/visibility-override] read failed", readErr);
+    return NextResponse.json({ error: "read_failed" }, { status: 500 });
+  }
+  if (!row) return NextResponse.json({ error: "not_found" }, { status: 404 });
+
+  const from = row.visibility_override as EventVisibilityOverride;
+  if (from === next) {
+    // 値に変化が無ければ DB 更新も action_log も書かない (連打 / 再送に強い)。
+    return NextResponse.json({ from, to: next, changed: false });
+  }
+
+  // subscription を引いて auto_promote を取る (manual は null)。
+  let subscriptionAutoPromote = true;
+  let externalAccountIdentifier = "";
+  if (row.source === EVENT_SOURCE.GOOGLE_CALENDAR) {
+    const subs = await new SupabaseCalendarSubscriptionGateway(supabase).list();
+    const sub = subs.find(
+      (s) => s.source === row.source && s.externalCalendarId === row.external_calendar_id,
+    );
+    if (sub) {
+      subscriptionAutoPromote = sub.autoPromoteToTimeline;
+      externalAccountIdentifier = sub.externalAccountIdentifier;
+    }
+  }
+
+  // 物理更新
+  try {
+    const gateway = new SupabaseEventGateway(supabase);
+    await gateway.setVisibilityOverride(id, next);
+  } catch (error) {
+    console.error("[events/visibility-override] update failed", error);
+    return NextResponse.json({ error: "update_failed" }, { status: 500 });
+  }
+
+  // action_log 発火
+  const tripleBase = {
+    source: row.source,
+    external_account_id: externalAccountIdentifier,
+    external_calendar_id: row.external_calendar_id,
+    external_id: row.external_id ?? "",
+  };
+
+  if (next === "shown") {
+    // to='shown' かつ default が auto_promote=true (= 表示) なら is_override_of_default=false。
+    // to='shown' かつ default が auto_promote=false (= 非表示) なら是 default 逸脱。
+    const isOverrideOfDefault = !subscriptionAutoPromote;
+    await logServerSide(
+      supabase,
+      user.id,
+      "event_promoted",
+      {
+        ...tripleBase,
+        from,
+        to: "shown",
+        subscription_auto_promote: subscriptionAutoPromote,
+        is_override_of_default: isOverrideOfDefault,
+      },
+      "user",
+    );
+  } else if (next === "hidden") {
+    const isOverrideOfDefault = subscriptionAutoPromote;
+    await logServerSide(
+      supabase,
+      user.id,
+      "event_demoted",
+      {
+        ...tripleBase,
+        from,
+        to: "hidden",
+        subscription_auto_promote: subscriptionAutoPromote,
+        is_override_of_default: isOverrideOfDefault,
+      },
+      "user",
+    );
+  } else {
+    // next === 'none': override 解除 (ADR 0032: 設定画面 reset 専用導線)
+    if (from !== "none") {
+      await logServerSide(
+        supabase,
+        user.id,
+        "event_override_cleared",
+        {
+          ...tripleBase,
+          from,
+          subscription_auto_promote: subscriptionAutoPromote,
+        },
+        "user",
+      );
+    }
+  }
+
+  return NextResponse.json({ from, to: next, changed: true });
+}

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,0 +1,32 @@
+import { redirect } from "next/navigation";
+
+import { GatewayProvider } from "@/shared/gateway/GatewayContext";
+import { isAiEnabled } from "@/shared/ai/env";
+import { createClient } from "@/shared/supabase/server";
+
+import { AppShell } from "../AppShell";
+
+export default async function EventsPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const meta = (user.user_metadata ?? {}) as Record<string, unknown>;
+  return (
+    <GatewayProvider>
+      <AppShell
+        initialView="events"
+        aiEnabled={isAiEnabled()}
+        user={{
+          email: user.email ?? null,
+          avatarUrl: typeof meta.avatar_url === "string" ? meta.avatar_url : null,
+        }}
+      />
+    </GatewayProvider>
+  );
+}

--- a/src/app/useDashboardMutations.ts
+++ b/src/app/useDashboardMutations.ts
@@ -6,7 +6,7 @@ import { useCallback } from "react";
 import { dashboardKeys } from "./useDashboardQueries";
 import { ACTION_TYPES, log } from "@/entities/action-log/logger";
 import type { CreateEventInput, UpdateEventInput } from "@/entities/event/gateway";
-import type { Event } from "@/entities/event/types";
+import type { Event, EventVisibilityOverride } from "@/entities/event/types";
 import type { CreateProjectInput, UpdateProjectInput } from "@/entities/project/gateway";
 import type { Project } from "@/entities/project/types";
 import type { CreateTaskInput } from "@/entities/task/gateway";
@@ -45,6 +45,12 @@ export type DashboardMutations = {
   updateEvent: (id: string, patch: UpdateEventInput) => Promise<void>;
   /** ADR 0010: manual event の削除。google_calendar は gateway 側で弾く。 */
   deleteEvent: (id: string) => Promise<void>;
+  /**
+   * Issue #145 / ADR 0032 Layer 3: event の visibility_override を更新。
+   * 'shown' / 'hidden' は EventDetailPanel と予定管理ページから、'none' は SettingsPanel
+   * の override 一覧 reset 専用導線から呼ぶ (ADR 0032: 日常 UI から none へは戻せない)。
+   */
+  setEventVisibilityOverride: (id: string, value: EventVisibilityOverride) => Promise<void>;
   createProject: (input: CreateProjectInput) => Promise<void>;
   updateProject: (id: string, patch: UpdateProjectInput) => Promise<void>;
   /** schema 上 ON DELETE SET NULL なので tasks/events も invalidate する。 */
@@ -284,6 +290,44 @@ export function useDashboardMutations(): DashboardMutations {
     },
   });
 
+  // Issue #145 / ADR 0031 Layer 3 / ADR 0032: event の visibility_override を更新する。
+  // server 側 (PATCH /api/events/[id]/visibility-override) で action_log
+  // (event_promoted / event_demoted / event_override_cleared) を発火し、
+  // is_override_of_default は subscription.auto_promote と to の関係から計算する。
+  // optimistic に events cache を書き換え、失敗したら rollback する。
+  const setEventVisibilityOverrideMutation = useMutation({
+    mutationFn: async ({ id, value }: { id: string; value: EventVisibilityOverride }) => {
+      const res = await fetch(`/api/events/${id}/visibility-override`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ value }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(body?.error ?? `visibility_override_failed: ${res.status}`);
+      }
+      return (await res.json()) as {
+        from: EventVisibilityOverride;
+        to: EventVisibilityOverride;
+        changed: boolean;
+      };
+    },
+    onMutate: async ({ id, value }) => {
+      await queryClient.cancelQueries({ queryKey: dashboardKeys.events });
+      const previous = queryClient.getQueryData<Event[]>(dashboardKeys.events);
+      queryClient.setQueryData<Event[]>(dashboardKeys.events, (prev) =>
+        (prev ?? []).map((e) => (e.id === id ? { ...e, visibilityOverride: value } : e)),
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(dashboardKeys.events, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.events });
+    },
+  });
+
   // ADR 0010: manual イベントだけが UI から削除可能。google_calendar は
   // SupabaseEventGateway.delete が source を見て弾く。
   const deleteEventMutation = useMutation({
@@ -489,6 +533,8 @@ export function useDashboardMutations(): DashboardMutations {
     updateEvent: (id, patch) =>
       updateEventMutation.mutateAsync({ id, patch }).then(() => undefined),
     deleteEvent: (id) => deleteEventMutation.mutateAsync(id).then(() => undefined),
+    setEventVisibilityOverride: (id, value) =>
+      setEventVisibilityOverrideMutation.mutateAsync({ id, value }).then(() => undefined),
     createProject: (input) => createProjectMutation.mutateAsync(input).then(() => undefined),
     updateProject: (id, patch) =>
       updateProjectMutation.mutateAsync({ id, patch }).then(() => undefined),

--- a/src/entities/event/gateway.ts
+++ b/src/entities/event/gateway.ts
@@ -1,4 +1,4 @@
-import type { Event } from "./types";
+import type { Event, EventVisibilityOverride } from "./types";
 
 export type CreateEventInput = {
   title: string;
@@ -74,6 +74,12 @@ export interface EventGateway {
   findAllGoogleEventsByCalendar(externalCalendarId: string): Promise<DeletedEventSnapshot[]>;
   /** 指定 calendar に紐づく google_calendar source の events を一括削除する。 */
   deleteAllGoogleEventsByCalendar(externalCalendarId: string): Promise<number>;
+  /**
+   * Issue #145 / ADR 0032: event 単位の `visibility_override` を更新する。
+   * 戻り値は更新後の Event。Layer 3 操作 UI (EventDetailPanel / 予定管理ページ /
+   * SettingsPanel の override 一覧) から呼ばれる。
+   */
+  setVisibilityOverride(id: string, value: EventVisibilityOverride): Promise<Event>;
 }
 
 /**

--- a/src/entities/event/supabase-gateway.test.ts
+++ b/src/entities/event/supabase-gateway.test.ts
@@ -202,6 +202,46 @@ describe("SupabaseEventGateway.update", () => {
 });
 
 // ---------------------------------------------------------------------------
+// setVisibilityOverride: Issue #145 / ADR 0032 — event 単位 override の更新
+// ---------------------------------------------------------------------------
+describe("SupabaseEventGateway.setVisibilityOverride", () => {
+  test("visibility_override 列だけを update し、更新後の Event を返す", async () => {
+    const updated = makeRow({ visibility_override: "shown" });
+    const { supabase, calls } = makeSupabase({
+      results: [
+        { data: updated }, // update().eq().select().single()
+      ],
+    });
+    const gw = new SupabaseEventGateway(supabase);
+
+    const result = await gw.setVisibilityOverride("e1", "shown");
+
+    expect(result.visibilityOverride).toBe("shown");
+    const eventsCalls = calls.filter((c) => c.table === "events");
+    const updateCall = eventsCalls.find((c) => c.method === "update");
+    expect(updateCall).toBeDefined();
+    expect(updateCall!.args[0]).toEqual({ visibility_override: "shown" });
+    // Google read-only 確認 (fetchSource) は呼ばない (visibility_override は kozutsumi 側拡張)。
+    const sourceSelects = eventsCalls.filter(
+      (c) => c.method === "select" && (c.args[0] as string) === "source",
+    );
+    expect(sourceSelects).toHaveLength(0);
+  });
+
+  test("hidden / none も同じ経路で update する", async () => {
+    for (const value of ["hidden", "none"] as const) {
+      const updated = makeRow({ visibility_override: value });
+      const { supabase, calls } = makeSupabase({ results: [{ data: updated }] });
+      const gw = new SupabaseEventGateway(supabase);
+      const r = await gw.setVisibilityOverride("e1", value);
+      expect(r.visibilityOverride).toBe(value);
+      const updateCall = calls.find((c) => c.method === "update");
+      expect(updateCall!.args[0]).toEqual({ visibility_override: value });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // delete: ADR 0010 / P2-4 — google_calendar は UI から削除不可
 // ---------------------------------------------------------------------------
 describe("SupabaseEventGateway.delete", () => {

--- a/src/entities/event/supabase-gateway.ts
+++ b/src/entities/event/supabase-gateway.ts
@@ -9,7 +9,7 @@ import type {
   UpdateEventInput,
   UpsertGoogleCalendarEventInput,
 } from "./gateway";
-import { EVENT_SOURCE, type Event } from "./types";
+import { EVENT_SOURCE, type Event, type EventVisibilityOverride } from "./types";
 
 type Sb = SupabaseClient<Database>;
 
@@ -224,6 +224,17 @@ export class SupabaseEventGateway implements EventGateway {
       .eq("external_calendar_id", externalCalendarId);
     if (error) throw error;
     return count ?? 0;
+  }
+
+  async setVisibilityOverride(id: string, value: EventVisibilityOverride): Promise<Event> {
+    const { data, error } = await this.supabase
+      .from("events")
+      .update({ visibility_override: value })
+      .eq("id", id)
+      .select("*")
+      .single();
+    if (error) throw error;
+    return fromRow(data);
   }
 }
 

--- a/src/entities/event/sync.test.ts
+++ b/src/entities/event/sync.test.ts
@@ -187,6 +187,7 @@ function makeFakeGateway(opts: { snapshots?: DeletedEventSnapshot[] } = {}) {
     update: vi.fn(),
     delete: vi.fn(),
     deleteAllForCurrentUser: vi.fn(),
+    setVisibilityOverride: vi.fn(),
     upsertFromGoogleCalendar: vi.fn(async (inputs) => {
       upsertCalls.push(inputs);
       return inputs.length;

--- a/src/features/event-detail/EventDetailPanel.test.tsx
+++ b/src/features/event-detail/EventDetailPanel.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render as rtlRender, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { UpdateEventInput } from "../../entities/event/gateway";
-import type { Event } from "../../entities/event/types";
+import type { Event, EventVisibilityOverride } from "../../entities/event/types";
 import type { Project } from "../../entities/project/types";
 import { ProjectsProvider } from "../../entities/project/ProjectsContext";
 import { EventDetailPanel } from "./EventDetailPanel";
@@ -46,6 +46,8 @@ function renderPanel(
     onChangeProject: (id: string, projectId: string | null) => void;
     onUpdate: (id: string, patch: UpdateEventInput) => Promise<void> | void;
     onDelete: (id: string) => Promise<void> | void;
+    onSetVisibilityOverride: (id: string, value: EventVisibilityOverride) => Promise<void> | void;
+    subscriptionAutoPromote: boolean;
   }> = {},
 ) {
   const props = { event: baseEvent, onClose: noop, ...overrides };
@@ -311,6 +313,88 @@ describe("EventDetailPanel", () => {
       expect(await findByText("DB error")).toBeTruthy();
       // 編集モードのまま (タイトル input が残る)
       expect(getByLabelText("タイトル")).toBeTruthy();
+    });
+  });
+
+  // Issue #145 / ADR 0031 Layer 3 / ADR 0032: 予定化 / 予定化解除の toggle UI
+  describe("予定化 toggle (Issue #145)", () => {
+    test("onSetVisibilityOverride 未指定なら toggle ボタンを出さない", () => {
+      const { queryByRole } = renderPanel();
+      expect(queryByRole("button", { name: "予定化解除" })).toBeNull();
+      expect(queryByRole("button", { name: "予定化する" })).toBeNull();
+    });
+
+    test("override='none' + auto_promote=true → 予定化中 / 予定化解除 ボタン", () => {
+      const { getByText, getByRole } = renderPanel({
+        onSetVisibilityOverride: vi.fn(),
+        subscriptionAutoPromote: true,
+      });
+      expect(getByText("予定化中（自動）")).toBeTruthy();
+      expect(getByRole("button", { name: "予定化解除" })).toBeTruthy();
+    });
+
+    test("override='none' + auto_promote=false → 予定化解除中 / 予定化する ボタン", () => {
+      const { getByText, getByRole } = renderPanel({
+        onSetVisibilityOverride: vi.fn(),
+        subscriptionAutoPromote: false,
+      });
+      expect(getByText("予定化解除中（自動）")).toBeTruthy();
+      expect(getByRole("button", { name: "予定化する" })).toBeTruthy();
+    });
+
+    test("override='shown' は default に関係なく予定化中表示", () => {
+      const { getByText, queryByText } = renderPanel({
+        event: { ...baseEvent, visibilityOverride: "shown" },
+        onSetVisibilityOverride: vi.fn(),
+        subscriptionAutoPromote: false,
+      });
+      expect(getByText("予定化中")).toBeTruthy();
+      // (自動) ラベルは override='none' のときだけ
+      expect(queryByText("予定化中（自動）")).toBeNull();
+    });
+
+    test("override='hidden' は default に関係なく予定化解除中表示", () => {
+      const { getByText } = renderPanel({
+        event: { ...baseEvent, visibilityOverride: "hidden" },
+        onSetVisibilityOverride: vi.fn(),
+        subscriptionAutoPromote: true,
+      });
+      expect(getByText("予定化解除中")).toBeTruthy();
+    });
+
+    test("予定化解除ボタン → onSetVisibilityOverride('hidden')", async () => {
+      const onSetVisibilityOverride = vi.fn().mockResolvedValue(undefined);
+      const { getByRole } = renderPanel({
+        onSetVisibilityOverride,
+        subscriptionAutoPromote: true,
+      });
+      fireEvent.click(getByRole("button", { name: "予定化解除" }));
+      await waitFor(() => {
+        expect(onSetVisibilityOverride).toHaveBeenCalledWith("e1", "hidden");
+      });
+    });
+
+    test("予定化するボタン → onSetVisibilityOverride('shown')", async () => {
+      const onSetVisibilityOverride = vi.fn().mockResolvedValue(undefined);
+      const { getByRole } = renderPanel({
+        event: { ...baseEvent, visibilityOverride: "hidden" },
+        onSetVisibilityOverride,
+        subscriptionAutoPromote: true,
+      });
+      fireEvent.click(getByRole("button", { name: "予定化する" }));
+      await waitFor(() => {
+        expect(onSetVisibilityOverride).toHaveBeenCalledWith("e1", "shown");
+      });
+    });
+
+    test("onSetVisibilityOverride reject 時はエラー文言を表示", async () => {
+      const onSetVisibilityOverride = vi.fn().mockRejectedValue(new Error("rpc failed"));
+      const { getByRole, findByText } = renderPanel({
+        onSetVisibilityOverride,
+        subscriptionAutoPromote: true,
+      });
+      fireEvent.click(getByRole("button", { name: "予定化解除" }));
+      expect(await findByText("rpc failed")).toBeTruthy();
     });
   });
 

--- a/src/features/event-detail/EventDetailPanel.tsx
+++ b/src/features/event-detail/EventDetailPanel.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 import type { UpdateEventInput } from "../../entities/event/gateway";
-import { EVENT_SOURCE, type Event } from "../../entities/event/types";
+import { EVENT_SOURCE, type Event, type EventVisibilityOverride } from "../../entities/event/types";
 import { GoogleCalendarBadge } from "../../entities/event/GoogleCalendarBadge";
 import { getProject } from "../../entities/project/projects";
 import { useProjects } from "../../entities/project/ProjectsContext";
@@ -35,6 +35,18 @@ type EventDetailPanelProps = {
    * バックを渡しても source='google_calendar' では削除ボタンを表示しない。
    */
   onDelete?: (id: string) => Promise<void> | void;
+  /**
+   * Issue #145 / ADR 0032 Layer 3: event 単位の予定化 override を切り替える。
+   * 'shown' / 'hidden' 双方向の toggle のみ受け付ける (日常 UI で 'none' へは戻せない)。
+   * 未指定なら toggle UI も表示しない (テストや特殊呼び出しで省略可)。
+   */
+  onSetVisibilityOverride?: (id: string, value: EventVisibilityOverride) => Promise<void> | void;
+  /**
+   * 当該 event の calendar subscription の `auto_promote_to_timeline` 値。
+   * `visibility_override='none'` のとき、effective visibility 計算に使う。
+   * 不明 (subscription なし / manual) のときは true (= 既定で表示) として扱う。
+   */
+  subscriptionAutoPromote?: boolean;
 };
 
 export function EventDetailPanel({
@@ -43,6 +55,8 @@ export function EventDetailPanel({
   onChangeProject,
   onUpdate,
   onDelete,
+  onSetVisibilityOverride,
+  subscriptionAutoPromote = true,
 }: EventDetailPanelProps) {
   const { projects, projectsById } = useProjects();
   const proj = event.projectId ? getProject(projectsById, event.projectId) : null;
@@ -67,7 +81,35 @@ export function EventDetailPanel({
   const [editingProject, setEditingProject] = useState(false);
   const [editing, setEditing] = useState(false);
   const [pending, setPending] = useState(false);
+  const [visibilityPending, setVisibilityPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Issue #145 / ADR 0031 Layer 3: 現状の effective visibility を計算し、ボタン文言を決める。
+  // - override='shown' → effective shown (default 逸脱 or default 一致は問わず表示中)
+  // - override='hidden' → effective hidden
+  // - override='none' → subscription.auto_promote に従う (manual / 未知 subscription は true 扱い)
+  const canToggleVisibility = !!onSetVisibilityOverride && !editing;
+  const effectiveShown =
+    event.visibilityOverride === "shown"
+      ? true
+      : event.visibilityOverride === "hidden"
+        ? false
+        : subscriptionAutoPromote;
+  const overrideActive = event.visibilityOverride !== "none";
+
+  const handleToggleVisibility = async () => {
+    if (visibilityPending || !onSetVisibilityOverride) return;
+    const next: EventVisibilityOverride = effectiveShown ? "hidden" : "shown";
+    setVisibilityPending(true);
+    setError(null);
+    try {
+      await onSetVisibilityOverride(event.id, next);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "予定化の切替に失敗しました");
+    } finally {
+      setVisibilityPending(false);
+    }
+  };
 
   // 編集フォームの draft 値。編集モードに入る時に event 値で初期化する。
   const [draftTitle, setDraftTitle] = useState(event.title);
@@ -289,6 +331,33 @@ export function EventDetailPanel({
                 </div>
               </div>
             )}
+
+            {canToggleVisibility ? (
+              <div className="px-5 pb-2">
+                <div className="flex items-center gap-2">
+                  <span className="font-jp text-[10px] text-fg-weak">予定化</span>
+                  <span
+                    className={`rounded-[4px] border px-1.5 py-[1px] font-jp text-[10px] ${
+                      effectiveShown
+                        ? "border-accent-blue/40 text-accent-blue"
+                        : "border-bg-divider text-fg-weak"
+                    }`}
+                  >
+                    {effectiveShown ? "予定化中" : "予定化解除中"}
+                    {overrideActive ? "" : "（自動）"}
+                  </span>
+                  <div className="flex-1" />
+                  <button
+                    type="button"
+                    onClick={handleToggleVisibility}
+                    disabled={visibilityPending}
+                    className="rounded-[4px] border border-bg-divider bg-transparent px-2.5 py-[3px] font-jp text-[10px] text-fg-subtle disabled:opacity-60"
+                  >
+                    {effectiveShown ? "予定化解除" : "予定化する"}
+                  </button>
+                </div>
+              </div>
+            ) : null}
 
             {error ? (
               <div className="px-5 pb-2">

--- a/src/features/event-management/EventManagement.test.tsx
+++ b/src/features/event-management/EventManagement.test.tsx
@@ -1,0 +1,163 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import type { CalendarSubscription } from "@/entities/calendar-subscription/types";
+import type { Event } from "@/entities/event/types";
+
+import { EventManagement } from "./EventManagement";
+
+const sub: CalendarSubscription = {
+  id: "sub-primary",
+  externalAccountId: "acc-1",
+  externalAccountIdentifier: "me@example.com",
+  source: "google_calendar",
+  externalCalendarId: "primary",
+  autoPromoteToTimeline: true,
+  displayName: "Primary",
+  color: null,
+  subscribedAt: "2026-04-01T00:00:00.000Z",
+};
+
+const subWork: CalendarSubscription = {
+  ...sub,
+  id: "sub-work",
+  externalCalendarId: "work@example.com",
+  autoPromoteToTimeline: false,
+  displayName: "Work",
+};
+
+const eventA: Event = {
+  id: "ev-A",
+  title: "予定A (primary, default 表示)",
+  startTime: "2026-05-04T01:00:00.000Z",
+  endTime: "2026-05-04T02:00:00.000Z",
+  projectId: null,
+  meetUrl: null,
+  hasAttachments: false,
+  description: "",
+  source: "google_calendar",
+  externalId: "ext-A",
+  externalCalendarId: "primary",
+  visibilityOverride: "none",
+  createdAt: "2026-05-04T00:00:00.000Z",
+};
+
+const eventB: Event = {
+  ...eventA,
+  id: "ev-B",
+  title: "予定B (work, default 非表示)",
+  externalId: "ext-B",
+  externalCalendarId: "work@example.com",
+  visibilityOverride: "none",
+  startTime: "2026-05-04T03:00:00.000Z",
+  endTime: "2026-05-04T04:00:00.000Z",
+};
+
+const eventC: Event = {
+  ...eventA,
+  id: "ev-C",
+  title: "予定C (primary, override=hidden)",
+  externalId: "ext-C",
+  visibilityOverride: "hidden",
+};
+
+describe("EventManagement (Issue #145)", () => {
+  test("default の「すべて」フィルタで全件表示", () => {
+    const { getByText } = render(
+      <EventManagement
+        events={[eventA, eventB, eventC]}
+        subscriptions={[sub, subWork]}
+        onSetVisibilityOverride={vi.fn()}
+      />,
+    );
+    expect(getByText(/予定A/)).toBeTruthy();
+    expect(getByText(/予定B/)).toBeTruthy();
+    expect(getByText(/予定C/)).toBeTruthy();
+  });
+
+  test("「予定化中」フィルタで effective shown のみ表示", () => {
+    const { getByRole, getByText, queryByText } = render(
+      <EventManagement
+        events={[eventA, eventB, eventC]}
+        subscriptions={[sub, subWork]}
+        onSetVisibilityOverride={vi.fn()}
+      />,
+    );
+    fireEvent.click(getByRole("tab", { name: "予定化中" }));
+    expect(getByText(/予定A/)).toBeTruthy(); // primary auto_promote=true
+    expect(queryByText(/予定B/)).toBeNull(); // work auto_promote=false
+    expect(queryByText(/予定C/)).toBeNull(); // override=hidden
+  });
+
+  test("「予定化解除中」フィルタで effective hidden のみ表示", () => {
+    const { getByRole, getByText, queryByText } = render(
+      <EventManagement
+        events={[eventA, eventB, eventC]}
+        subscriptions={[sub, subWork]}
+        onSetVisibilityOverride={vi.fn()}
+      />,
+    );
+    fireEvent.click(getByRole("tab", { name: "予定化解除中" }));
+    expect(queryByText(/予定A/)).toBeNull();
+    expect(getByText(/予定B/)).toBeTruthy();
+    expect(getByText(/予定C/)).toBeTruthy();
+  });
+
+  test("「個別指定中」フィルタで visibility_override !== 'none' のみ", () => {
+    const { getByRole, queryByText, getByText } = render(
+      <EventManagement
+        events={[eventA, eventB, eventC]}
+        subscriptions={[sub, subWork]}
+        onSetVisibilityOverride={vi.fn()}
+      />,
+    );
+    fireEvent.click(getByRole("tab", { name: "個別指定中" }));
+    expect(queryByText(/予定A/)).toBeNull();
+    expect(queryByText(/予定B/)).toBeNull();
+    expect(getByText(/予定C/)).toBeTruthy();
+  });
+
+  test("予定化するボタン → onSetVisibilityOverride('shown')", async () => {
+    const cb = vi.fn().mockResolvedValue(undefined);
+    const { getAllByRole } = render(
+      <EventManagement events={[eventB]} subscriptions={[subWork]} onSetVisibilityOverride={cb} />,
+    );
+    // eventB は default 非表示 (auto_promote=false, override=none) → button: 予定化する
+    const btn = getAllByRole("button", { name: "予定化する" })[0];
+    fireEvent.click(btn);
+    await waitFor(() => {
+      expect(cb).toHaveBeenCalledWith("ev-B", "shown");
+    });
+  });
+
+  test("予定化解除ボタン → onSetVisibilityOverride('hidden')", async () => {
+    const cb = vi.fn().mockResolvedValue(undefined);
+    const { getAllByRole } = render(
+      <EventManagement events={[eventA]} subscriptions={[sub]} onSetVisibilityOverride={cb} />,
+    );
+    const btn = getAllByRole("button", { name: "予定化解除" })[0];
+    fireEvent.click(btn);
+    await waitFor(() => {
+      expect(cb).toHaveBeenCalledWith("ev-A", "hidden");
+    });
+  });
+
+  test("空の場合は空メッセージを表示", () => {
+    const { getByText } = render(
+      <EventManagement events={[]} subscriptions={[]} onSetVisibilityOverride={vi.fn()} />,
+    );
+    expect(getByText(/取り込み済みの予定がありません/)).toBeTruthy();
+  });
+
+  test("カレンダー displayName が表示される (subscription とのマッチ経由)", () => {
+    const { getAllByText } = render(
+      <EventManagement
+        events={[eventA, eventB]}
+        subscriptions={[sub, subWork]}
+        onSetVisibilityOverride={vi.fn()}
+      />,
+    );
+    expect(getAllByText("Primary").length).toBeGreaterThan(0);
+    expect(getAllByText("Work").length).toBeGreaterThan(0);
+  });
+});

--- a/src/features/event-management/EventManagement.tsx
+++ b/src/features/event-management/EventManagement.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import type { CalendarSubscription } from "@/entities/calendar-subscription/types";
+import { GoogleCalendarBadge } from "@/entities/event/GoogleCalendarBadge";
+import { EVENT_SOURCE, type Event, type EventVisibilityOverride } from "@/entities/event/types";
+import { fmtDuration, formatClock, localDateOf } from "@/shared/lib/time";
+
+import { computeEventVisibilityState } from "./visibilityState";
+
+type EventManagementProps = {
+  events: readonly Event[];
+  subscriptions: readonly CalendarSubscription[];
+  /**
+   * Issue #145 / ADR 0032 Layer 3: 個別 event の予定化 / 解除を切り替える。
+   * 'none' へのリセットは含まない (日常 UI では reset 不可、SettingsPanel 専用導線)。
+   */
+  onSetVisibilityOverride: (id: string, value: EventVisibilityOverride) => Promise<void>;
+  /** 詳細パネルを開きたいとき。未指定なら詳細リンクを出さない (テスト用に省略可)。 */
+  onOpenEvent?: (id: string) => void;
+};
+
+type FilterMode = "all" | "shown" | "hidden" | "overridden";
+
+const FILTER_MODES: { key: FilterMode; label: string; help: string }[] = [
+  { key: "all", label: "すべて", help: "取り込み済みのすべての予定" },
+  { key: "shown", label: "予定化中", help: "タイムラインに乗っている予定" },
+  { key: "hidden", label: "予定化解除中", help: "タイムラインに乗っていない予定" },
+  { key: "overridden", label: "個別指定中", help: "default と異なる個別指定をした予定" },
+];
+
+/**
+ * 取り込んだ events 全件を一覧して、個別に予定化 / 解除できる管理ページ (Issue #145)。
+ *
+ * 用途:
+ * - auto-promote=OFF の calendar に取り込んだ event を後から個別予定化する導線
+ *   (#145 完了条件: 「これがないと auto-promote OFF の calendar の使い勝手が破綻する」)
+ * - 「予定化中の予定は何か」を一覧で確認する
+ * - 過去 event の振り返り override (ADR 0034 L8: 制限なし)
+ *
+ * default で `start_time` 降順 (= 新しい順) に並べる。日付ごとにグルーピングして表示する。
+ */
+export function EventManagement({
+  events,
+  subscriptions,
+  onSetVisibilityOverride,
+  onOpenEvent,
+}: EventManagementProps) {
+  const [filter, setFilter] = useState<FilterMode>("all");
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // 安定した参照のため useMemo (subscriptions が変わったときだけ再計算)。
+  const subVisibilities = useMemo(
+    () =>
+      subscriptions.map((s) => ({
+        source: s.source,
+        externalCalendarId: s.externalCalendarId,
+        autoPromoteToTimeline: s.autoPromoteToTimeline,
+      })),
+    [subscriptions],
+  );
+
+  const subDisplayMap = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const s of subscriptions) {
+      m.set(`${s.source}::${s.externalCalendarId}`, s.displayName ?? s.externalCalendarId);
+    }
+    return m;
+  }, [subscriptions]);
+
+  const enriched = useMemo(() => {
+    return (
+      events
+        .map((ev) => {
+          const state = computeEventVisibilityState(ev, subVisibilities);
+          const calendarLabel =
+            ev.source === EVENT_SOURCE.MANUAL
+              ? "手動追加"
+              : (subDisplayMap.get(`${ev.source}::${ev.externalCalendarId}`) ??
+                ev.externalCalendarId);
+          return { event: ev, state, calendarLabel };
+        })
+        // start_time 降順 (新しい順)
+        .sort((a, b) => (a.event.startTime < b.event.startTime ? 1 : -1))
+    );
+  }, [events, subVisibilities, subDisplayMap]);
+
+  const filtered = useMemo(() => {
+    if (filter === "all") return enriched;
+    if (filter === "shown") return enriched.filter((x) => x.state.effectiveShown);
+    if (filter === "hidden") return enriched.filter((x) => !x.state.effectiveShown);
+    return enriched.filter((x) => x.state.override !== "none");
+  }, [enriched, filter]);
+
+  // 日付ごとにグループ化 (ローカル日付)。
+  const groups = useMemo(() => {
+    const map = new Map<string, typeof filtered>();
+    for (const x of filtered) {
+      const key = localDateOf(x.event.startTime);
+      const existing = map.get(key);
+      if (existing) existing.push(x);
+      else map.set(key, [x]);
+    }
+    return [...map.entries()];
+  }, [filtered]);
+
+  const handleToggle = async (id: string, next: EventVisibilityOverride) => {
+    setPendingId(id);
+    setError(null);
+    try {
+      await onSetVisibilityOverride(id, next);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "予定化の切替に失敗しました");
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  return (
+    <div className="px-5 pt-3">
+      <header className="mb-3">
+        <h1 className="m-0 font-jp text-[14px] font-bold text-fg-emphasized">予定管理</h1>
+        <p className="mt-1 text-[11px] leading-relaxed text-fg-muted">
+          取り込み済みの予定を一覧します。個別に「予定化」「予定化解除」すると、その判断はカレンダーごとの自動予定化設定より優先されます。
+        </p>
+      </header>
+
+      <div role="tablist" aria-label="予定の表示フィルタ" className="mb-3 flex gap-1">
+        {FILTER_MODES.map((m) => {
+          const active = filter === m.key;
+          return (
+            <button
+              key={m.key}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => setFilter(m.key)}
+              title={m.help}
+              className={`rounded-[4px] px-2.5 py-[3px] font-jp text-[11px] ${
+                active
+                  ? "bg-bg-divider text-fg-emphasized"
+                  : "bg-transparent text-fg-weak hover:text-fg-subtle"
+              }`}
+            >
+              {m.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {error ? (
+        <div
+          role="alert"
+          className="mb-3 rounded bg-[#ef444420] px-2 py-1.5 text-[11px] text-accent-red"
+        >
+          {error}
+        </div>
+      ) : null}
+
+      {filtered.length === 0 ? (
+        <p className="py-8 text-center text-[11px] text-fg-muted">
+          {filter === "overridden"
+            ? "個別指定している予定はまだありません。"
+            : "取り込み済みの予定がありません。"}
+        </p>
+      ) : (
+        <ul role="list" className="m-0 list-none space-y-4 p-0 pb-[80px]">
+          {groups.map(([dateKey, items]) => (
+            <li key={dateKey}>
+              <div className="mb-1 font-jp text-[10px] uppercase tracking-wider text-fg-faint">
+                {dateKey}
+              </div>
+              <ul role="list" className="m-0 list-none space-y-1.5 p-0">
+                {items.map(({ event, state, calendarLabel }) => (
+                  <EventRow
+                    key={event.id}
+                    event={event}
+                    effectiveShown={state.effectiveShown}
+                    overrideValue={state.override}
+                    isOverrideOfDefault={state.isOverrideOfDefault}
+                    calendarLabel={calendarLabel}
+                    onToggle={(next) => handleToggle(event.id, next)}
+                    onOpenEvent={onOpenEvent}
+                    busy={pendingId === event.id}
+                  />
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+type EventRowProps = {
+  event: Event;
+  effectiveShown: boolean;
+  overrideValue: EventVisibilityOverride;
+  isOverrideOfDefault: boolean;
+  calendarLabel: string;
+  onToggle: (value: EventVisibilityOverride) => void;
+  onOpenEvent?: (id: string) => void;
+  busy: boolean;
+};
+
+function EventRow({
+  event,
+  effectiveShown,
+  overrideValue,
+  isOverrideOfDefault,
+  calendarLabel,
+  onToggle,
+  onOpenEvent,
+  busy,
+}: EventRowProps) {
+  const overrideActive = overrideValue !== "none";
+  const next: EventVisibilityOverride = effectiveShown ? "hidden" : "shown";
+  const buttonLabel = effectiveShown ? "予定化解除" : "予定化する";
+  const start = formatClock(event.startTime);
+  const end = formatClock(event.endTime);
+  const minutes = Math.max(
+    0,
+    Math.round((new Date(event.endTime).getTime() - new Date(event.startTime).getTime()) / 60000),
+  );
+
+  return (
+    <li className="flex items-start gap-3 rounded-md border border-bg-divider bg-bg-primary px-3 py-2">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5">
+          {event.source === EVENT_SOURCE.GOOGLE_CALENDAR ? <GoogleCalendarBadge size="sm" /> : null}
+          <span
+            className={`rounded-[3px] border px-1 py-[1px] font-jp text-[9px] ${
+              effectiveShown
+                ? "border-accent-blue/40 text-accent-blue"
+                : "border-bg-divider text-fg-weak"
+            }`}
+          >
+            {effectiveShown ? "予定化中" : "予定化解除中"}
+          </span>
+          {overrideActive ? (
+            <span
+              className={`rounded-[3px] border px-1 py-[1px] font-jp text-[9px] ${
+                isOverrideOfDefault
+                  ? "border-accent-amber/50 text-accent-amber"
+                  : "border-bg-divider text-fg-weak"
+              }`}
+              title={
+                isOverrideOfDefault
+                  ? "カレンダーの自動予定化設定と異なる個別指定をしています"
+                  : "個別指定していますが、カレンダー側の自動予定化設定と同じ方向です"
+              }
+            >
+              個別指定中
+            </span>
+          ) : null}
+          <span className="truncate text-[10px] text-fg-faint">{calendarLabel}</span>
+        </div>
+        {onOpenEvent ? (
+          <button
+            type="button"
+            onClick={() => onOpenEvent(event.id)}
+            className="mt-1 block w-full truncate text-left font-jp text-[12px] font-medium text-fg-emphasized hover:underline"
+            title={event.title}
+          >
+            {event.title}
+          </button>
+        ) : (
+          <div
+            className="mt-1 truncate font-jp text-[12px] font-medium text-fg-emphasized"
+            title={event.title}
+          >
+            {event.title}
+          </div>
+        )}
+        <div className="mt-0.5 text-[10px] tabular-nums text-fg-weak">
+          {start}–{end} ({fmtDuration(minutes)})
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center">
+        <button
+          type="button"
+          onClick={() => onToggle(next)}
+          disabled={busy}
+          className="rounded-[4px] border border-bg-divider bg-transparent px-2.5 py-[3px] font-jp text-[10px] text-fg-subtle disabled:opacity-60"
+        >
+          {buttonLabel}
+        </button>
+      </div>
+    </li>
+  );
+}

--- a/src/features/event-management/EventManagement.tsx
+++ b/src/features/event-management/EventManagement.tsx
@@ -166,9 +166,11 @@ export function EventManagement({
             : "取り込み済みの予定がありません。"}
         </p>
       ) : (
-        <ul role="list" className="m-0 list-none space-y-4 p-0 pb-[80px]">
+        // 日付グループは <section> で囲む (listitem 役割を持たせない: e2e の getByRole('listitem')
+        // が leaf の event row だけを返すようにするため)。leaf 行のみが role=listitem。
+        <div className="space-y-4 pb-[80px]">
           {groups.map(([dateKey, items]) => (
-            <li key={dateKey}>
+            <section key={dateKey} aria-label={dateKey}>
               <div className="mb-1 font-jp text-[10px] uppercase tracking-wider text-fg-faint">
                 {dateKey}
               </div>
@@ -187,9 +189,9 @@ export function EventManagement({
                   />
                 ))}
               </ul>
-            </li>
+            </section>
           ))}
-        </ul>
+        </div>
       )}
     </div>
   );

--- a/src/features/event-management/visibilityState.test.ts
+++ b/src/features/event-management/visibilityState.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "vitest";
+
+import type { Event } from "@/entities/event/types";
+import type { SubscriptionVisibility } from "@/features/day-timeline/visibility";
+
+import { computeEventVisibilityState } from "./visibilityState";
+
+const baseManual: Pick<Event, "source" | "externalCalendarId" | "visibilityOverride"> = {
+  source: "manual",
+  externalCalendarId: "manual",
+  visibilityOverride: "none",
+};
+
+const baseGoogle: Pick<Event, "source" | "externalCalendarId" | "visibilityOverride"> = {
+  source: "google_calendar",
+  externalCalendarId: "primary",
+  visibilityOverride: "none",
+};
+
+describe("computeEventVisibilityState (Issue #145)", () => {
+  test("manual event は subscription 概念なしで default 表示", () => {
+    const s = computeEventVisibilityState(baseManual, []);
+    expect(s.subscriptionAutoPromote).toBe(true);
+    expect(s.effectiveShown).toBe(true);
+    expect(s.isOverrideOfDefault).toBe(false);
+  });
+
+  test("manual event の hidden override は default 表示に逆らった override", () => {
+    const s = computeEventVisibilityState({ ...baseManual, visibilityOverride: "hidden" }, []);
+    expect(s.effectiveShown).toBe(false);
+    expect(s.isOverrideOfDefault).toBe(true);
+  });
+
+  test("google event override='none' + auto_promote=true → 表示, default 一致", () => {
+    const subs: SubscriptionVisibility[] = [
+      { source: "google_calendar", externalCalendarId: "primary", autoPromoteToTimeline: true },
+    ];
+    const s = computeEventVisibilityState(baseGoogle, subs);
+    expect(s.effectiveShown).toBe(true);
+    expect(s.isOverrideOfDefault).toBe(false);
+  });
+
+  test("google event override='none' + auto_promote=false → 非表示, default 一致", () => {
+    const subs: SubscriptionVisibility[] = [
+      { source: "google_calendar", externalCalendarId: "primary", autoPromoteToTimeline: false },
+    ];
+    const s = computeEventVisibilityState(baseGoogle, subs);
+    expect(s.effectiveShown).toBe(false);
+    expect(s.isOverrideOfDefault).toBe(false);
+  });
+
+  test("google event override='shown' + auto_promote=false → 表示, default 逸脱", () => {
+    const subs: SubscriptionVisibility[] = [
+      { source: "google_calendar", externalCalendarId: "primary", autoPromoteToTimeline: false },
+    ];
+    const s = computeEventVisibilityState({ ...baseGoogle, visibilityOverride: "shown" }, subs);
+    expect(s.effectiveShown).toBe(true);
+    expect(s.isOverrideOfDefault).toBe(true);
+  });
+
+  test("google event override='hidden' + auto_promote=true → 非表示, default 逸脱", () => {
+    const subs: SubscriptionVisibility[] = [
+      { source: "google_calendar", externalCalendarId: "primary", autoPromoteToTimeline: true },
+    ];
+    const s = computeEventVisibilityState({ ...baseGoogle, visibilityOverride: "hidden" }, subs);
+    expect(s.effectiveShown).toBe(false);
+    expect(s.isOverrideOfDefault).toBe(true);
+  });
+
+  test("google event override='shown' + auto_promote=true → 表示, default 一致 (override は default と同方向)", () => {
+    const subs: SubscriptionVisibility[] = [
+      { source: "google_calendar", externalCalendarId: "primary", autoPromoteToTimeline: true },
+    ];
+    const s = computeEventVisibilityState({ ...baseGoogle, visibilityOverride: "shown" }, subs);
+    expect(s.effectiveShown).toBe(true);
+    expect(s.isOverrideOfDefault).toBe(false);
+  });
+
+  test("google event で subscription が無い (orphan) は表示扱いの auto_promote=true", () => {
+    const s = computeEventVisibilityState(baseGoogle, []);
+    expect(s.subscriptionAutoPromote).toBe(true);
+    expect(s.effectiveShown).toBe(true);
+  });
+});

--- a/src/features/event-management/visibilityState.ts
+++ b/src/features/event-management/visibilityState.ts
@@ -1,0 +1,61 @@
+import type { Event } from "@/entities/event/types";
+import type { SubscriptionVisibility } from "@/features/day-timeline/visibility";
+
+/**
+ * 1 event の effective visibility 状態 (Issue #145 / ADR 0031 Layer 2 + Layer 3)。
+ *
+ * 予定管理ページ / SettingsPanel override 一覧 / EventDetailPanel が共通で参照する
+ * 計算層。purely functional に保ち、`SubscriptionVisibility[]` のみ依存させる。
+ */
+export type EventVisibilityState = {
+  /** 現状の `visibility_override` 値 (DB の生値)。 */
+  override: Event["visibilityOverride"];
+  /** subscription を引いて、override が 'none' の場合に default で表示されるかを示す。 */
+  subscriptionAutoPromote: boolean;
+  /** 最終的に DayTimeline / TimelineBar に出るか (override + auto_promote 合成結果)。 */
+  effectiveShown: boolean;
+  /**
+   * ユーザーが default に逆らって override しているか (`is_override_of_default`)。
+   * Phase 4 学習素材として action_log 側でも記録する核シグナル (ADR 0035)。
+   */
+  isOverrideOfDefault: boolean;
+};
+
+export function computeEventVisibilityState(
+  event: Pick<Event, "source" | "externalCalendarId" | "visibilityOverride">,
+  subscriptions: readonly SubscriptionVisibility[],
+): EventVisibilityState {
+  // manual event は subscription を持たないが、ADR 0032 で visibility_override は持つ。
+  // default は表示なので auto_promote=true 相当として扱う。
+  let subscriptionAutoPromote = true;
+  if (event.source !== "manual") {
+    const sub = subscriptions.find(
+      (s) => s.source === event.source && s.externalCalendarId === event.externalCalendarId,
+    );
+    // subscription が見つからない (orphan) のは異常系。visibility.ts と同じく events 行を尊重して
+    // 表示扱いにする (auto_promote=true 相当)。
+    subscriptionAutoPromote = sub ? sub.autoPromoteToTimeline : true;
+  }
+
+  const effectiveShown =
+    event.visibilityOverride === "shown"
+      ? true
+      : event.visibilityOverride === "hidden"
+        ? false
+        : subscriptionAutoPromote;
+
+  // ユーザーが default を変えた状態かどうか:
+  //   - 'shown' override かつ default が hidden (auto_promote=false) → 逸脱
+  //   - 'hidden' override かつ default が shown (auto_promote=true) → 逸脱
+  //   - 'none' のときは default のままなので逸脱ではない
+  const isOverrideOfDefault =
+    (event.visibilityOverride === "shown" && !subscriptionAutoPromote) ||
+    (event.visibilityOverride === "hidden" && subscriptionAutoPromote);
+
+  return {
+    override: event.visibilityOverride,
+    subscriptionAutoPromote,
+    effectiveShown,
+    isOverrideOfDefault,
+  };
+}

--- a/src/features/settings/SettingsPanel.tsx
+++ b/src/features/settings/SettingsPanel.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useMemo, useState } from "react";
 
 import type { CalendarSubscription } from "@/entities/calendar-subscription/types";
+import { EVENT_SOURCE, type Event, type EventVisibilityOverride } from "@/entities/event/types";
+import { formatClock, localDateOf } from "@/shared/lib/time";
 
 import { useCalendarSubscriptions, type CalendarListItem } from "./useCalendarSubscriptions";
 
@@ -11,6 +13,13 @@ type SettingsPanelProps = {
   onClose: () => void;
   /** UserMenu の Google アカウント (= primary external account) の identifier (text)。 */
   primaryExternalAccountId: string | null;
+  /** Issue #145: override 一覧の元データ。 */
+  events: readonly Event[];
+  /**
+   * Issue #145 / ADR 0032: override 一覧から個別 reset (`'none'`) する唯一の導線。
+   * 日常 UI からの reset は禁止 (ADR 0032)、本 panel 専用。
+   */
+  onSetVisibilityOverride: (id: string, value: EventVisibilityOverride) => Promise<void>;
 };
 
 /**
@@ -23,7 +32,13 @@ type SettingsPanelProps = {
  * 取り込み中は disabled にして連打を防ぐ。primary calendar (= migration seed の subscription) も
  * 通常の操作対象として扱う (取り込み解除可)。
  */
-export function SettingsPanel({ open, onClose, primaryExternalAccountId }: SettingsPanelProps) {
+export function SettingsPanel({
+  open,
+  onClose,
+  primaryExternalAccountId,
+  events,
+  onSetVisibilityOverride,
+}: SettingsPanelProps) {
   const { subscriptionsQuery, calendarListQuery, subscribe, unsubscribe, toggleAutoPromote } =
     useCalendarSubscriptions();
 
@@ -149,8 +164,130 @@ export function SettingsPanel({ open, onClose, primaryExternalAccountId }: Setti
             )}
           </div>
         </section>
+
+        <OverridesSection
+          events={events}
+          subscriptions={subscriptions}
+          onSetVisibilityOverride={onSetVisibilityOverride}
+        />
       </div>
     </div>
+  );
+}
+
+function OverridesSection({
+  events,
+  subscriptions,
+  onSetVisibilityOverride,
+}: {
+  events: readonly Event[];
+  subscriptions: CalendarSubscription[];
+  onSetVisibilityOverride: (id: string, value: EventVisibilityOverride) => Promise<void>;
+}) {
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const subDisplayMap = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const s of subscriptions) {
+      m.set(`${s.source}::${s.externalCalendarId}`, s.displayName ?? s.externalCalendarId);
+    }
+    return m;
+  }, [subscriptions]);
+
+  // ADR 0032: 設定画面の override 一覧 = `visibility_override !== 'none'` を一覧、reset 専用導線。
+  // start_time 降順 (新しい順) で並べる。
+  const overridden = useMemo(
+    () =>
+      events
+        .filter((e) => e.visibilityOverride !== "none")
+        .map((e) => ({
+          event: e,
+          calendarLabel:
+            e.source === EVENT_SOURCE.MANUAL
+              ? "手動追加"
+              : (subDisplayMap.get(`${e.source}::${e.externalCalendarId}`) ?? e.externalCalendarId),
+        }))
+        .sort((a, b) => (a.event.startTime < b.event.startTime ? 1 : -1)),
+    [events, subDisplayMap],
+  );
+
+  const handleReset = async (id: string) => {
+    setPendingId(id);
+    setError(null);
+    try {
+      await onSetVisibilityOverride(id, "none");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "リセットに失敗しました");
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  return (
+    <section aria-label="個別予定化の設定" className="mt-6 border-t border-bg-divider pt-4">
+      <h3 className="mb-2 text-[12px] font-semibold text-fg-emphasized">個別予定化の設定</h3>
+      <p className="mb-3 text-[11px] leading-relaxed text-fg-muted">
+        「予定化」「予定化解除」を個別に指定した予定の一覧です。リセットすると、そのカレンダーの自動予定化設定に従う動作に戻ります。
+      </p>
+
+      {error ? (
+        <div
+          role="alert"
+          className="mb-2 rounded bg-[#ef444420] px-2 py-1.5 text-[11px] text-accent-red"
+        >
+          {error}
+        </div>
+      ) : null}
+
+      {overridden.length === 0 ? (
+        <p className="text-[11px] text-fg-muted">個別指定している予定はまだありません。</p>
+      ) : (
+        <ul role="list" className="m-0 list-none space-y-1.5 p-0">
+          {overridden.map(({ event, calendarLabel }) => (
+            <li
+              key={event.id}
+              className="flex items-start gap-3 rounded-md border border-bg-divider bg-bg-primary px-3 py-2"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-1.5">
+                  <span
+                    className={`rounded-[3px] border px-1 py-[1px] font-jp text-[9px] ${
+                      event.visibilityOverride === "shown"
+                        ? "border-accent-blue/40 text-accent-blue"
+                        : "border-bg-divider text-fg-weak"
+                    }`}
+                  >
+                    {event.visibilityOverride === "shown" ? "予定化中" : "予定化解除中"}
+                  </span>
+                  <span className="truncate text-[10px] text-fg-faint">{calendarLabel}</span>
+                </div>
+                <div
+                  className="mt-1 truncate font-jp text-[12px] font-medium text-fg-emphasized"
+                  title={event.title}
+                >
+                  {event.title}
+                </div>
+                <div className="mt-0.5 text-[10px] tabular-nums text-fg-weak">
+                  {localDateOf(event.startTime)} {formatClock(event.startTime)}–
+                  {formatClock(event.endTime)}
+                </div>
+              </div>
+              <div className="flex shrink-0 items-center">
+                <button
+                  type="button"
+                  onClick={() => handleReset(event.id)}
+                  disabled={pendingId === event.id}
+                  className="rounded-[4px] border border-bg-divider bg-transparent px-2.5 py-[3px] font-jp text-[10px] text-fg-subtle disabled:opacity-60"
+                >
+                  リセット
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
   );
 }
 


### PR DESCRIPTION
## 概要 (What)

ADR 0031 の 3 層モデルのうち **Layer 3 (event 単位 visibility_override)** を実装。
取り込み済み event を一覧 / 個別操作する `/events` ページを追加し、Header の動線を `tree` から `予定` に置換。

## 関連 Issue

Closes #145

## 背景 (Why)

#144 で Layer 1/2 (calendar 単位の subscription + auto_promote) が完成したが、ユーザーから「取り込まれた event のうちどれが timeline に乗るかが見えない」「auto_promote=OFF にしたカレンダーの中の特定 event だけ予定化する手段がない」という観測があった。これは [ADR 0031](https://github.com/y-oga-819/kozutsumi/blob/main/docs/adr/0031-calendar-subscription-and-event-promotion.md) Layer 3 / [ADR 0032](https://github.com/y-oga-819/kozutsumi/blob/main/docs/adr/0032-events-visibility-override-physical-model.md) で予告されていた未実装範囲。

`/tree` 画面は dogfooding でメンテされておらず、ヘッダー動線として残しておく価値が薄かったため、その枠に予定管理を置く。

## Before → After (概念・フロー・メンタルモデル)

**Before:**
- Layer 1/2 までの世界では、event は `subscription.auto_promote_to_timeline` で **calendar 単位の一括 default** だけが効いた
- 取り込み済みだが timeline に乗っていない event を確認 / 操作する場所が無く、auto_promote=OFF の calendar は実質「取り込んでも見えないだけ」になりがちだった
- 個別 event の例外判断 (「この社内全体定例だけは外したい」「家族カレンダーのこの予定だけは取り込みたい」) を表現する語彙が無かった

**After:**
- 3 層が揃った: subscription whitelist (Layer 1) → calendar default (Layer 2) → event 個別 override (Layer 3)
- `/events` ページで全 event を確認 / 個別予定化解除ができる
- ADR 0032 ルール: 日常 UI からの `none` reset は不可。取り消したいときは反対方向の再 override (shown ↔ hidden) で行う。完全に default 挙動に戻したいレアケース用に、設定画面に「個別予定化の設定」section を専用導線として用意
- Phase 4 学習素材として `is_override_of_default` (subscription default に逆らった override かどうか) を action_log に記録

```
Layer 1 (subscription)        Layer 2 (auto_promote)        Layer 3 (visibility_override)
   "このカレンダーを取り込む"   →   "このカレンダーは default 表示"  →   "ただしこの予定だけは別判断"
        #144 ✅                       #144 ✅                            本 PR ✅
```

## 追加したテスト (How verified)

- [x] **unit (vitest)**: `computeEventVisibilityState` (8 ケース: source / override / auto_promote / orphan の合成)
- [x] **unit (vitest)**: `SupabaseEventGateway.setVisibilityOverride` (3 値ぶん, kozutsumi 側拡張なので Google read-only ガードを呼ばないことも踏む)
- [x] **unit (vitest)**: `EventDetailPanel` の予定化 toggle (8 ケース: callback 未指定 / override 各値 / auto_promote 各値 / reject エラー)
- [x] **unit (vitest)**: `EventManagement` の filter / toggle (8 ケース: 4 フィルタ × default 表示 / promote / demote / 空状態)
- [x] **e2e (Playwright)**: `event-visibility-override.spec.ts` で API 経由の DB 反映 + action_log (`event_promoted` / `event_demoted` の `is_override_of_default` フラグ) + UI 文言切替を踏む。tree 動線が消えていることも確認
- [x] **既存 e2e の追従**: `golden-path.spec.ts` の Tree 遷移パートを「予定」遷移に置換、`tree-view-history.spec.ts` を direct URL 化 (`/tree` route 自体は維持)
- [x] `npm run check` (format + lint + typecheck + 全 unit) green

## リリース前チェックリスト (When / Before merge)

- [x] マイグレーションは無し (#159 で `events.visibility_override` 列は既に存在)
- [x] 環境変数 / シークレット追加なし
- [x] 既存 user への破壊的変更なし: `/tree` route は維持 (direct URL アクセス可)、ヘッダー動線のみ差し替え

## このPRの範囲外 (Out of scope)

- 自動フィルタルール (title pattern / participants 数 / RSVP 状態) — 別 issue
- 「タスクとしての着手対象にするか」（時間拘束ではなくタスク化の話。別軸）
- 三値 visibility モデル (`info_only` 等、ADR 0032 で将来拡張余地のみ確保)
- `/tree` route の物理削除 — 動線だけ落としており route 自体は残すことで既存テストとの互換を維持


---
_Generated by [Claude Code](https://claude.ai/code/session_018Ysp3ESDuJ2xHaA9dYnotC)_