### PR TITLE
feat(infra): preview env を別 Supabase project に分離 + ADR 0042 / 0043

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -3,7 +3,13 @@
 # .env.local は git 管理外 (.gitignore)。
 
 # ===== Supabase =====
-# Supabase Dashboard > Project Settings > API から取得
+# Supabase Dashboard > Project Settings > API から取得。
+# 環境ごとの値の使い分けは ADR-0042 / 0043 を参照:
+#   - ローカル (本ファイル): supabase local stack または開発者個人の Supabase project
+#   - Vercel Production scope: 本番 Supabase project の値
+#   - Vercel Preview scope: preview 専用 Supabase project の値 (本番と物理的に別)
+# Vercel 側は scope ごとに同じ変数名で別の値を持たせるので、コード側 (src/shared/supabase/env.ts)
+# は process.env を読むだけで自動で切り替わる。
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 

--- a/.github/workflows/db-migrate-preview.yml
+++ b/.github/workflows/db-migrate-preview.yml
@@ -1,0 +1,92 @@
+name: DB migrate (preview)
+
+# preview Supabase project に migration を適用する。
+# 設計判断は ADR-0042 / ADR-0043 を参照。
+#
+# Trigger:
+# - pull_request (opened/synchronize/reopened) で supabase/migrations/** が変わったとき
+# - workflow_dispatch (手動 / debug)
+#
+# secret は SUPABASE_PREVIEW_DB_URL のみ。step env で渡す
+# (job env / workflow env には置かない: ADR-0020 の hardening 方針を踏襲)。
+# 本番 SUPABASE_DB_URL は本 workflow から参照しない。
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "supabase/migrations/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # preview DB は 1 個共有 (ADR-0043 の後勝ち戦略)。
+  # migrate / reset は同じ group でシリアライズし、本番への副作用を物理的に排除する。
+  group: preview-db
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    name: Apply migrations to preview
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      # 本番 workflow と同じ理由で psql 17 を入れる (本番 / preview は同じ major version 前提)。
+      - name: Install PostgreSQL 17 client tools
+        run: |
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+            -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+          sudo sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client-17
+          test -x /usr/lib/postgresql/17/bin/pg_dump
+          echo "/usr/lib/postgresql/17/bin" >> "$GITHUB_PATH"
+
+      - name: Show migration state (local files vs applied)
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_PREVIEW_DB_URL }}
+        run: |
+          echo "::group::Local migration files (supabase/migrations/)"
+          ls -1 supabase/migrations/ || true
+          echo "::endgroup::"
+          echo "::group::Applied migrations on preview (supabase_migrations.schema_migrations)"
+          psql "$SUPABASE_DB_URL" -c \
+            "SELECT version FROM supabase_migrations.schema_migrations ORDER BY version DESC LIMIT 30;" \
+            || echo "Could not read schema_migrations (table might not exist on first run)"
+          echo "::endgroup::"
+
+      - name: Apply migrations
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_PREVIEW_DB_URL }}
+        run: |
+          supabase db push --db-url "$SUPABASE_DB_URL"
+
+      - name: Verify post-migrate state
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_PREVIEW_DB_URL }}
+        run: |
+          echo "::group::Applied migrations after push"
+          psql "$SUPABASE_DB_URL" -c \
+            "SELECT version FROM supabase_migrations.schema_migrations ORDER BY version DESC LIMIT 10;"
+          echo "::endgroup::"
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "### DB migrate (preview)"
+            echo ""
+            echo "- Trigger: \`${{ github.event_name }}\`"
+            echo "- ADR: [0042](../blob/main/docs/adr/0042-preview-env-uses-separate-supabase-project.md) / [0043](../blob/main/docs/adr/0043-preview-db-migration-auto-apply-on-pr-push.md)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/db-migrate-preview.yml
+++ b/.github/workflows/db-migrate-preview.yml
@@ -66,6 +66,22 @@ jobs:
             || echo "Could not read schema_migrations (table might not exist on first run)"
           echo "::endgroup::"
 
