### PR TITLE
feat(task-stack): 新規タスクの Top 直下挿入 + 親バッジ起点グループ並べ替え (Closes #172)

### DIFF
--- a/e2e/task-group-reorder.spec.ts
+++ b/e2e/task-group-reorder.spec.ts
@@ -1,0 +1,292 @@
+import type { Page } from "@playwright/test";
+
+import { createAdminClient, getTaskByTitle, seedTask, waitForActionLog } from "./db";
+import { expect, test } from "./fixtures";
+
+/**
+ * Issue #172 / ADR-0040 / ADR-0041:
+ *   - 新規タスクは Top の直下 (visible 上から 2 番目) に挿入される
+ *   - 親バッジ起点で同じ `parent_task_id` を持つ全行をグループとして
+ *     まとめて並び替えできる (action_log: `task_reordered.group_parent_id`)
+ *   - グループ内の個別行ドラッグは従来通り (Grip 起点) 動く
+ */
+
+test.describe("ADR-0040: 新規タスクは Top 直下に挿入される", () => {
+  test("Top タスクは押し下げられず、新規タスクが Stack 2 番目に入る", async ({
+    signedInPageWithProject: page,
+    projectName,
+  }) => {
+    // 既存タスク 3 件を順に登録 (末尾追加挙動が default だった頃と同じ操作)。
+    // ADR-0040 後は「最後に登録した N3 が Top の直下」に来るのが期待挙動。
+    const titles = ["先頭A", "中B", "末C"] as const;
+    for (const t of titles) {
+      await createTaskViaUI(page, t, projectName);
+    }
+
+    const stack = page.getByRole("list", { name: "タスクスタック" });
+    // 3 件入った時点での visible 順は登録順 (= A, B, C)。最後に登録した C が
+    // Top の直下に入っているはず。
+    await expectVisibleOrder(stack, ["先頭A", "末C", "中B"]);
+
+    // 4 件目を追加。Top (A) は維持され、N が 2 番目に来る。
+    await createTaskViaUI(page, "新規N", projectName);
+    await expectVisibleOrder(stack, ["先頭A", "新規N", "末C", "中B"]);
+  });
+});
+
+test.describe("ADR-0041: 親バッジ起点のグループ並べ替え", () => {
+  test("親 P の子グループが分断中でも、親バッジドラッグでグループ単位で再収束する", async ({
+    signedInPageWithProject: page,
+    projectName,
+    testUserId: userId,
+  }) => {
+    const admin = createAdminClient();
+    // signedInPageWithProject が UI 経由で作った project を再利用するため、
+    // service_role で project を引き当てる (e2e fixture の補助 path)。
+    const { data: projRow, error: projErr } = await admin
+      .from("projects")
+      .select("id")
+      .eq("user_id", userId)
+      .eq("name", projectName)
+      .single();
+    if (projErr || !projRow) throw new Error("[e2e] project not found");
+    const projectId = (projRow as { id: string }).id;
+
+    // 分断状態を service_role で seed する:
+    //   stack_order:  0       1     2     3     4
+    //   id:           c1     N    c2    p(hidden)  s
+    //   parent:        p     -     p     -     -
+    // visible:        c1     N    c2     -     s
+    const parent = await seedTask(admin, {
+      userId,
+      projectId,
+      title: "親P",
+      stackOrder: 3,
+      decomposeStatus: "decomposed",
+    });
+    await seedTask(admin, {
+      userId,
+      projectId,
+      title: "子c1",
+      stackOrder: 0,
+      parentTaskId: parent.id,
+    });
+    await seedTask(admin, {
+      userId,
+      projectId,
+      title: "新N",
+      stackOrder: 1,
+    });
+    await seedTask(admin, {
+      userId,
+      projectId,
+      title: "子c2",
+      stackOrder: 2,
+      parentTaskId: parent.id,
+    });
+    await seedTask(admin, {
+      userId,
+      projectId,
+      title: "兄弟s",
+      stackOrder: 4,
+    });
+
+    await page.reload();
+    const stack = page.getByRole("list", { name: "タスクスタック" });
+    // 分断状態の visible 順を確認。
+    await expectVisibleOrder(stack, ["子c1", "新N", "子c2", "兄弟s"]);
+
+    // 子 c2 の親バッジを起点にグループドラッグ → 兄弟s の上に落とす。
+    // 期待: グループ {c1, c2} が s の手前にまとめて移動 → visible = [新N, 子c1, 子c2, 兄弟s]。
+    await dragGroupAboveRow(page, "子c2", "親P", "兄弟s");
+
+    await expect
+      .poll(async () => visibleTitles(stack), {
+        message: "グループ移動後の visible 順",
+        timeout: 5_000,
+      })
+      .toEqual(["新N", "子c1", "子c2", "兄弟s"]);
+
+    // action_log に group_parent_id 付きの task_reordered が、グループ要素 2 件分残る。
+    const c1Row = await getTaskByTitle(admin, userId, "子c1");
+    const c2Row = await getTaskByTitle(admin, userId, "子c2");
+    await waitForActionLog(
+      admin,
+      userId,
+      (l) =>
+        l.action_type === "task_reordered" &&
+        (l.metadata as { task_id?: string }).task_id === c1Row.id &&
+        (l.metadata as { group_parent_id?: string }).group_parent_id === parent.id,
+      { description: "task_reordered.group_parent_id (c1)" },
+    );
+    await waitForActionLog(
+      admin,
+      userId,
+      (l) =>
+        l.action_type === "task_reordered" &&
+        (l.metadata as { task_id?: string }).task_id === c2Row.id &&
+        (l.metadata as { group_parent_id?: string }).group_parent_id === parent.id,
+      { description: "task_reordered.group_parent_id (c2)" },
+    );
+  });
+
+  test("グループ内の個別行ドラッグ (Grip 起点) は従来通り 1 行だけ動く", async ({
+    signedInPageWithProject: page,
+    projectName,
+    testUserId: userId,
+  }) => {
+    const admin = createAdminClient();
+    const { data: projRow } = await admin
+      .from("projects")
+      .select("id")
+      .eq("user_id", userId)
+      .eq("name", projectName)
+      .single();
+    const projectId = (projRow as { id: string }).id;
+
+    const parent = await seedTask(admin, {
+      userId,
+      projectId,
+      title: "親P",
+      stackOrder: 0,
+      decomposeStatus: "decomposed",
+    });
+    await seedTask(admin, {
+      userId,
+      projectId,
+      title: "子c1",
+      stackOrder: 1,
+      parentTaskId: parent.id,
+    });
+    await seedTask(admin, {
+      userId,
+      projectId,
+      title: "子c2",
+      stackOrder: 2,
+      parentTaskId: parent.id,
+    });
+    await seedTask(admin, {
+      userId,
+      projectId,
+      title: "兄弟s",
+      stackOrder: 3,
+    });
+
+    await page.reload();
+    const stack = page.getByRole("list", { name: "タスクスタック" });
+    await expectVisibleOrder(stack, ["子c1", "子c2", "兄弟s"]);
+
+    // c2 の Grip を掴んで s の上へ単独ドラッグ → 期待: c1, s, c2 (グループ分断)
+    await dragRowAboveRowByGrip(page, "子c2", "兄弟s");
+
+    await expect
+      .poll(async () => visibleTitles(stack), {
+        message: "個別行 (Grip) ドラッグは 1 行だけ動く",
+        timeout: 5_000,
+      })
+      .toEqual(["子c1", "兄弟s", "子c2"]);
+
+    // action_log: 単独ドラッグなので group_parent_id は付かない。
+    const c2Row = await getTaskByTitle(admin, userId, "子c2");
+    const log = await waitForActionLog(
+      admin,
+      userId,
+      (l) =>
+        l.action_type === "task_reordered" &&
+        (l.metadata as { task_id?: string }).task_id === c2Row.id,
+      { description: "task_reordered (c2 個別)" },
+    );
+    expect((log.metadata as { group_parent_id?: string }).group_parent_id).toBeUndefined();
+  });
+});
+
+async function createTaskViaUI(page: Page, title: string, projectName: string): Promise<void> {
+  await page.getByRole("button", { name: "新規追加" }).click();
+  const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+  await addDialog.getByRole("tab", { name: "タスク" }).click();
+  await addDialog.getByLabel("タイトル").fill(title);
+  await addDialog.getByRole("radio", { name: "30分" }).click();
+  await addDialog.getByLabel("プロジェクト (任意)").selectOption({ label: projectName });
+  await addDialog.getByRole("button", { name: "追加" }).click();
+  await expect(addDialog).toHaveCount(0);
+}
+
+async function visibleTitles(stack: ReturnType<Page["getByRole"]>): Promise<string[]> {
+  // listitem 内の最初のタイトル文字列を上から順に拾う。Top カードと行カードで
+  // タイトルの位置が違うので、aria-label="並び替えハンドル" 兄弟の text を取る。
+  const items = await stack.getByRole("listitem").all();
+  const titles: string[] = [];
+  for (const item of items) {
+    const txt = (await item.textContent()) ?? "";
+    titles.push(txt);
+  }
+  return titles;
+}
+
+async function expectVisibleOrder(
+  stack: ReturnType<Page["getByRole"]>,
+  expected: string[],
+): Promise<void> {
+  // 各 expected タイトルが listitem の中で対応する index 位置に現れるかを踏む。
+  for (let i = 0; i < expected.length; i++) {
+    await expect(stack.getByRole("listitem").nth(i)).toContainText(expected[i]);
+  }
+}
+
+/**
+ * 親バッジ (`role=button`, `aria-label="親グループ並び替え: <親名>"`) を起点にした
+ * グループドラッグ。`sourceTitle` の行に乗っている親バッジを掴んで、
+ * `targetTitle` の上端より少し下に落とす (= target の midline より上)。
+ */
+async function dragGroupAboveRow(
+  page: Page,
+  sourceTitle: string,
+  parentTitle: string,
+  targetTitle: string,
+): Promise<void> {
+  const stack = page.getByRole("list", { name: "タスクスタック" });
+  const sourceRow = stack.getByRole("listitem").filter({ hasText: sourceTitle });
+  const targetRow = stack.getByRole("listitem").filter({ hasText: targetTitle });
+
+  const badge = sourceRow.getByRole("button", { name: `親グループ並び替え: ${parentTitle}` });
+  const badgeBox = await badge.boundingBox();
+  const targetBox = await targetRow.boundingBox();
+  if (!badgeBox || !targetBox) throw new Error("badge/row not measurable");
+
+  const startX = badgeBox.x + badgeBox.width / 2;
+  const startY = badgeBox.y + badgeBox.height / 2;
+  const endX = startX;
+  const endY = targetBox.y + 4;
+
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(startX, startY - 20, { steps: 5 });
+  await page.mouse.move(endX, endY, { steps: 10 });
+  await page.mouse.up();
+}
+
+async function dragRowAboveRowByGrip(
+  page: Page,
+  sourceTitle: string,
+  targetTitle: string,
+): Promise<void> {
+  const stack = page.getByRole("list", { name: "タスクスタック" });
+  const sourceRow = stack.getByRole("listitem").filter({ hasText: sourceTitle });
+  const targetRow = stack.getByRole("listitem").filter({ hasText: targetTitle });
+
+  const grip = sourceRow.locator(".cursor-grab").first();
+  const gripBox = await grip.boundingBox();
+  const targetBox = await targetRow.boundingBox();
+  if (!gripBox || !targetBox) throw new Error("row/grip not measurable");
+
+  const startX = gripBox.x + gripBox.width / 2;
+  const startY = gripBox.y + gripBox.height / 2;
+  const endX = startX;
+  const endY = targetBox.y + 4;
+
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(startX, startY + 5, { steps: 5 });
+  await page.mouse.move(endX, endY, { steps: 10 });
+  await page.mouse.up();
+}

--- a/e2e/task-group-reorder.spec.ts
+++ b/e2e/task-group-reorder.spec.ts
@@ -100,12 +100,7 @@ test.describe("ADR-0041: 親バッジ起点のグループ並べ替え", () => {
     // 期待: グループ {c1, c2} が s の手前にまとめて移動 → visible = [新N, 子c1, 子c2, 兄弟s]。
     await dragGroupAboveRow(page, "子c2", "親P", "兄弟s");
 
-    await expect
-      .poll(async () => visibleTitles(stack), {
-        message: "グループ移動後の visible 順",
-        timeout: 5_000,
-      })
-      .toEqual(["新N", "子c1", "子c2", "兄弟s"]);
+    await pollVisibleOrder(stack, ["新N", "子c1", "子c2", "兄弟s"], "グループ移動後の visible 順");
 
     // action_log に group_parent_id 付きの task_reordered が、グループ要素 2 件分残る。
     const c1Row = await getTaskByTitle(admin, userId, "子c1");
@@ -179,12 +174,11 @@ test.describe("ADR-0041: 親バッジ起点のグループ並べ替え", () => {
     // c2 の Grip を掴んで s の上へ単独ドラッグ → 期待: c1, s, c2 (グループ分断)
     await dragRowAboveRowByGrip(page, "子c2", "兄弟s");
 
-    await expect
-      .poll(async () => visibleTitles(stack), {
-        message: "個別行 (Grip) ドラッグは 1 行だけ動く",
-        timeout: 5_000,
-      })
-      .toEqual(["子c1", "兄弟s", "子c2"]);
+    await pollVisibleOrder(
+      stack,
+      ["子c1", "兄弟s", "子c2"],
+      "個別行 (Grip) ドラッグは 1 行だけ動く",
+    );
 
     // action_log: 単独ドラッグなので group_parent_id は付かない。
     const c2Row = await getTaskByTitle(admin, userId, "子c2");
@@ -211,32 +205,53 @@ async function createTaskViaUI(page: Page, title: string, projectName: string): 
   await expect(addDialog).toHaveCount(0);
 }
 
-async function visibleTitles(stack: ReturnType<Page["getByRole"]>): Promise<string[]> {
-  // listitem 内の最初のタイトル文字列を上から順に拾う。Top カードと行カードで
-  // タイトルの位置が違うので、aria-label="並び替えハンドル" 兄弟の text を取る。
-  const items = await stack.getByRole("listitem").all();
-  const titles: string[] = [];
-  for (const item of items) {
-    const txt = (await item.textContent()) ?? "";
-    titles.push(txt);
-  }
-  return titles;
-}
-
 async function expectVisibleOrder(
   stack: ReturnType<Page["getByRole"]>,
   expected: string[],
 ): Promise<void> {
   // 各 expected タイトルが listitem の中で対応する index 位置に現れるかを踏む。
+  // listitem の textContent は Top カードで「project header / 開始 ボタン /
+  // 未分解 pill」等を含むため完全一致ではなく toContainText で部分一致を取る。
   for (let i = 0; i < expected.length; i++) {
     await expect(stack.getByRole("listitem").nth(i)).toContainText(expected[i]);
   }
 }
 
 /**
+ * 並び替え操作後の visible 順を poll で待つ。`expectVisibleOrder` と同じ
+ * セマンティクスだが、Playwright の組み込み auto-wait を超えて長めの timeout
+ * を取りたいケース (DnD → optimistic update → server reorder の経路) で使う。
+ */
+async function pollVisibleOrder(
+  stack: ReturnType<Page["getByRole"]>,
+  expected: string[],
+  message: string,
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const items = await stack.getByRole("listitem").all();
+        if (items.length !== expected.length) return null;
+        const matched: string[] = [];
+        for (let i = 0; i < expected.length; i++) {
+          const txt = (await items[i].textContent()) ?? "";
+          if (!txt.includes(expected[i])) return null;
+          matched.push(expected[i]);
+        }
+        return matched;
+      },
+      { message, timeout: 8_000 },
+    )
+    .toEqual(expected);
+}
+
+/**
  * 親バッジ (`role=button`, `aria-label="親グループ並び替え: <親名>"`) を起点にした
  * グループドラッグ。`sourceTitle` の行に乗っている親バッジを掴んで、
  * `targetTitle` の上端より少し下に落とす (= target の midline より上)。
+ *
+ * バッジは text-[9px] の小さな要素のため、boundingBox 取得前に visible / scroll
+ * を明示的に待つ (CI 環境でレイアウト確定前に measure すると drag 不発になる)。
  */
 async function dragGroupAboveRow(
   page: Page,
@@ -249,6 +264,8 @@ async function dragGroupAboveRow(
   const targetRow = stack.getByRole("listitem").filter({ hasText: targetTitle });
 
   const badge = sourceRow.getByRole("button", { name: `親グループ並び替え: ${parentTitle}` });
+  await badge.waitFor({ state: "visible" });
+  await badge.scrollIntoViewIfNeeded();
   const badgeBox = await badge.boundingBox();
   const targetBox = await targetRow.boundingBox();
   if (!badgeBox || !targetBox) throw new Error("badge/row not measurable");
@@ -274,7 +291,12 @@ async function dragRowAboveRowByGrip(
   const sourceRow = stack.getByRole("listitem").filter({ hasText: sourceTitle });
   const targetRow = stack.getByRole("listitem").filter({ hasText: targetTitle });
 
-  const grip = sourceRow.locator(".cursor-grab").first();
+  // Row 1 の Grip (`aria-label="並び替えハンドル"`) を狙う。Row 3 の親バッジも
+  // `.cursor-grab` を持つので `locator(".cursor-grab")` だと曖昧になるため
+  // aria-label で明示的に指す。
+  const grip = sourceRow.getByLabel("並び替えハンドル");
+  await grip.waitFor({ state: "visible" });
+  await grip.scrollIntoViewIfNeeded();
   const gripBox = await grip.boundingBox();
   const targetBox = await targetRow.boundingBox();
   if (!gripBox || !targetBox) throw new Error("row/grip not measurable");

--- a/e2e/task-reorder.spec.ts
+++ b/e2e/task-reorder.spec.ts
@@ -1,6 +1,6 @@
 import type { Page } from "@playwright/test";
 
-import { createAdminClient, getTaskByTitle, waitForActionLog } from "./db";
+import { createAdminClient, getTaskByTitle, seedTask, waitForActionLog } from "./db";
 import { expect, test } from "./fixtures";
 
 /**
@@ -10,6 +10,11 @@ import { expect, test } from "./fixtures";
  * Phase 4 でユーザーがどのタスクを上に持ち上げて着手したか を学ぶには、
  * 並び替えの from/to_position と stack_order の両方が必要。UI 操作
  * (custom pointer events) と DB の最終状態を 1 セットで踏む。
+ *
+ * 起点データは `seedTask` で線形 (stack_order=0,1,2) に置く。UI 経由の
+ * createTaskWithAi は ADR-0040 で「Top 直下挿入」に変わっており、連続
+ * 登録すると visible 順がアルファベット順にならないため、並び替え検証と
+ * 切り離す目的で seed 経路を選ぶ。
  */
 test.describe("DnD 並び替え (task_reordered + tasks.stack_order)", () => {
   test("末尾を先頭に持ち上げると stack_order が 0,1,2 で再採番され、from/to ログが残る", async ({
@@ -19,10 +24,12 @@ test.describe("DnD 並び替え (task_reordered + tasks.stack_order)", () => {
   }) => {
     const titles = ["並べ替え A", "並べ替え B", "並べ替え C"] as const;
     const admin = createAdminClient();
+    const projectId = await getProjectId(admin, userId, projectName);
 
-    for (const t of titles) {
-      await createTask(page, t, projectName);
+    for (let i = 0; i < titles.length; i++) {
+      await seedTask(admin, { userId, projectId, title: titles[i], stackOrder: i });
     }
+    await page.reload();
 
     const stack = page.getByRole("list", { name: "タスクスタック" });
     for (const t of titles) {
@@ -71,10 +78,12 @@ test.describe("DnD 並び替え (task_reordered + tasks.stack_order)", () => {
   }) => {
     const titles = ["逆方向 X", "逆方向 Y", "逆方向 Z"] as const;
     const admin = createAdminClient();
+    const projectId = await getProjectId(admin, userId, projectName);
 
-    for (const t of titles) {
-      await createTask(page, t, projectName);
+    for (let i = 0; i < titles.length; i++) {
+      await seedTask(admin, { userId, projectId, title: titles[i], stackOrder: i });
     }
+    await page.reload();
 
     const stack = page.getByRole("list", { name: "タスクスタック" });
     for (const t of titles) {
@@ -111,16 +120,19 @@ test.describe("DnD 並び替え (task_reordered + tasks.stack_order)", () => {
   });
 });
 
-async function createTask(page: Page, title: string, projectName: string): Promise<void> {
-  await page.getByRole("button", { name: "新規追加" }).click();
-  const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
-  await addDialog.getByRole("tab", { name: "タスク" }).click();
-  await addDialog.getByLabel("タイトル").fill(title);
-  // #170 / ADR 0038: task_size は登録時必須。
-  await addDialog.getByRole("radio", { name: "30分" }).click();
-  await addDialog.getByLabel("プロジェクト (任意)").selectOption({ label: projectName });
-  await addDialog.getByRole("button", { name: "追加" }).click();
-  await expect(addDialog).toHaveCount(0);
+async function getProjectId(
+  admin: ReturnType<typeof createAdminClient>,
+  userId: string,
+  projectName: string,
+): Promise<string> {
+  const { data, error } = await admin
+    .from("projects")
+    .select("id")
+    .eq("user_id", userId)
+    .eq("name", projectName)
+    .single();
+  if (error || !data) throw new Error(`[e2e] project not found: ${projectName}`);
+  return (data as { id: string }).id;
 }
 
 /**

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -119,6 +119,7 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
     updateCategory,
     updateSize,
     reorder,
+    reorderGroup,
     createTaskWithAi,
     createEvent,
     updateEventProject,
@@ -234,6 +235,7 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
               topTimer={topTimer}
               toggleDone={toggleDone}
               reorder={reorder}
+              reorderGroup={reorderGroup}
               nowMin={nowMin}
               now={nowMs}
               today={today}
@@ -285,7 +287,7 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
               projects={projects}
               events={events}
               onClose={() => setAddOpen(false)}
-              onCreateTask={(input) => createTaskWithAi(input, pendingTasks.length)}
+              onCreateTask={(input) => createTaskWithAi(input)}
               onCreateEvent={createEvent}
               onCreateProject={createProject}
               onOpenProject={setProjectDetailId}
@@ -331,6 +333,7 @@ type StackViewProps = {
   topTimer: TopTimerBinding;
   toggleDone: (id: string) => void;
   reorder: (fromId: string, toId: string) => void;
+  reorderGroup: (parentTaskId: string, toId: string) => void;
   nowMin: number;
   now: number;
   today: string;
@@ -346,6 +349,7 @@ function StackView({
   topTimer,
   toggleDone,
   reorder,
+  reorderGroup,
   nowMin,
   now,
   today,
@@ -368,6 +372,7 @@ function StackView({
         topTimer={topTimer}
         now={now}
         onReorder={reorder}
+        onReorderGroup={reorderGroup}
         onToggleDone={toggleDone}
         onOpenDetail={onOpenDetail}
       />

--- a/src/app/useDashboardMutations.ts
+++ b/src/app/useDashboardMutations.ts
@@ -11,7 +11,11 @@ import type { CreateProjectInput, UpdateProjectInput } from "@/entities/project/
 import type { Project } from "@/entities/project/types";
 import type { CreateTaskInput } from "@/entities/task/gateway";
 import type { Task, TaskCategory, TaskSize } from "@/entities/task/types";
-import { reorderTasksById } from "@/features/task-stack/reorderTasks";
+import {
+  insertAtTopPlusOne,
+  reorderGroupById,
+  reorderTasksById,
+} from "@/features/task-stack/reorderTasks";
 import { triggerCategorize } from "@/features/task-stack/triggerCategorize";
 import { triggerDecompose } from "@/features/task-stack/triggerDecompose";
 import { triggerResplit } from "@/features/task-stack/triggerResplit";
@@ -40,10 +44,19 @@ export type DashboardMutations = {
   /** DnD でのタスク並び替え。action_log: TASK_REORDERED。 */
   reorder: (fromId: string, toId: string) => void;
   /**
+   * ADR-0041: 親バッジ起点のグループ並び替え。`parentTaskId` を共有する全行を
+   * グループとしてまとめて `toId` の位置に移す。action_log: TASK_REORDERED を
+   * グループ要素ごとに 1 件発火し、metadata に `group_parent_id` を含める。
+   */
+  reorderGroup: (parentTaskId: string, toId: string) => void;
+  /**
    * AddPanel からのタスク作成。タスク insert 後に AI 分解 + AI category 推論を
    * fire-and-forget で投げる (P3-4 / P3-6, ADR 0015 / 0017)。
+   *
+   * ADR-0040: 新規タスクは現在の Top タスクの直下 (visible 上から 2 番目) に挿入する。
+   * 呼び出し元は stackOrder を渡さない (内部で cache から Top+1 を算出する)。
    */
-  createTaskWithAi: (input: CreateTaskInput, stackOrder: number) => Promise<void>;
+  createTaskWithAi: (input: CreateTaskInput) => Promise<void>;
   createEvent: (input: CreateEventInput) => Promise<void>;
   /** ADR 0010: google_calendar event の project_id だけ kozutsumi 側で編集可。 */
   updateEventProject: (id: string, projectId: string | null) => void;
@@ -428,26 +441,98 @@ export function useDashboardMutations(): DashboardMutations {
     [queryClient, reorderMutation],
   );
 
+  // ADR-0041: 親バッジ起点のグループ並べ替え。`parentTaskId` を共有する全 pending を
+  // グループとしてまとめて `toId` の位置に移す。
+  // action_log: グループ要素ごとに 1 件 `task_reordered` を発火し、metadata に
+  // `group_parent_id` を含める (ADR-0001 の「個別 type の payload 揺らぎは JSONB
+  // で吸収」原則の範囲内。新 type は起こさない)。Phase 4 ではこの flag で
+  // 「ユーザーがグループ単位で動かした」事象を 1 操作として再構成可能。
+  const reorderGroup = useCallback(
+    (parentTaskId: string, toId: string) => {
+      const cached = queryClient.getQueryData<Task[]>(dashboardKeys.tasks) ?? [];
+      const pending = cached.filter((t) => !isDone(t));
+      const done = cached.filter((t) => isDone(t));
+      const groupIds = new Set(
+        pending.filter((t) => t.parentTaskId === parentTaskId).map((t) => t.id),
+      );
+      if (groupIds.size === 0) return;
+      // グループ内 row へドロップは no-op (自分のグループに自分を落とさない)
+      if (groupIds.has(toId)) return;
+      if (pending.findIndex((t) => t.id === toId) < 0) return;
+
+      const reordered = reorderGroupById(pending, parentTaskId, toId);
+      queryClient.setQueryData<Task[]>(dashboardKeys.tasks, [...reordered, ...done]);
+
+      // グループ要素ごとに log: 起点行が分散している場合でも `group_parent_id` で
+      // 同じグループ移動だと再構成できる。to_position はグループ移動後の位置。
+      const toPositionByOldIdx = new Map<string, number>();
+      reordered.forEach((t, newIdx) => {
+        if (groupIds.has(t.id)) toPositionByOldIdx.set(t.id, newIdx);
+      });
+      pending.forEach((t, oldIdx) => {
+        if (!groupIds.has(t.id)) return;
+        log(ACTION_TYPES.TASK_REORDERED, {
+          task_id: t.id,
+          from_position: oldIdx,
+          to_position: toPositionByOldIdx.get(t.id) ?? oldIdx,
+          group_parent_id: parentTaskId,
+        });
+      });
+
+      reorderMutation.mutate(
+        reordered.map((t) => ({ id: t.id, stackOrder: t.stackOrder })),
+        {
+          onError: () => {
+            queryClient.invalidateQueries({ queryKey: dashboardKeys.tasks });
+          },
+        },
+      );
+    },
+    [queryClient, reorderMutation],
+  );
+
   const createTaskWithAi = useCallback(
-    async (input: CreateTaskInput, stackOrder: number) => {
-      const created = await createTaskMutation.mutateAsync({ ...input, stackOrder });
+    async (input: CreateTaskInput) => {
+      // ADR-0040: 新規タスクは server 側でいったん末尾相当で create し、
+      // 直後に Top+1 へ renumber する 2 段階で実装する。
+      // 仮値は cache から算出する pending 件数 (= 末尾相当 stack_order)。
+      const initialCached = queryClient.getQueryData<Task[]>(dashboardKeys.tasks) ?? [];
+      const initialPendingCount = initialCached.filter((t) => !isDone(t)).length;
+      const created = await createTaskMutation.mutateAsync({
+        ...input,
+        stackOrder: initialPendingCount,
+      });
+
+      // issue #167: cancelQueries を挟むことで「他経路で in-flight な tasks refetch
+      // (例: focus 戻り後の自動 refetch / 並走するイベント refetch) が
+      // setQueryData('decomposing') を上書きする」競合を防ぐ。
+      await queryClient.cancelQueries({ queryKey: dashboardKeys.tasks });
+
+      // 楽観 cache: created を Top の直下 (visible 上から 2 番目) に挿入し、
+      // pending を 0..n で振り直す (ADR-0040)。decomposing pill も同時に立てる。
+      const current = queryClient.getQueryData<Task[]>(dashboardKeys.tasks) ?? [];
+      // mutateAsync 後の再 fetch で created がすでに cache に居る可能性があるので除外する。
+      const currentPendingExcl = current.filter((t) => !isDone(t) && t.id !== created.id);
+      const currentDone = current.filter((t) => isDone(t));
+      const createdWithPill: Task = { ...created, decomposeStatus: "decomposing" };
+      const renumbered = insertAtTopPlusOne(currentPendingExcl, current, createdWithPill);
+      queryClient.setQueryData<Task[]>(dashboardKeys.tasks, [...renumbered, ...currentDone]);
+
+      // server 側も同じ並びに揃える (背面で進める)。失敗時は invalidate して DB 正に倒す。
+      reorderMutation.mutate(
+        renumbered.map((t) => ({ id: t.id, stackOrder: t.stackOrder })),
+        {
+          onError: () => {
+            queryClient.invalidateQueries({ queryKey: dashboardKeys.tasks });
+          },
+        },
+      );
+
       // P3-6 / ADR 0017: タスク作成成功後に AI 分解を fire-and-forget で投げる。
       // server 側でも `decompose_status='decomposing'` に倒すが、UI に分解中 pill を
       // 即時出すため optimistic に cache を書き換える。AI_ENABLED=false / 失敗時は
       // server が `none` に戻す (decompose-server の guard 経路)。
       //
-      // issue #167: cancelQueries を挟むことで「他経路で in-flight な tasks refetch
-      // (例: focus 戻り後の自動 refetch / 並走するイベント refetch) が
-      // setQueryData('decomposing') を上書きする」競合を防ぐ。
-      await queryClient.cancelQueries({ queryKey: dashboardKeys.tasks });
-      queryClient.setQueryData<Task[]>(dashboardKeys.tasks, (prev) => {
-        const list = prev ?? [];
-        const found = list.some((t) => t.id === created.id);
-        const updated = { ...created, decomposeStatus: "decomposing" as const };
-        return found
-          ? list.map((t) => (t.id === created.id ? { ...t, decomposeStatus: "decomposing" } : t))
-          : [...list, updated];
-      });
       // issue #167: server 側 decompose 完了後 (成功 / 失敗 / skipped 問わず) に
       // tasks を invalidate して refetch する。これがないと cache が `decomposing`
       // で固まり、親 `decomposed` への遷移と子フラット化が手動リロードまで反映されない。
@@ -463,7 +548,7 @@ export function useDashboardMutations(): DashboardMutations {
         queryClient.invalidateQueries({ queryKey: dashboardKeys.tasks });
       });
     },
-    [createTaskMutation, queryClient],
+    [createTaskMutation, queryClient, reorderMutation],
   );
 
   const triggerDecomposeWithOptimistic = useCallback(
@@ -512,6 +597,7 @@ export function useDashboardMutations(): DashboardMutations {
     updateCategory: (id, taskCategory) => updateCategoryMutation.mutate({ id, taskCategory }),
     updateSize: (id, taskSize) => updateSizeMutation.mutate({ id, taskSize }),
     reorder,
+    reorderGroup,
     createTaskWithAi,
     createEvent: (input) => createEventMutation.mutateAsync(input).then(() => undefined),
     updateEventProject: (id, projectId) => updateEventProjectMutation.mutate({ id, projectId }),

--- a/src/entities/action-log/types.ts
+++ b/src/entities/action-log/types.ts
@@ -87,10 +87,17 @@ export type ActionMetadataMap = {
     estimated_minutes?: number;
     actual_minutes?: number;
   };
+  // ADR-0041: グループ並べ替え (親バッジ起点で同じ parent_task_id を持つ全行を
+  // まとめて移動) のとき、各要素の log に `group_parent_id` を含める。
+  // 個別 row の移動 (Grip 起点) では undefined。
+  // ADR-0001 の「個別 type の payload 揺らぎは JSONB で吸収」原則に収まる範囲。
+  // Phase 4 では同一 `created_at` 近辺の同 `group_parent_id` ログ群を 1 グループ
+  // 移動として再構成する。
   task_reordered: {
     task_id: string;
     from_position: number;
     to_position: number;
+    group_parent_id?: string;
   };
   // ADR 0035 §5: 削除系は元 entity が物理削除されるため snapshot を必須化する。
   // 過去ログ (snapshot 列が無かった頃) は backfill しない (ADR 0035 §6)。

--- a/src/features/task-stack/TaskRow.tsx
+++ b/src/features/task-stack/TaskRow.tsx
@@ -24,6 +24,9 @@ import { StatusPill } from "./StatusPill";
  *
  * 完了 checkbox は出さない (Top-only complete; ADR 0016 §7)。
  * leaf-parent (親自身が Stack 行) は「⤷ 親」を出さず、status pill のみ。
+ *
+ * ADR-0041: 親バッジ (`⤷ 親名`) は同じ `parent_task_id` を持つ全行をグループとして
+ * まとめて動かすドラッグ起点になる。Grip 起点 (single drag) と並立する。
  */
 type TaskRowProps = {
   task: Task;
@@ -35,7 +38,13 @@ type TaskRowProps = {
   parent?: Task;
   /** 子タスクなら親に紐付く進捗。leaf-parent では undefined。 */
   progress?: Progress;
+  /** Grip ハンドル起点の単独ドラッグ pointerDown ハンドラ。 */
   onPointerDown: (e: ReactPointerEvent<HTMLElement>) => void;
+  /**
+   * 親バッジ起点のグループドラッグ pointerDown ハンドラ (ADR-0041)。
+   * 子タスク (`parent !== undefined`) のときだけ親バッジに乗せる。
+   */
+  onGroupPointerDown?: (e: ReactPointerEvent<HTMLElement>) => void;
   onClick: () => void;
 };
 
@@ -47,6 +56,7 @@ export function TaskRow({
   parent,
   progress,
   onPointerDown,
+  onGroupPointerDown,
   onClick,
 }: TaskRowProps) {
   const { projectsById } = useProjects();
@@ -115,7 +125,21 @@ export function TaskRow({
         <div className="ml-[26px] mt-1 flex items-center gap-2">
           {showProgress && parent ? (
             <span
-              className="min-w-0 flex-1 truncate font-jp text-[9px]"
+              role="button"
+              tabIndex={0}
+              aria-label={`親グループ並び替え: ${parent.title}`}
+              onPointerDown={
+                onGroupPointerDown
+                  ? (e) => {
+                      e.stopPropagation();
+                      onGroupPointerDown(e);
+                    }
+                  : undefined
+              }
+              onClick={(e) => e.stopPropagation()}
+              className={`min-w-0 flex-1 truncate font-jp text-[9px] ${
+                onGroupPointerDown ? "cursor-grab touch-none" : ""
+              }`}
               style={{ color: `${getProject(projectsById, parent.projectId).color}cc` }}
               title={`親: ${parent.title}`}
             >

--- a/src/features/task-stack/TaskStack.test.tsx
+++ b/src/features/task-stack/TaskStack.test.tsx
@@ -491,6 +491,7 @@ describe("TaskStack", () => {
         doneTasks={[]}
         topTimer={idleTimer}
         onReorder={noop}
+        onReorderGroup={noop}
         onToggleDone={noop}
         onOpenDetail={noop}
       />,
@@ -533,6 +534,7 @@ describe("TaskStack", () => {
         doneTasks={[]}
         topTimer={idleTimer}
         onReorder={noop}
+        onReorderGroup={noop}
         onToggleDone={noop}
         onOpenDetail={noop}
       />,
@@ -552,6 +554,7 @@ describe("TaskStack", () => {
         doneTasks={doneTasks}
         topTimer={idleTimer}
         onReorder={noop}
+        onReorderGroup={noop}
         onToggleDone={noop}
         onOpenDetail={noop}
       />,
@@ -570,6 +573,7 @@ describe("TaskStack", () => {
         doneTasks={[]}
         topTimer={idleTimer}
         onReorder={noop}
+        onReorderGroup={noop}
         onToggleDone={noop}
         onOpenDetail={onOpenDetail}
       />,

--- a/src/features/task-stack/TaskStack.tsx
+++ b/src/features/task-stack/TaskStack.tsx
@@ -43,12 +43,17 @@ type TaskStackProps = {
   /** 現在時刻 (ms)。依存イベントの相対時刻 / 直近判定で使う。0 は SSR 時の placeholder。 */
   now: number;
   /**
-   * 並び替え操作。`fromId` を `toId` の位置に移す。
+   * 単独行の並び替え操作。`fromId` を `toId` の位置に移す。
    * Stack 行の index ではなく id ベースで受け取るのは、`buildStackItems` が
    * decomposed 親を除外するため、UI 上の index と pending Task[] の index が
    * 一致しないことがあるため。
    */
   onReorder: (fromId: string, toId: string) => void;
+  /**
+   * ADR-0041: 親バッジ起点のグループ並べ替え。`parentTaskId` を共有する全行を
+   * グループとしてまとめて `toId` の位置に移す。
+   */
+  onReorderGroup: (parentTaskId: string, toId: string) => void;
   onToggleDone: (id: string) => void;
   onOpenDetail: (id: string) => void;
 };
@@ -60,6 +65,7 @@ export function TaskStack({
   topTimer,
   now,
   onReorder,
+  onReorderGroup,
   onToggleDone,
   onOpenDetail,
 }: TaskStackProps) {
@@ -71,15 +77,20 @@ export function TaskStack({
   );
 
   const handleReorderByIdx = useCallback(
-    (fromIdx: number, toIdx: number) => {
+    (fromIdx: number, toIdx: number, mode: "single" | "group") => {
       const fromItem = items[fromIdx];
       const toItem = items[toIdx];
       if (!fromItem || !toItem) return;
-      onReorder(fromItem.task.id, toItem.task.id);
+      if (mode === "group" && fromItem.kind === "leaf-child") {
+        onReorderGroup(fromItem.parent.id, toItem.task.id);
+      } else {
+        onReorder(fromItem.task.id, toItem.task.id);
+      }
     },
-    [items, onReorder],
+    [items, onReorder, onReorderGroup],
   );
-  const { dragIdx, overIdx, rowRefs, handlePointerDown } = useStackDnD(handleReorderByIdx);
+  const { dragIdx, overIdx, dragMode, rowRefs, handlePointerDown } =
+    useStackDnD(handleReorderByIdx);
 
   return (
     <>
@@ -89,10 +100,25 @@ export function TaskStack({
         並び順が意味を持つリスト。role=list / listitem を立てておくと
         スクリーンリーダーが項目数を読み上げ、e2e も semantic に取れる。
       */}
+      {/*
+        ADR-0041: グループドラッグ中は同一 parent_task_id を持つ全行を「動いている」
+        ように見せる (起点行だけだと「グループが動く」感覚が伝わらない)。
+        起点行 (`dragIdx`) が leaf-child のときに、その parent.id と一致する
+        全 items を fade させる。
+      */}
       <ul role="list" aria-label="タスクスタック" className="m-0 list-none p-0">
         {items.map((item, idx) => {
           const isFirst = idx === 0;
-          const isBeingDragged = dragIdx === idx;
+          const draggedItem = dragIdx !== null ? items[dragIdx] : undefined;
+          const draggedGroupParentId =
+            dragMode === "group" && draggedItem?.kind === "leaf-child"
+              ? draggedItem.parent.id
+              : null;
+          const isGroupMember =
+            draggedGroupParentId !== null &&
+            item.kind === "leaf-child" &&
+            item.parent.id === draggedGroupParentId;
+          const isBeingDragged = dragIdx === idx || isGroupMember;
           const isDropTarget = overIdx === idx && dragIdx !== null && dragIdx !== idx;
           const task = item.task;
           const parent = item.kind === "leaf-child" ? item.parent : undefined;
@@ -131,7 +157,10 @@ export function TaskStack({
                   isBeingDragged={isBeingDragged}
                   parent={parent}
                   progress={progress}
-                  onPointerDown={(e) => handlePointerDown(idx, e)}
+                  onPointerDown={(e) => handlePointerDown(idx, e, "single")}
+                  onGroupPointerDown={
+                    parent ? (e) => handlePointerDown(idx, e, "group") : undefined
+                  }
                   onClick={() => onOpenDetail(task.id)}
                 />
               )}

--- a/src/features/task-stack/reorderTasks.test.ts
+++ b/src/features/task-stack/reorderTasks.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import type { Task } from "@/entities/task/types";
 
-import { reorderTasksById } from "./reorderTasks";
+import { insertAtTopPlusOne, reorderGroupById, reorderTasksById } from "./reorderTasks";
 
 const baseTask: Task = {
   id: "t",
@@ -78,5 +78,132 @@ describe("reorderTasksById", () => {
     expect(pending.map((x) => x.id)).toEqual(["a", "b"]);
     expect(a.stackOrder).toBe(0);
     expect(b.stackOrder).toBe(1);
+  });
+});
+
+describe("reorderGroupById (ADR-0041)", () => {
+  test("親 P の子グループを兄弟 x の位置に移動: 相対順序を保ったまままとめて動く", () => {
+    // pending = [c1, c2, p (hidden), s, x] (visible = [c1, c2, s, x])
+    // groupIds は parent_task_id === 'p' を持つ行 (= c1, c2) のみ。
+    // decomposed 親 p 自身は parentTaskId=null なのでグループ要素ではない。
+    // p の stack_order は hidden の都合で見かけ上影響しない。
+    const pending = [
+      t({ id: "c1", parentTaskId: "p", stackOrder: 0 }),
+      t({ id: "c2", parentTaskId: "p", stackOrder: 1 }),
+      t({ id: "p", decomposeStatus: "decomposed", stackOrder: 2 }),
+      t({ id: "s", stackOrder: 3 }),
+      t({ id: "x", stackOrder: 4 }),
+    ];
+
+    const result = reorderGroupById(pending, "p", "x");
+
+    // others = [p, s, x]、group = [c1, c2]。x 手前にグループ挿入で
+    // pending = [p, s, c1, c2, x]。visible = [s, c1, c2, x] となり
+    // 「P の子グループが s の後 / x の前」に動いた状態になる。
+    expect(result.map((r) => r.id)).toEqual(["p", "s", "c1", "c2", "x"]);
+    expect(result.map((r) => r.stackOrder)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  test("分断中のグループ (P の子が複数の塊に分かれている) も全行が 1 グループとして動く", () => {
+    // pending = [c1, N, c2, c3, p (hidden), s] (visible = [c1, N, c2, c3, s])
+    // group = [c1, c2, c3] (parentTaskId === 'p')、N と p と s はグループ外。
+    const pending = [
+      t({ id: "c1", parentTaskId: "p", stackOrder: 0 }),
+      t({ id: "N", stackOrder: 1 }),
+      t({ id: "c2", parentTaskId: "p", stackOrder: 2 }),
+      t({ id: "c3", parentTaskId: "p", stackOrder: 3 }),
+      t({ id: "p", decomposeStatus: "decomposed", stackOrder: 4 }),
+      t({ id: "s", stackOrder: 5 }),
+    ];
+
+    const result = reorderGroupById(pending, "p", "s");
+
+    // others = [N, p, s]、group = [c1, c2, c3]。s 手前にグループ挿入で
+    // pending = [N, p, c1, c2, c3, s]。visible = [N, c1, c2, c3, s] で
+    // 分断状態 (c1, N, c2, c3) がグループ単位で再収束される。
+    expect(result.map((r) => r.id)).toEqual(["N", "p", "c1", "c2", "c3", "s"]);
+    expect(result.map((r) => r.stackOrder)).toEqual([0, 1, 2, 3, 4, 5]);
+  });
+
+  test("グループ内の row へドロップは no-op", () => {
+    const pending = [
+      t({ id: "c1", parentTaskId: "p", stackOrder: 0 }),
+      t({ id: "c2", parentTaskId: "p", stackOrder: 1 }),
+      t({ id: "s", stackOrder: 2 }),
+    ];
+    const result = reorderGroupById(pending, "p", "c2");
+    expect(result.map((r) => r.id)).toEqual(["c1", "c2", "s"]);
+  });
+
+  test("該当 parent_task_id を持つ task が無いと no-op", () => {
+    const pending = [t({ id: "a", stackOrder: 0 }), t({ id: "b", stackOrder: 1 })];
+    const result = reorderGroupById(pending, "missing-parent", "a");
+    expect(result.map((r) => r.id)).toEqual(["a", "b"]);
+  });
+
+  test("不変性: 入力配列・要素は変更しない", () => {
+    const c1 = t({ id: "c1", parentTaskId: "p", stackOrder: 0 });
+    const s = t({ id: "s", stackOrder: 1 });
+    const pending = [c1, s];
+
+    reorderGroupById(pending, "p", "s");
+
+    expect(pending.map((x) => x.id)).toEqual(["c1", "s"]);
+    expect(c1.stackOrder).toBe(0);
+    expect(s.stackOrder).toBe(1);
+  });
+});
+
+describe("insertAtTopPlusOne (ADR-0040)", () => {
+  test("Top の直下に挿入し stackOrder を 0..n で振り直す", () => {
+    const pending = [
+      t({ id: "a", stackOrder: 0 }),
+      t({ id: "b", stackOrder: 1 }),
+      t({ id: "c", stackOrder: 2 }),
+    ];
+    const newTask = t({ id: "N", stackOrder: 99 });
+
+    const result = insertAtTopPlusOne(pending, pending, newTask);
+
+    expect(result.map((r) => r.id)).toEqual(["a", "N", "b", "c"]);
+    expect(result.map((r) => r.stackOrder)).toEqual([0, 1, 2, 3]);
+  });
+
+  test("pending が空のときは head に挿入", () => {
+    const newTask = t({ id: "N", stackOrder: 99 });
+    const result = insertAtTopPlusOne([], [], newTask);
+    expect(result.map((r) => r.id)).toEqual(["N"]);
+    expect(result.map((r) => r.stackOrder)).toEqual([0]);
+  });
+
+  test("decomposed 親が pending の先頭に居ても、visible Top (= 子) の直下に入る", () => {
+    // pending = [decomposed 親 P, child_P_1, child_P_2, sibling]
+    // visible Top = child_P_1 (P は除外される)
+    // 新規 N は child_P_1 の直下 (= 親グループを分断する位置)
+    const pending = [
+      t({ id: "P", decomposeStatus: "decomposed", stackOrder: 0 }),
+      t({ id: "c1", parentTaskId: "P", stackOrder: 1 }),
+      t({ id: "c2", parentTaskId: "P", stackOrder: 2 }),
+      t({ id: "s", stackOrder: 3 }),
+    ];
+    const newTask = t({ id: "N", stackOrder: 99 });
+
+    const result = insertAtTopPlusOne(pending, pending, newTask);
+
+    // pending の中で c1 の直後 (= idx 2 の位置) に N が入り、全て renumber される。
+    expect(result.map((r) => r.id)).toEqual(["P", "c1", "N", "c2", "s"]);
+    expect(result.map((r) => r.stackOrder)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  test("不変性: 入力配列・要素は変更しない", () => {
+    const a = t({ id: "a", stackOrder: 0 });
+    const newTask = t({ id: "N", stackOrder: 99 });
+    const pending = [a];
+
+    insertAtTopPlusOne(pending, pending, newTask);
+
+    expect(pending.map((x) => x.id)).toEqual(["a"]);
+    expect(a.stackOrder).toBe(0);
+    expect(newTask.stackOrder).toBe(99);
   });
 });

--- a/src/features/task-stack/reorderTasks.ts
+++ b/src/features/task-stack/reorderTasks.ts
@@ -1,5 +1,7 @@
 import type { Task } from "@/entities/task/types";
 
+import { buildStackItems } from "./stackItems";
+
 /**
  * `pending` 配列内で `fromId` を `toId` の位置に移し、`stackOrder` を 0..n-1 で振り直す。
  *
@@ -17,5 +19,64 @@ export function reorderTasksById(pending: readonly Task[], fromId: string, toId:
   const next = [...pending];
   const [item] = next.splice(fromIdx, 1);
   next.splice(toIdx, 0, item);
+  return next.map((t, i) => ({ ...t, stackOrder: i }));
+}
+
+/**
+ * ADR-0041: 親バッジ起点のグループ並べ替え。
+ * `parentTaskId` を共有する全 task をグループ要素として、相対順序を保ったまま
+ * `toId` の位置にまとめて挿入し、`stackOrder` を 0..n-1 で振り直す。
+ *
+ * - `toId` がグループ内 row のときは no-op (自分のグループに自分を落とさない)
+ * - `parentTaskId` を持つ task が `pending` に無い / `toId` が見つからない場合も no-op
+ * - グループ要素が 1 件のみのときは `reorderTasksById` 相当の挙動になる
+ *
+ * グループは Stack 内で複数の塊に分かれている (= 分断中) ことがある。その場合も
+ * `parent_task_id` の equivalence class 全体が 1 グループとして動く (ADR-0041 Notes)。
+ */
+export function reorderGroupById(
+  pending: readonly Task[],
+  parentTaskId: string,
+  toId: string,
+): Task[] {
+  const groupIds = new Set(pending.filter((t) => t.parentTaskId === parentTaskId).map((t) => t.id));
+  if (groupIds.size === 0) return [...pending];
+  if (groupIds.has(toId)) return [...pending];
+  const targetIdx = pending.findIndex((t) => t.id === toId);
+  if (targetIdx < 0) return [...pending];
+
+  const groupMembers = pending.filter((t) => groupIds.has(t.id));
+  const others = pending.filter((t) => !groupIds.has(t.id));
+  const targetIdxInOthers = others.findIndex((t) => t.id === toId);
+  // toId はグループ外なので others に必ず存在する。
+  const next = [
+    ...others.slice(0, targetIdxInOthers),
+    ...groupMembers,
+    ...others.slice(targetIdxInOthers),
+  ];
+  return next.map((t, i) => ({ ...t, stackOrder: i }));
+}
+
+/**
+ * ADR-0040: 新規タスクを「現在の Top タスクの 1 つ下」(= visible 上から 2 番目)
+ * に挿入し、`stackOrder` を 0..n で振り直す。
+ *
+ * - visible が空 (= Top 無し) のときは head に挿入する
+ * - decomposed 親は visible からスキップされるので、visible Top の `pending` 内
+ *   index を求めてその直後に挿入する
+ *
+ * 「Top に置く」のではなく Top の直下に置くのは、作業中タスク (Top) を
+ * 押し下げないため (ADR-0040)。
+ */
+export function insertAtTopPlusOne(
+  pending: readonly Task[],
+  allTasks: readonly Task[],
+  task: Task,
+): Task[] {
+  const { items } = buildStackItems(pending, allTasks);
+  const topVisible = items[0]?.task;
+  const topIdx = topVisible ? pending.findIndex((t) => t.id === topVisible.id) : -1;
+  const insertIdx = topIdx >= 0 ? topIdx + 1 : 0;
+  const next = [...pending.slice(0, insertIdx), task, ...pending.slice(insertIdx)];
   return next.map((t, i) => ({ ...t, stackOrder: i }));
 }

--- a/src/features/task-stack/useStackDnD.ts
+++ b/src/features/task-stack/useStackDnD.ts
@@ -7,20 +7,33 @@ import {
 } from "react";
 import { findDropTarget } from "./findDropTarget";
 
+/**
+ * Drag mode (ADR-0041):
+ * - `single`: 行カードの Grip 起点。1 行だけ動かす (従来挙動)
+ * - `group`:  行カードの 親バッジ (`⤷ 親名`) 起点。同じ `parent_task_id` を持つ
+ *             全行をグループとしてまとめて動かす
+ */
+export type DragMode = "single" | "group";
+
 export type UseStackDnDResult = {
   dragIdx: number | null;
   overIdx: number | null;
+  dragMode: DragMode | null;
   /** 行要素 (li or div) の ref。getBoundingClientRect しか使わないので HTMLElement で十分。 */
   rowRefs: MutableRefObject<(HTMLElement | null)[]>;
-  handlePointerDown: (idx: number, e: ReactPointerEvent<HTMLElement>) => void;
+  handlePointerDown: (idx: number, e: ReactPointerEvent<HTMLElement>, mode?: DragMode) => void;
 };
 
-export function useStackDnD(onReorder: (from: number, to: number) => void): UseStackDnDResult {
+export function useStackDnD(
+  onReorder: (from: number, to: number, mode: DragMode) => void,
+): UseStackDnDResult {
   const [dragIdx, setDragIdx] = useState<number | null>(null);
   const [overIdx, setOverIdx] = useState<number | null>(null);
+  const [dragMode, setDragMode] = useState<DragMode | null>(null);
   const rowRefs = useRef<(HTMLElement | null)[]>([]);
   const dragIdxRef = useRef<number | null>(null);
   const overIdxRef = useRef<number | null>(null);
+  const dragModeRef = useRef<DragMode | null>(null);
   const startY = useRef(0);
   const isDragging = useRef(false);
 
@@ -30,14 +43,16 @@ export function useStackDnD(onReorder: (from: number, to: number) => void): UseS
   }, []);
 
   const handlePointerDown = useCallback(
-    (idx: number, e: ReactPointerEvent<HTMLElement>) => {
+    (idx: number, e: ReactPointerEvent<HTMLElement>, mode: DragMode = "single") => {
       e.preventDefault();
       startY.current = e.clientY;
       isDragging.current = false;
       dragIdxRef.current = idx;
       overIdxRef.current = null;
+      dragModeRef.current = mode;
       setDragIdx(idx);
       setOverIdx(null);
+      setDragMode(mode);
 
       const onMove = (ev: PointerEvent) => {
         ev.preventDefault();
@@ -52,12 +67,17 @@ export function useStackDnD(onReorder: (from: number, to: number) => void): UseS
       const onUp = () => {
         const from = dragIdxRef.current;
         const to = overIdxRef.current;
-        if (isDragging.current && from !== null && to !== null && from !== to) onReorder(from, to);
+        const m = dragModeRef.current ?? "single";
+        if (isDragging.current && from !== null && to !== null && from !== to) {
+          onReorder(from, to, m);
+        }
         dragIdxRef.current = null;
         overIdxRef.current = null;
+        dragModeRef.current = null;
         isDragging.current = false;
         setDragIdx(null);
         setOverIdx(null);
+        setDragMode(null);
         window.removeEventListener("pointermove", onMove);
         window.removeEventListener("pointerup", onUp);
         window.removeEventListener("pointercancel", onUp);
@@ -69,5 +89,5 @@ export function useStackDnD(onReorder: (from: number, to: number) => void): UseS
     [computeTarget, onReorder],
   );
 
-  return { dragIdx, overIdx, rowRefs, handlePointerDown };
+  return { dragIdx, overIdx, dragMode, rowRefs, handlePointerDown };
 }


### PR DESCRIPTION
## 概要 (What)

- 新規タスクは Top の 1 つ下 (visible 上から 2 番目) に挿入されるようにした (ADR-0040)
- 行カードの親バッジを起点に、同じ親を持つ全行をグループとしてまとめてドラッグ移動できるようにした (ADR-0041)
- グループ移動を action_log で再構成できるよう `task_reordered.metadata.group_parent_id` を追加 (オプション、新 type 不要)

## 関連 Issue

Closes #172

## 背景 (Why)

[ADR-0036](../blob/main/docs/adr/0036-simplify-task-registration-workflow.md) のシンプル世界観 (登録 → 上から順にやる) を実体験として成立させるための 2 つの判断:

- 新規タスクの差し込み位置が約束されていないと「直近で登録 → すぐ着手」が default にならず、新規が末尾に埋もれる ([ADR-0040](../blob/main/docs/adr/0040-new-task-insert-position-top.md))
- Top 直下挿入は親共有グループを分断する。分断後に 1 件ずつ手作業で並べ替えるのは負担が大きい ([ADR-0041](../blob/main/docs/adr/0041-parent-shared-grouping-reorder.md))

## Before → After (概念・フロー・メンタルモデル)

**Before:**

- 新規タスクは Stack 末尾に追加 (`pendingTasks.length` を caller が渡す)
- 並べ替えは行カードの Grip 起点で 1 行ずつのみ
- AI 分解後の子グループが新規挿入で分断されると、復旧手段は個別ドラッグの繰り返し

**After:**

- 新規タスクは visible Top の 1 つ下に挿入される (caller は stackOrder を渡さない、内部で Top+1 を算出)
- Grip 起点 = 単独ドラッグ / 親バッジ起点 = グループドラッグ で並立
- グループ操作で分断中の親共有グループを 1 操作で再収束できる (`parent_task_id` の equivalence class 全体が動く)

action_log: `task_reordered.metadata.group_parent_id?: string` をオプションで追加。グループ移動は要素ごとに 1 件発火し、全件で同じ `group_parent_id` を共有する。Phase 4 では同一 `created_at` 近辺の同 `group_parent_id` ログ群を 1 グループ移動として再構成する。

## 追加したテスト (How verified)

- [x] unit: `reorderTasks.test.ts` に `reorderGroupById` (基本 / 分断中 / グループ内ドロップ no-op / 不変性) と `insertAtTopPlusOne` (基本 / 空 / decomposed 親が先頭 / 不変性) を追加
- [x] unit: `TaskStack.test.tsx` の既存テストを `onReorderGroup` prop 追加で通す
- [x] e2e (`e2e/task-group-reorder.spec.ts` 新規):
  - ADR-0040: 既存 3 件 + 新規 1 件で「Top は維持、N が 2 番目」を踏む
  - ADR-0041: 分断状態 (`c1, N, c2, s`) を seed → 親バッジドラッグで `[N, c1, c2, s]` に再収束 → action_log の `group_parent_id` を確認
  - ADR-0041: グループ内の Grip ドラッグは従来通り 1 行だけ動き、`group_parent_id` は付かないことを踏む
- [x] `npm run check` (format + lint + typecheck + 553 unit tests) green
- [ ] ブラウザでの実機確認は未実施。preview deploy で golden path / グループドラッグの操作感を踏むのが望ましい

## リリース前チェックリスト (When / Before merge)

- [x] マイグレーション無し (action_log payload は JSONB なので既存 schema で OK)
- [x] 環境変数 / シークレット追加無し
- [x] 破壊的変更無し (`createTaskWithAi` の `stackOrder` 引数を削除したが内部 API。caller は `AppShell` の 1 箇所のみで同 PR で更新済み)

## このPRの範囲外 (Out of scope)

- **reorder の atomic 化** — 既存 `Promise.all` 並列 update は partial failure で DB が中途半端に残るリスクがあるが、既存個別 reorder にも同じ問題があり本 PR で再生産しているわけではない。根治は別 issue に切り出した:
  - #184 (migration: `reorder_tasks_atomic` RPC 追加、本番 DB 適用までを含む)
  - #185 (implementation: gateway / mutation を RPC 経由に切り替え、#184 完了後)
- **Top カードの親バッジを group drag 起点にする** — ADR-0040 で守ろうとしている「Top は今やっているもので固定」を尊重し、行カードの親バッジのみ group drag 対応とした。Top カードに対するグループ操作が必要な場合は、Top に別タスクを置いてから親バッジで動かす導線を取る
- **「グループ移動」専用 action_log type の追加** — `task_reordered.group_parent_id` で Phase 4 の再構成は十分。新 type 化は ADR-0035 の supersede or 追加 ADR を要するため、本 PR では metadata 拡張に留めた (ADR-0001 の JSONB 揺らぎ吸収原則の範囲内)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DoYXqpwmjAzw1Rs2Fcenae)_