### PR TITLE
fix(task-stack): visibilitychange で foreground 復帰時に timer tick を強制 (Closes #153)

### DIFF
--- a/src/features/task-stack/useTaskTimer.test.tsx
+++ b/src/features/task-stack/useTaskTimer.test.tsx
@@ -233,6 +233,42 @@ describe("useTaskTimer", () => {
     });
   });
 
+  test("visibilitychange (visible) で active タスクの elapsedSeconds が即時更新される", async () => {
+    const startedAtMs = new Date("2026-04-19T10:00:00.000Z").getTime();
+    // setInterval が tick を踏んでいない (= background で throttle 中) 状況を
+    // 再現するため、Date.now() のみを stub して時刻を進める。
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(startedAtMs);
+    m.list.mockResolvedValue([
+      {
+        id: "te-open",
+        taskId: "t1",
+        startedAt: new Date(startedAtMs).toISOString(),
+        pausedAt: null,
+        pauseReason: null,
+        durationSeconds: null,
+      },
+    ]);
+    const activeTask: Task = { ...baseTask, status: "active" };
+    const { Wrapper } = wrapTimer(m);
+    const { result } = renderHook(() => useTaskTimer(activeTask), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => {
+      expect(result.current.isRunning).toBe(true);
+    });
+
+    nowSpy.mockReturnValue(startedAtMs + 60_000);
+    // visibilitychange (visible) → 即時 tick → elapsedSeconds が追従する。
+    await act(async () => {
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        get: () => "visible",
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    expect(result.current.elapsedSeconds).toBe(60);
+  });
+
   test("リロード復元: paused タスクの最終 pause_reason を pauseReason で返す", async () => {
     m.list.mockResolvedValue([
       {

--- a/src/features/task-stack/useTaskTimer.ts
+++ b/src/features/task-stack/useTaskTimer.ts
@@ -58,11 +58,21 @@ export function useTaskTimer(task: Task | null): TaskTimerApi {
   const isRunning = isActive && openEntry !== null;
 
   // アクティブな間は 1 秒間隔で再描画する。停止中は interval を張らない。
+  // タブが background で setInterval が throttle された場合、foreground 復帰時に
+  // visibilitychange で即時 tick して表示を最新に追従させる (#153)。
   const [tickMs, setTickMs] = useState<number>(() => Date.now());
   useEffect(() => {
     if (!isRunning) return;
-    const id = window.setInterval(() => setTickMs(Date.now()), 1000);
-    return () => window.clearInterval(id);
+    const tick = () => setTickMs(Date.now());
+    const id = window.setInterval(tick, 1000);
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") tick();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      window.clearInterval(id);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
   }, [isRunning]);
 
   const elapsedSeconds = useMemo(() => sumDurationSeconds(entries, tickMs), [entries, tickMs]);


### PR DESCRIPTION
## 概要 (What)

タスクタイマー実行中にタブが background へ移って `setInterval` が throttle された場合、foreground 復帰直後の経過秒数表示が古いまま固まる。`visibilitychange` で `visible` 復帰時に即時 tick を打って表示を最新時刻に追従させる。

## 関連 Issue

Closes #153

## 背景 (Why)

`useTaskTimer` は 1 秒ごとに `setTickMs(Date.now())` で再描画 trigger を打つだけで、経過秒数自体は `entries[].startedAt` 基準で `sumDurationSeconds` が常に算出する。つまり機能上の正しさは保たれているが、ブラウザがタブを inactive と判断して `setInterval` を間引きすると、表示が「最後に tick した時点の秒数」で止まって見える。

NTP 等で時刻補正された場合も同様に飛びが起こり得るが、実用上は visibilitychange による foreground 復帰の補正で十分カバーできる（次の 1 秒 tick が来るまでの差は最大 1 秒）。

ADR レベルの判断ではないため ADR は起票しない。

## Before → After (概念・フロー・メンタルモデル)

**Before:** background から戻ってくると、画面の経過秒数が一瞬古い値で見えてから次の 1 秒 tick で正しい値に飛ぶ。

**After:** foreground 復帰した瞬間に最新時刻で再描画され、ユーザーから見て「ずっと進んでいた」ように見える。

## 追加したテスト (How verified)

- [x] `useTaskTimer.test.tsx` に visibilitychange (visible) で `elapsedSeconds` が即時更新されるテストを追加（`Date.now` を stub し setInterval を踏まずに時刻を進めて throttle 中の状況を再現）
- [x] 既存 11 件 + 追加 1 件 = 12 件すべて pass
- [x] `npm run lint` / `npm run typecheck` / `npm run format:check` pass

## このPRの範囲外 (Out of scope)

- Web Worker や `requestAnimationFrame` ベースの精密 tick への切り替え（issue の現状容認/最小対応の方針に沿うため）

https://claude.ai/code/session_01EuMo3cv9Y1DumfttjNNuyv

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuMo3cv9Y1DumfttjNNuyv)_