+      - name: Ensure HEAD contains all migrations from main (rebase guard)
+        run: |
+          # 通常 pull_request の checkout は merge ref なので main の migration files は揃う。
+          # mergeable=false (conflict) や workflow_dispatch を古い branch から叩いた時に、
+          # main にあって HEAD に無い migration があると preview DB が中途半端な状態になるので止める。
+          # 趣旨は ADR-0023 の missing-migrations 検査と同じ。
+          git fetch --depth=1 origin main
+          main_migs=$(git ls-tree -r --name-only origin/main -- supabase/migrations/ | sort)
+          head_migs=$(git ls-tree -r --name-only HEAD -- supabase/migrations/ | sort)
+          missing=$(comm -23 <(echo "$main_migs") <(echo "$head_migs"))
+          if [ -n "$missing" ]; then
+            echo "::error::main にあって HEAD に無い migration があります。main を取り込んで再 push してください。"
+            echo "$missing"
+            exit 1
+          fi
+
       - name: Apply migrations
         env:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_PREVIEW_DB_URL }}

--- a/.github/workflows/db-reset-preview.yml
+++ b/.github/workflows/db-reset-preview.yml
@@ -1,0 +1,105 @@
+name: DB reset (preview)
+
+# preview Supabase project を main 状態に戻す。
+# 設計判断は ADR-0043 を参照。
+#
+# やること:
+# - public schema を drop → 作り直し
+# - supabase_migrations.schema_migrations を truncate
+# - main の migration を全部再適用
+#
+# auth / storage 等の Supabase 管理スキーマは触らない (テスト user / OAuth 設定は維持)。
+# kozutsumi の migration はすべて public schema 配下なので、これで main 状態に揃う。
+#
+# Trigger:
+# - pull_request (closed) で supabase/migrations/** を含む PR が閉じたとき (merge / discard 問わず)
+# - schedule で週次 (毎週日曜 00:00 UTC = 09:00 JST)
+# - workflow_dispatch (手動)
+#
+# secret は SUPABASE_PREVIEW_DB_URL のみ。本番 SUPABASE_DB_URL は本 workflow から参照しない。
+
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - "supabase/migrations/**"
+  schedule:
+    # 毎週日曜 00:00 UTC = 09:00 JST
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # migrate-preview と同じ group で serialize する (ADR-0043)。
+  group: preview-db
+  cancel-in-progress: false
+
+jobs:
+  reset:
+    name: Reset preview DB to main state
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      # PR close trigger でも main の migration files を使うので、明示的に main を checkout する。
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Install PostgreSQL 17 client tools
+        run: |
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+            -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+          sudo sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client-17
+          test -x /usr/lib/postgresql/17/bin/pg_dump
+          echo "/usr/lib/postgresql/17/bin" >> "$GITHUB_PATH"
+
+      - name: Drop public schema and clear migration history
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_PREVIEW_DB_URL }}
+        run: |
+          # 注意: auth / storage / supabase_migrations 等の管理スキーマは drop しない。
+          # public 以外で migration が作る objects があれば本 reset では取り切れない。
+          # 現 kozutsumi の migration はすべて public schema 配下なので問題なし。
+          psql "$SUPABASE_DB_URL" --set ON_ERROR_STOP=on <<'SQL'
+          DROP SCHEMA IF EXISTS public CASCADE;
+          CREATE SCHEMA public;
+          GRANT ALL ON SCHEMA public TO postgres;
+          GRANT ALL ON SCHEMA public TO public;
+          TRUNCATE TABLE supabase_migrations.schema_migrations;
+          SQL
+
+      - name: Re-apply main migrations
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_PREVIEW_DB_URL }}
+        run: |
+          supabase db push --db-url "$SUPABASE_DB_URL"
+
+      - name: Verify post-reset state
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_PREVIEW_DB_URL }}
+        run: |
+          echo "::group::Applied migrations after reset"
+          psql "$SUPABASE_DB_URL" -c \
+            "SELECT version FROM supabase_migrations.schema_migrations ORDER BY version DESC LIMIT 30;"
+          echo "::endgroup::"
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "### DB reset (preview)"
+            echo ""
+            echo "- Trigger: \`${{ github.event_name }}\`"
+            echo "- ADR: [0042](../blob/main/docs/adr/0042-preview-env-uses-separate-supabase-project.md) / [0043](../blob/main/docs/adr/0043-preview-db-migration-auto-apply-on-pr-push.md)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/adr/0042-preview-env-uses-separate-supabase-project.md
+++ b/docs/adr/0042-preview-env-uses-separate-supabase-project.md
@@ -1,0 +1,117 @@
+# ADR 0042: Vercel preview deployment は本番と別の Supabase project を見る
+
+- **Status**: Accepted
+- **Date**: 2026-05-04
+- **Related**: [ADR-0019](./0019-db-migration-via-manual-github-actions.md) / [ADR-0020](./0020-db-migration-credential-as-db-connection-string.md) / [ADR-0023](./0023-pr-migration-diff-auto-comment.md) / [ADR-0043](./0043-preview-db-migration-auto-apply-on-pr-push.md)
+
+## Context
+
+kozutsumi は Vercel に deploy しており、PR を出すと自動で preview deployment が立つ。
+現状この preview env は **本番 Supabase project の URL / anon key** を見ている。これが 2 つの問題を生む。
+
+1. **migration 入りの PR を preview で動作確認できない**
+   PR に `supabase/migrations/*.sql` が含まれていても、本番 DB にはまだ適用されていない。
+   feature の動作確認には schema が前提になっているので、現状は **migration だけ別 PR にして
+   先にマージ → 手動 workflow (ADR-0019) で本番に適用 → 本体 feature の PR を preview で確認**
+   という 2 段階フローを取らざるを得ない。1 つの仕様変更を 2 PR に分割する手間と、
+   migration 単独 merge の時点で main の schema が「コードの期待」と一時的にズレる窓ができる。
+
+2. **preview から本番データに書き込める**
+   preview の anon key が本番と同じため、preview 上で操作したテストデータが本番 DB に混入する。
+   個人開発で `auth.uid()` ベースの RLS なので他人には漏れないが、自分の本番データが
+   「PR で実験した中途半端な状態」で汚れる。dogfooding データ（Phase 4 で使う行動ログ）の
+   品質が下がる。
+
+「migration 適用は本番に対しては手動 + approval」(ADR-0019) という慎重さは保ったまま、
+preview env だけは「PR の HEAD にある migration が当たった schema」を見せたい。
+
+## Decision
+
+Vercel **Preview** environment は本番 Supabase project ではなく、**preview 専用の Supabase
+project** を見る。Production environment は引き続き本番 project を見る。
+
+- preview 専用 project は Supabase free tier で 1 つ追加する（org あたり 2 active project まで無料）
+- Vercel の Environment Variables を **Preview / Production で別値**に設定し、
+  `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` を Preview だけ preview project
+  のものに差し替える
+- preview project の DB は **使い捨て前提**。永続価値のあるデータは置かない（テスト seed のみ）
+- preview project への migration 適用方法は ADR-0043 で別途決める
+
+## Consequences
+
+### 肯定的影響
+
+- **migration 入り feature を 1 PR で完結できる**。preview で migration を含む schema 状態を
+  動作確認できるので、「migration 先出し PR + feature PR」の 2 段階運用が消える
+- **本番データが preview から汚染されない**。preview 上のテスト操作が本番 RLS を超えて漏れる
+  経路が物理的に消える（DB 自体が別）
+- **dogfooding データの質が保たれる**。Phase 4 学習素材としての行動ログに「PR 検証時の
+  ノイズ操作」が混ざらなくなる
+- **本番 DB への migration 適用は ADR-0019 の手動 + approval を維持できる**。preview と production
+  で適用経路が分かれるので、preview の自動化が production の慎重さを侵食しない
+- **preview の OAuth callback / リダイレクト URL を本番から分離できる**。Google OAuth client の
+  許可 URI に preview ドメインを追加する設定変更が必要だが、これは preview project 側の auth
+  設定として閉じる
+
+### 否定的影響・トレードオフ
+
+- **Supabase free tier の 2 active project 枠を 1 つ消費する**。今後 staging / 別アプリで
+  もう 1 project 欲しくなったら有料化が必要
+- **secret / 環境変数の管理対象が増える**。preview project 用の URL / anon key / service role key
+  / DB connection string を Vercel と GitHub Secrets の両方に設定する必要がある
+- **preview project の auth 設定（Google OAuth client / redirect URL）を別途構成する必要がある**。
+  Google Cloud Console 側で preview project の callback URL を許可 URI に追加する手間が出る
+- **preview project の seed をどう用意するか**は別問題として残る（本番データはコピーしない方針なので、
+  最低限のテストユーザー / project / task を seed する仕組みが要る）
+- **本番 anon key が preview に漏れていないことを確認する初期コスト**。既存 Vercel env の Production
+  と Preview を明確に分ける作業が必要
+
+### 何をしないか（境界）
+
+- **本番 DB への migration 適用フローは変えない**。ADR-0019 の手動 `workflow_dispatch` + approval
+  を維持する。preview の自動化は production の安全装置を緩める方向には使わない
+- **本番データを preview にコピーしない**。本番のユーザーデータ（自分の生活ログ）を CI / CD 経路で
+  別 project に流すと漏洩経路が増える。preview seed は最小限のダミーデータで作る
+- **preview project に PII / 本番 secret を置かない**。Google OAuth は preview 用 client を分けるか、
+  本番 client の許可 URI を広げて使い回すかは別判断（実装時に詰める）
+
+## Alternatives considered
+
+- **現状維持（preview が本番 DB を見る）**:
+  migration 2 段階運用と本番データ汚染が常時のコストとして残る。kozutsumi は個人開発で PR が
+  そこまで多くないので「我慢できなくはない」が、Phase 3 以降 migration 頻度が上がっており
+  ボトルネック化している。不採用
+
+- **Supabase Branching を使う**:
+  Supabase 公式の preview 機能で、PR ごとに ephemeral DB branch を切ってくれる。理想的だが
+  **Pro plan ($25/月) 前提** で、kozutsumi の「個人開発・無料運用」制約に合わない。不採用。
+  将来 Pro 化したタイミングで本 ADR を supersede する候補
+
+- **PR ごとに ephemeral Supabase project を作る**:
+  Supabase free tier は org あたり 2 active project 制限なので、PR ごとに増やせない。
+  Supabase API で project を programmatic に作成・削除する経路もあるが、free tier の制限と
+  課金リスクの両方が立ちはだかる。不採用
+
+- **Neon 等の Postgres preview branching サービスに DB を乗り換える**:
+  Neon は free tier で branching が使える。技術的には preview 問題を最も綺麗に解ける。
+  ただし Supabase の Auth / Storage / Realtime / Edge Functions と一体運用してきた前提を
+  全部捨てることになり、移行コストが本問題の解決規模を大きく超える。本 ADR の射程外。
+  Phase 4 以降に「Supabase 全体の制約が支配的になった」段階で別 ADR で再検討
+
+- **preview env も同じ本番 DB を見るが、preview 用の schema (`preview_*`) に migration を当てる**:
+  schema 単位で隔離する案。Supabase の auth schema や RLS との相性が悪く、
+  app コード側でも schema prefix を環境ごとに切り替える実装が要る。複雑度に対するメリットが薄い。
+  不採用
+
+## Notes
+
+- 環境変数の設定方法・preview DB への migration 適用フロー・preview DB の reset / seed 運用は
+  ADR-0043 で扱う（本 ADR は「分離するか否か」だけの判断）
+- 漏洩時の対応・credential 管理方針は ADR-0020 の枠組みを preview project 側にも適用する
+  （preview 用 `SUPABASE_DB_URL` を GitHub Secrets に置き、step env で渡す）
+- 将来 supersede される条件:
+  - Supabase Pro plan に移行して Branching が使える状態になった場合
+  - Supabase free tier の project 上限が変わって PR ごとの ephemeral project が現実的になった場合
+  - DB 自体を別サービス（Neon 等）に乗り換える場合
+  - kozutsumi がアルファを抜けて他人のデータを預かるフェーズに入り、preview 環境の隔離要件が
+    変わる場合

--- a/docs/adr/0043-preview-db-migration-auto-apply-on-pr-push.md
+++ b/docs/adr/0043-preview-db-migration-auto-apply-on-pr-push.md
@@ -1,0 +1,133 @@
+# ADR 0043: preview DB への migration は PR push 起点の GitHub Actions で自動適用する（共有 1 project / 後勝ち）
+
+- **Status**: Accepted
+- **Date**: 2026-05-04
+- **Related**: [ADR-0019](./0019-db-migration-via-manual-github-actions.md) / [ADR-0020](./0020-db-migration-credential-as-db-connection-string.md) / [ADR-0023](./0023-pr-migration-diff-auto-comment.md) / [ADR-0042](./0042-preview-env-uses-separate-supabase-project.md)
+
+## Context
+
+ADR-0042 で preview env は本番と別の Supabase project を見ると決めた。preview project に
+**PR HEAD の migration が当たった schema** を反映する仕組みが必要になる。
+
+選択肢としては (a) PR ごとに DB を分離する / (b) 全 PR で 1 個の preview DB を共有する
+の 2 軸があり、それぞれ migration 適用方法が変わる。
+
+(a) は理想的だが、Supabase free tier の 2 active project 上限と PR 数の動的性から実現困難
+（ADR-0042 で却下済み）。残るは (b) で、共有 DB に「どう migration を当てるか」「衝突をどう
+扱うか」を決める必要がある。
+
+kozutsumi の運用前提:
+
+- 個人開発で **同時に open している PR は 1〜2 本** が普通。並行 migration の頻度は低い
+- preview DB は永続価値なし（ADR-0042 / 使い捨て前提）
+- 本番 DB の migration 適用フロー（ADR-0019 の手動 + approval）は維持する必要がある
+- ADR-0023 の PR migration diff コメントワークフローは ephemeral local Supabase で完結しており、
+  preview project には触っていない
+
+## Decision
+
+preview Supabase project への migration 適用は、**PR の `synchronize` / `opened` / `reopened`
+イベントで起動する GitHub Actions ワークフロー**で `supabase db push` を行う。共有 1 project に
+**後勝ち**で適用する。
+
+- Trigger: `pull_request` の `opened` / `synchronize` / `reopened`、`paths: supabase/migrations/**`
+  でフィルタ
+- 認証: `SUPABASE_PREVIEW_DB_URL` を GitHub Secrets に置き、step env で渡す（ADR-0020 と同じ
+  hardening 方針）
+- 適用コマンド: `supabase db push --db-url "$SUPABASE_PREVIEW_DB_URL"`
+- **本番 DB には一切触らない**。secret も別物（`SUPABASE_DB_URL` は本番、`SUPABASE_PREVIEW_DB_URL`
+  は preview）
+- PR がマージ / クローズされたとき、または定期 cron で **preview DB を main 状態にリセット**
+  するワークフローを別途持つ（後勝ち汚染の累積を防ぐ）
+- ADR-0019 の本番 migration workflow は変えない（手動 + approval を維持）
+- ADR-0023 の PR migration diff コメントワークフローも変えない（preview への apply とは別レイヤー）
+
+## Consequences
+
+### 肯定的影響
+
+- **migration 入り PR を 1 PR で動作確認できる**。ADR-0042 の主目的が達成される
+- **本番 DB は一切触らない**ので、preview の自動化が production の安全装置（ADR-0019 の approval）
+  を侵食しない
+- **secret が物理的に分かれる**。preview DB credential が漏れても本番 DB は守られる
+- **既存の本番 migration workflow との責務分離が明確**。ファイルとしても別 workflow になり、
+  どちらを触っているか一目で分かる
+- **個人開発の運用コストに合う**。並行 PR が少ないので「後勝ち + 定期リセット」で実用上回る
+
+### 否定的影響・トレードオフ
+
+- **共有 1 project なので並行 PR 間で schema が衝突する**。複数 PR が同時に異なる migration を
+  push すると最後に push した PR の schema が乗り、他 PR の preview は壊れた状態を見る
+- **後勝ち汚染が累積する**。merge されずに close された PR の migration が DB に残り続ける。
+  定期リセット（または PR close hook）で main 状態に戻さないと preview DB が乱雑になる
+- **migration 適用が失敗した PR は preview DB を pending 状態で残す**。CI 上は workflow fail で
+  検知できるが、次の PR push が失敗修正を含む migration なら救えるが、無関係な PR の push なら
+  preview DB の pending 状態が長引く
+- **Vercel の preview build と migration 適用の順序保証がない**。Vercel は push を受けて build を
+  始め、GitHub Actions は並行で migration を流す。先に build が終わって preview に到達した瞬間は
+  「コードは新 schema 期待・DB は旧 schema」の窓ができる。実用上は数十秒の窓なので、PR レビューで
+  見るときには解消している前提で許容する
+- **PR 作者が migration apply の status を意識する必要がある**。Actions の job が green になって
+  から preview を確認する運用になる
+- **preview DB の reset 運用を別途設計・実装する必要がある**。本 ADR では「リセット workflow が
+  必要」とだけ決めて、具体実装（PR close hook or 週次 cron or 両方）は実装 issue で詰める
+
+### 何をしないか（境界）
+
+- **PR ごとの ephemeral DB / schema 分離はしない**。ADR-0042 の制約（free tier 2 project 上限）
+  と複雑度から非現実的
+- **migration を down / rollback する仕組みは持たない**。preview DB は使い捨て前提なので、
+  「壊れたら main 状態に reset」で対応する
+- **Vercel deploy hook と GitHub Actions を同期させない**。順序保証は諦め、数十秒の窓を許容する
+- **本番 migration workflow（ADR-0019）の trigger を変えない**。本 ADR は preview 経路を
+  追加するだけで、production は手動 `workflow_dispatch` + approval のまま
+
+### 「後勝ち」を許容する根拠
+
+並行 PR が少ない（実測 1〜2 本同時 open）個人開発で、**「最後に push した PR の schema が他 PR の
+preview を一時的に壊す」確率は低く、壊れても再 push で復旧できる**。完璧な隔離（ADR-0042
+Alternatives で却下した PR ごと ephemeral project）に必要なコストは、現状の PR 頻度に対して
+過剰。並行 PR が常時 3 本以上になったら本 ADR を見直す。
+
+## Alternatives considered
+
+- **PR ごとに schema を分けて 1 project 内で隔離する** (`preview_pr_<n>` schema):
+  app 側で schema prefix を環境変数で切り替える実装が必要。Supabase の auth schema との
+  境界も難しい。複雑度に対する benefit が薄い。不採用
+
+- **Vercel deploy hook で preview build 内から `supabase db push` を実行する**:
+  build environment に DB credential を置く必要があり、Vercel の secret 管理経路が増える。
+  build と migration が同じ workflow になり、片方の失敗が build 全体を失敗させる結合度の高さも
+  問題。GitHub Actions に分離する方が責務が綺麗。不採用
+
+- **`workflow_dispatch` で手動 trigger する**（本番と同じ運用）:
+  本番と同じ慎重さは不要（preview DB は使い捨て）。手動 trigger を毎 PR 強制すると ADR-0042 の
+  「1 PR で完結する」目的が達成できない（push のたびに workflow を回す手間が出る）。不採用
+
+- **PR merge 時に main の migration を preview に当てる**:
+  merge 時しか preview DB が更新されない。PR レビュー時点で migration が反映されていないので
+  ADR-0042 の目的を満たさない。不採用
+
+- **後勝ちではなく「先勝ち」（最初に push した PR の schema を保持）**:
+  実装が複雑（schema_migrations の状態を見て判定する必要があり、PR ごとの優先度判断も要る）。
+  個人開発のシンプルさを失う。不採用
+
+- **Supabase CLI の `db diff` で生成 SQL を preview に当てる**:
+  ADR-0023 が既に migration files の整合性を検証しているので二重。本 ADR は **本物の
+  migration files を本物の DB に当てる**ことが目的（preview 環境を本番と同じ deploy 経路で
+  再現する）ので、`db diff` 経由ではなく `db push` を使う
+
+## Notes
+
+- 実装単位（GitHub Actions workflow ファイル / Vercel env 設定 / preview project の auth 設定 /
+  reset workflow）は別 issue で起票する
+- 本 ADR は **preview 自動化** が目的。本番への適用は ADR-0019 の手動 workflow に従う
+- preview DB の reset 戦略（PR close hook / 週次 cron / 両方）は実装時に詰める。本 ADR では
+  「リセット手段が必要」とだけ決める
+- 漏洩時の対応は ADR-0020 の枠組みを `SUPABASE_PREVIEW_DB_URL` にも適用する（dashboard で
+  password を reset → GitHub Secrets を更新）
+- 将来 supersede される条件:
+  - Supabase Pro plan に移行して Branching が使える状態になった場合（ADR-0042 と同時に
+    supersede される）
+  - 並行 open PR が常時 3 本以上になり、共有 1 project の衝突が運用負荷として顕在化した場合
+  - preview build と migration 適用の順序保証が必要になった場合（feature flag 連動など）

--- a/supabase/migrations/20260504020000_preview_workflow_smoke.sql
+++ b/supabase/migrations/20260504020000_preview_workflow_smoke.sql
@@ -1,0 +1,6 @@
+-- preview migrate workflow の smoke test。
+-- ADR-0042 / 0043 で追加した db-migrate-preview.yml が pull_request 経由で起動し、
+-- preview Supabase project に supabase db push が通ることを確認するための一時 migration。
+--
+-- ⚠️ このファイルは merge 前に削除する。squash merge で main の履歴には残らない。
+-- DB への副作用なし (本ファイルはコメントのみ)。

--- a/supabase/migrations/20260504020000_preview_workflow_smoke.sql
+++ b/supabase/migrations/20260504020000_preview_workflow_smoke.sql
@@ -1,6 +1,0 @@
--- preview migrate workflow の smoke test。
--- ADR-0042 / 0043 で追加した db-migrate-preview.yml が pull_request 経由で起動し、
--- preview Supabase project に supabase db push が通ることを確認するための一時 migration。
---
--- ⚠️ このファイルは merge 前に削除する。squash merge で main の履歴には残らない。
--- DB への副作用なし (本ファイルはコメントのみ)。


### PR DESCRIPTION
## 概要 (What)

Vercel preview deployment が本番 Supabase project を見ている現状を分離する。ADR 2 本 + workflow 2 本 + env 例の更新を 1 PR にまとめる。

- **ADR-0042**: preview env は本番と別の Supabase free project を見る（「分離するか」の判断）
- **ADR-0043**: preview DB への migration は PR push 起点の GitHub Actions で共有 1 project に後勝ちで自動適用（「どう適用するか」の判断）
- `.github/workflows/db-migrate-preview.yml`: PR push + `workflow_dispatch` で起動、`supabase db push` を preview project に適用
- `.github/workflows/db-reset-preview.yml`: PR close hook + 週次 cron + `workflow_dispatch` で preview DB を main 状態にリセット
- `.env.local.example`: Supabase セクションに ADR 参照と Vercel scope 運用の説明を追記

## 関連 Issue

Closes #186

## 背景 (Why)

現状、Vercel preview は本番 Supabase project の URL / anon key を見ているため:

1. **migration 入り PR が 2 段階運用を強制される**
   migration だけ別 PR にして先 merge → 本番に手動 apply (ADR-0019) → 本体 feature PR を preview で確認、という流れ。1 仕様変更を 2 PR に割らないと preview で動作確認できない。

2. **preview 操作が本番 DB に書き込まれる**
   anon key が本番と同じため、preview 上のテストデータが本番に混入。Phase 4 の dogfooding 行動ログが汚れる。

「本番 migration は手動 + approval」(ADR-0019) の慎重さは保ちつつ、preview だけは「PR HEAD の migration が当たった schema」を見せたい、というのが今回の論点。Supabase Branching は Pro plan ($25/月) 前提のため、無料枠で取れる現実解として preview 専用 free project を 1 つ作って共有 + 後勝ちで自動 apply する構成を選ぶ（org の 2 active project 枠を 1 つ消費する）。

## Before → After (概念・フロー・メンタルモデル)

**Before:**

```
PR (migration + feature)
   ├─ migration 部分だけ切り出して別 PR
   │     └─ merge → 手動 workflow で本番 apply (ADR-0019)
   └─ feature PR を rebase してから preview で確認
```

- preview env = 本番 DB
- 1 仕様変更 = 2 PR + 手動承認待ちが間に挟まる
- preview 操作が本番データに直接書く

**After:**

```
PR (migration + feature)
   └─ push
        ├─ Vercel: preview build (Preview scope の env で preview project を参照)
        └─ GitHub Actions db-migrate-preview: supabase db push を preview project に自動適用
              └─ 数十秒後、preview env で migration 込みの動作確認可能

PR close (merge / discard どちらでも)
   └─ GitHub Actions db-reset-preview: preview DB を main 状態にリセット

本番 DB は ADR-0019 の手動 + approval workflow で merge 後に適用 (変更なし)
```

- preview env = preview 専用 Supabase free project (本番と物理的に別)
- 1 仕様変更 = 1 PR
- preview 操作は preview DB に閉じる
- 本番 secret (`SUPABASE_DB_URL`) と preview secret (`SUPABASE_PREVIEW_DB_URL`) は別物。preview workflow が本番に触る経路は構造的に存在しない
- 本番への適用経路と慎重さは ADR-0019 のまま据え置き

## 環境ごとの DB URL 切り替えの仕組み

**レイヤー A: app runtime (Vercel)**

Vercel の Environment Variables には Production / Preview / Development の 3 つの scope があり、同じ変数名で scope ごとに別の値を保持できる。`NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` を Preview scope だけ preview project の値に差し替えれば、Vercel が deploy 時に対応する scope の値を自動注入する。コード側 (`src/shared/supabase/env.ts`) は変更不要。

**レイヤー B: GitHub Actions (workflow)**

GitHub Secrets は scope の概念がないので **secret 名を物理的に分ける**:
- 本番 migrate workflow → `secrets.SUPABASE_DB_URL`
- preview migrate / reset workflow → `secrets.SUPABASE_PREVIEW_DB_URL`

workflow ファイルごとに使う secret が固定されるので、preview workflow が本番に触ることは構造的に起きない。

## 追加したテスト (How verified)

- [x] ADR セルフチェック（1 判断 = 1 ADR / Status / Date / Related / Alternatives / supersede trigger 独立性）
- [x] `prettier --check` が新規ファイルで通る
- [x] workflow yaml の構造を `db-migrate.yml` (本番) のパターンに揃える
- [x] trivial migration (`supabase/migrations/20260504020000_preview_workflow_smoke.sql`) を一時的に追加して `pull_request` event 経由で `db-migrate-preview` を起動 → green 確認 → merge 前に削除

## リリース前チェックリスト (When / Before merge)

外部設定（順序通り進める）:

- [x] Supabase Dashboard で preview project を作成（region / Postgres major 17 を本番と揃える）
- [x] preview project に main の migration を初期適用（`supabase db push --db-url <preview>` をローカルで 1 回）
- [x] GitHub Repository Secrets に `SUPABASE_PREVIEW_DB_URL` を追加（本番 `SUPABASE_DB_URL` とは別の secret 名）
- [x] Google Cloud Console で OAuth client の許可リダイレクト URI に preview project の callback URL を追加
- [x] preview project 側の `auth.external.google` を有効化（Supabase Dashboard）
- [ ] **preview project の Authentication → URL Configuration を設定**
  - Site URL: 安定 alias を 1 個（fallback 用、例: `https://kozutsumi-git-main-y-oga-819s-projects.vercel.app`）
  - Redirect URLs (allow list): `https://kozutsumi-*-y-oga-819s-projects.vercel.app/auth/callback`（Vercel preview の動的 URL を wildcard で許可。`*` は `/` を含まない任意文字列に match）
  - 設定が無いと OAuth 後に Site URL の default (`http://localhost:3000`) に fallback されて preview deployment にログインできない

検証:

- [x] `db-migrate-preview` workflow が PR push で起動し、preview DB に migration がきれいに当たる（trivial migration 経由で確認）
- [x] Vercel Preview env の `NEXT_PUBLIC_SUPABASE_URL` / `_ANON_KEY` を preview project の値に差し替え（Production scope は据え置き）
- [ ] preview deployment で Google sign-in が完走し、preview project の DB を見ていることを確認（Authentication → Users / Table Editor → tasks に書かれている）

クリーンアップ:

- [ ] preview DB の `schema_migrations` から smoke 行を削除（`DELETE FROM supabase_migrations.schema_migrations WHERE version = '20260504020000';`）
- [ ] `supabase/migrations/20260504020000_preview_workflow_smoke.sql` を削除して push、CI 再 green を確認
- [ ] squash merge

## このPRの範囲外 (Out of scope)

- 本番 migration workflow (ADR-0019) の変更 — preview 経路を**追加**するだけで production の手動 + approval は据え置き
- ADR-0023 の PR migration diff コメント workflow の変更 — ephemeral local Supabase で完結している既存仕組みはそのまま
- Supabase Pro plan / Branching への移行 — 無料縛りの本 ADR 系列の射程外（移行時に ADR-0042 / 0043 を supersede する）
- DB 自体の別サービス乗り換え（Neon 等） — overkill
- preview project への本番データコピー — セキュリティ・容量的に不採用、seed は最小ダミーデータで作る
- PR ごとの ephemeral DB / schema 隔離 — ADR-0042 / 0043 の Alternatives で却下済み
- preview project の seed 整備 — 必要に応じて派生 issue で扱う
- e2e `task-reorder.spec.ts:20` の flaky 修正 — 本 PR とは無関係に発生、別途 #191 で扱う
