### PR TITLE
refactor(ai/decompose): race guard を条件付き UPDATE に統一 (ADR-0042)

### DIFF
--- a/docs/adr/0042-ai-race-guard-via-conditional-update.md
+++ b/docs/adr/0042-ai-race-guard-via-conditional-update.md
@@ -1,0 +1,75 @@
+# ADR 0042: AI 機能の race guard は条件付き UPDATE で claim する
+
+- **Status**: Accepted
+- **Date**: 2026-05-04
+- **Related**: Issue #157 / [ADR-0017](./0017-ai-task-decomposition-async.md) / [ADR-0021](./0021-ai-decomposition-failure-visibility.md) / [ADR-0027](./0027-child-resplit-flatten.md)
+
+## Context
+
+AI 機能 (decompose / resplit / categorize) は fire-and-forget の Route Handler から起動される ([ADR-0017](./0017-ai-task-decomposition-async.md))。同じタスクに対する 2 重 click や client 側 optimistic ズレで重複起動が発生し、race を踏むと:
+
+- `decompose_status` が `decomposing` で固まる ([ADR-0021](./0021-ai-decomposition-failure-visibility.md) §1 不変条件の violation)
+- 1 本目成功後の 2 本目が `target_not_found` 経由で spurious な `task_decompose_failed` を action_log に積む ([ADR-0021](./0021-ai-decomposition-failure-visibility.md) HC-4 学習素材の品質劣化)
+- 人間 override が AI 応答到着で上書きされる (categorize)
+
+現状、3 つの AI server で guard 戦略が非対称:
+
+| server | pattern |
+|---|---|
+| `decompose-server.ts:48-66` | read → guard 判定 → `setDecomposeStatus("decomposing")` の **2 step。間に TOCTOU race window** |
+| `resplit-server.ts:87,239-255` (`tryClaimDecomposing`) | `.update().eq().neq()` の **条件付き UPDATE で 1 step claim** |
+| `categorize-server.ts:74-93` | `.update().eq().is("task_category", null)` の **条件付き UPDATE で 1 step claim** |
+
+新規 AI 機能を追加するとき、どちらを踏襲すべきかコードから読み取れず、選定意図も明文化されていない。
+
+## Decision
+
+AI 機能の race guard は **条件付き UPDATE で対象列を atomic に claim する** pattern に統一する。新規 AI 機能はこの pattern を踏襲する。
+
+具体には:
+
+- 「AI が排他的に書き込む列」を 1 つ決め、その列の「未着手を表す値」を `WHERE` 条件に入れた `UPDATE ... RETURNING` を投げる
+- 0 行更新 = 既に他 actor (concurrent run / 人間 override) が確定済 → orchestrator は skipped に倒す
+- 1 行更新 = 自分が claim 成功 → 以降の AI 呼び出しに進む
+
+既存 `decompose-server.ts` も同 pattern に揃える (issue #157 の実装フェーズで対応)。
+
+共通 helper は **作らない**。guard 列と未着手判定の述語が機能ごとに異なる (`decompose_status != 'decomposing'` / `task_category IS NULL` / 将来追加される列) ため、generic 化すると call site の意図が薄れる。pattern (規約) を共有するだけで十分。
+
+## Consequences
+
+### 肯定的影響
+
+- 新規 AI 機能追加時に「どちらを踏襲すべきか」の迷いが消える
+- decompose の TOCTOU race window が消え、[ADR-0021](./0021-ai-decomposition-failure-visibility.md) §1 の不変条件が DB レベルで保証される
+- spurious `task_decompose_failed` log が減り、Phase 4 学習素材の品質が向上する
+- 各 server に置かれる `tryClaim*` 関数が同じ命名・形になり、コードレビューで「これは race guard」と一目で識別できる
+
+### 否定的影響・トレードオフ
+
+- 既存 `decompose-server.ts` を揃える migration PR が 1 本必要 (issue #157)
+- 各 server に `tryClaim*` の薄い実装が重複する (共通 helper を作らない判断のコスト)
+- 条件付き UPDATE が 0 行更新を返すケースを必ず分岐扱いする必要がある (write-time error か concurrent claim かを区別する)。これは既に resplit / categorize で実装パターンが確立しているので追従するだけ
+
+## Alternatives considered
+
+- **案A**: 共通 helper `guardAiClaim(column, predicate, target)` を作る
+  - 不採用: guard 列・未着手述語・成功時の値が機能ごとに異なり、generic signature が複雑化する。call site で「この helper が何を排他しているか」が読み取りにくくなる。pattern (規約) として共有するだけで code 重複は最小 (各 `tryClaim*` は数行)
+- **案B**: 現状維持 (decompose は 2 step、新規は実装者判断)
+  - 不採用: [ADR-0021](./0021-ai-decomposition-failure-visibility.md) §1 不変条件を破る race window が残る。新規実装者が判断ミスで 2 step を選ぶと race window が増える
+- **案C**: 新規 AI 機能だけ resplit pattern を踏襲、decompose は触らない
+  - 不採用: 一貫性が崩れたままで「なぜ decompose だけ違うか」が読み取れない。新規実装者は古い decompose を見て真似する可能性が高い (近場のコードを参照しがち)
+- **案D**: Supabase RPC (Postgres function) に concurrency control を寄せる
+  - 不採用: 現在の `fn_decompose_parent_task` / `fn_resplit_child_task` は claim 後の atomic な write 部分を担っており、claim 自体は orchestrator (TS 側) で行う方が「AI 呼び出し前後」の制御フローが追いやすい。RPC 化が必要になるのは別 trigger (例: ストリーム化 / queue 経由) で、その時に supersede すればよい
+
+## Notes
+
+- 既存 `decompose-server.ts` を揃える実装は issue #157 で行う。2 step を 1 step に変える際、`SKIP_STATUSES` (`status` 列) と `ALREADY_RESOLVED` (`decompose_status` 列) は別概念なので、status は read 時 check + decompose_status は条件付き UPDATE、という形にする
+- supersede trigger:
+  - 別の concurrency control (Postgres advisory lock / SELECT FOR UPDATE / message queue で single-writer 保証) に倒す方針に変えた時
+  - DB を Postgres から別物に変えた時
+  - AI orchestrator を Route Handler から別基盤 (queue worker 等) に移し、claim 自体を queue 側で行う時
+- 関連 code:
+  - `src/entities/task/decompose-server.ts:48-69` (旧 pattern, 揃える対象)
+  - `src/entities/task/resplit-server.ts:87,239-255` (`tryClaimDecomposing`)
+  - `src/entities/task/categorize-server.ts:74-93` (条件付き UPDATE on `task_category IS NULL`)

--- a/src/entities/task/decompose-server.test.ts
+++ b/src/entities/task/decompose-server.test.ts
@@ -18,6 +18,12 @@ type Plan = {
   rpc: { data: string[] | null; error: { message: string } | null };
   insertActionLogs: { error: { message: string } | null };
   rpcThrow?: unknown; // rpc が throw する想定 (last-resort safety net テスト用)
+  /**
+   * ADR 0042 / Issue #157: tryClaimDecomposing で「既に decomposing / decomposed / skipped に
+   * 確定済」を疑似する。true のとき claim 経路の maybeSingle が { data: null } を返し、
+   * orchestrator は skipped/already_resolved に倒す (race window が閉じていることのテスト)。
+   */
+  claimReturnsExisting?: boolean;
 };
 
 function makeSupabase(plan: Plan): {
@@ -59,11 +65,31 @@ function makeSupabase(plan: Plan): {
           })),
         })),
       })),
-      // setDecomposeStatus: update({...}).eq("id", taskId) — eq is awaited (PostgrestFilterBuilder is thenable)
+      // 2 系統の chain を同じ shape で返す (resplit-server.test.ts と同形):
+      //   (a) `.update().eq()` を await: setDecomposeStatus (failed / skipped) 用、{ error } を解決
+      //   (b) `.update().eq().in().select().maybeSingle()`: tryClaimDecomposing (ADR 0042) 用、
+      //       claim 成功で { data: { id }, error: null }、race 敗北で plan.claimReturnsExisting = true
+      //       のとき { data: null }
       update: (patch: { decompose_status?: unknown }) => ({
         eq: (_col: string, val: unknown) => {
           calls.statusUpdates.push({ id: val, decompose_status: patch.decompose_status });
-          return Promise.resolve({ error: plan.update.error });
+          const promise = Promise.resolve({ error: plan.update.error });
+          return Object.assign(promise, {
+            in: () => ({
+              select: () => ({
+                maybeSingle: () =>
+                  Promise.resolve({
+                    data:
+                      plan.claimReturnsExisting === true
+                        ? null
+                        : plan.update.error
+                          ? null
+                          : { id: val },
+                    error: plan.update.error,
+                  }),
+              }),
+            }),
+          });
         },
       }),
     };
@@ -257,6 +283,26 @@ describe("decomposeTask", () => {
 
     expect(result).toEqual({ kind: "skipped", reason: "already_resolved" });
     expect(generate).not.toHaveBeenCalled();
+  });
+
+  // ADR 0042 / Issue #157: fetchParent → setDecomposeStatus(decomposing) の旧 2 step に
+  // あった TOCTOU race window を、tryClaimDecomposing の条件付き UPDATE で閉じた。
+  // 並行 click や fire-and-forget の重複起動でも、後勝ちの 1 本だけが進み、もう 1 本は
+  // skipped/already_resolved で潰れることをテストする。
+  test("並行起動: claim が race で負けたら skipped/already_resolved (ADR 0042)", async () => {
+    const plan = defaultPlan(makeParentRow());
+    plan.claimReturnsExisting = true;
+    const { client, calls } = makeSupabase(plan);
+    const generate = vi.fn();
+
+    const result = await decomposeTask(makeDeps({ client, generate }));
+
+    expect(result).toEqual({ kind: "skipped", reason: "already_resolved" });
+    expect(generate).not.toHaveBeenCalled();
+    expect(calls.rpcCalls).toHaveLength(0);
+    expect(calls.actionLogs).toHaveLength(0);
+    // claim attempt 自体は statusUpdates に記録されるが (mock 構造上)、それ以降の追加 update は無い
+    expect(calls.statusUpdates).toEqual([{ id: "parent-1", decompose_status: "decomposing" }]);
   });
 
   test("既に failed → 詳細パネル「再実行」で再分解できる (ADR 0021 §1: failed → decomposing を許容)", async () => {

--- a/src/entities/task/decompose-server.ts
+++ b/src/entities/task/decompose-server.ts
@@ -10,13 +10,15 @@ import {
 import type { Database, Json, Tables } from "@/shared/types/database";
 
 /**
- * AI タスク分解 (P3-6 / ADR 0017 / 0018 / 0016 / 0021) の server 側 orchestrator。
+ * AI タスク分解 (P3-6 / ADR 0017 / 0018 / 0016 / 0021 / 0042) の server 側 orchestrator。
  *
  * 流れ:
  * 1. 親タスクを userId スコープで取得 (RLS 前提だが defense in depth)。見つからなければ no-op
- * 2. race condition guard: 親が active/paused/done か、既に decomposed/skipped/failed なら no-op
+ * 2. read 時 fast-exit: 親が active/paused/done か、既に decomposed/skipped なら no-op
  *    (ADR 0017 Notes: 親 active 化済みは分解対象から外す。冪等性のため重複時もスキップ)
- * 3. 親の decompose_status を `decomposing` に倒す
+ * 3. ADR 0042 の race guard: `tryClaimDecomposing` の条件付き UPDATE で `decompose_status`
+ *    を `none|failed → decomposing` に atomic 遷移。0 行更新なら他 fire に負けた / 直前に
+ *    decomposed/skipped に確定したケースなので `already_resolved` で skipped に倒す。
  * 4. ここから先は ADR 0021 の不変条件: 「`decomposing` で固まらない」。
  *    すべての失敗経路で parent を必ず終端 status (`failed` / `skipped` / `decomposed`) に倒し、
  *    試行結果を `action_logs` に記録する。
@@ -49,6 +51,9 @@ const SKIP_STATUSES = new Set(["active", "paused", "done"]);
 // 終端のうち「再分解しない」ものだけ。`failed` は ADR 0021 §1 で `failed → decomposing` を
 // 明示的に許容しているので含めない（詳細パネルの「再実行」ボタンが直接ここを通る）。
 const ALREADY_RESOLVED = new Set(["decomposed", "skipped"]);
+// claim の allowlist: ここに含まれる pre-state からのみ `decomposing` への遷移を許容する。
+// `decomposed` / `skipped` は冪等のため再分解しない。`decomposing` は他 fire の進行中。
+const CLAIMABLE_PRE_STATES = ["none", "failed"] as const;
 
 export async function decomposeTask(deps: DecomposeTaskDeps): Promise<DecomposeTaskOutcome> {
   const { supabase, userId, taskId, generate } = deps;
@@ -65,8 +70,14 @@ export async function decomposeTask(deps: DecomposeTaskDeps): Promise<DecomposeT
     return { kind: "skipped", reason: "already_resolved" };
   }
 
-  // 重複 fire-and-forget や client 側 optimistic ズレに耐えるよう、ここで decomposing に確定させる。
-  await setDecomposeStatus(supabase, parent.id, "decomposing");
+  // ADR 0042: 条件付き UPDATE で `decomposing` を atomic に claim する。fetchParent との間に
+  // concurrent fire が `decomposing` に倒したり decomposed/skipped で確定した場合、claim は
+  // 0 行更新で失敗 → skipped/already_resolved に倒し、AI 呼び出しを起こさない。これにより
+  // ADR 0021 §1 の不変条件 (decomposing で固まらない) を DB レベルで保証する。
+  const claimed = await tryClaimDecomposing(supabase, parent.id);
+  if (!claimed) {
+    return { kind: "skipped", reason: "already_resolved" };
+  }
 
   try {
     return await runDecompose(supabase, userId, parent, generate);
@@ -234,6 +245,39 @@ async function fetchParent(
     return null;
   }
   return (data as ParentRow | null) ?? null;
+}
+
+/**
+ * ADR 0042: `decompose_status` を `none|failed → decomposing` に atomic 遷移させる。
+ *
+ * `.in("decompose_status", CLAIMABLE_PRE_STATES)` で pre-state を allowlist 制約することで:
+ * - 並行 fire との TOCTOU race window を閉じる (後勝ち 1 本だけが claim 成功)
+ * - fetchParent 後に decomposed/skipped に確定したケースも 0 行更新で吸収
+ *
+ * 0 行更新 (data === null) → claim 失敗 → orchestrator は skipped/already_resolved に倒す。
+ * supabase error は safe-side に倒して `false` を返す (ADR 0013 augmentation only)。
+ *
+ * resplit-server.ts の `tryClaimDecomposing` (ADR 0027) と同じ pattern を共有するが、
+ * 当該 server は `.neq("decomposing")` で「進行中以外なら claim」を許す (resplit はユーザー
+ * 明示クリック起動なので decomposed/skipped/failed → 再分解を許容)。decompose は auto 起動
+ * のため `none|failed` だけに絞る点が異なる (ADR 0042: guard 述語は機能ごとに別)。
+ */
+async function tryClaimDecomposing(
+  supabase: SupabaseClient<Database>,
+  taskId: string,
+): Promise<boolean> {
+  const { data, error } = await supabase
+    .from("tasks")
+    .update({ decompose_status: "decomposing" })
+    .eq("id", taskId)
+    .in("decompose_status", [...CLAIMABLE_PRE_STATES])
+    .select("id")
+    .maybeSingle();
+  if (error) {
+    console.error("[ai/decompose] claim decomposing failed", error);
+    return false;
+  }
+  return data !== null;
 }
 
 /**


### PR DESCRIPTION
## 概要 (What)

AI 機能 (decompose / resplit / categorize) の race guard pattern を「対象列を atomic に claim する条件付き UPDATE」に統一する。

- ADR-0042 で規約を確定
- 既存 `decompose-server.ts` を `tryClaimDecomposing` の条件付き UPDATE pattern に揃え、TOCTOU race window を閉じる

## 関連 Issue

Closes #157

## 背景 (Why)

現状、AI 機能 server で race guard 戦略が非対称:

| server | pattern |
|---|---|
| `decompose-server.ts` (旧) | read → guard 判定 → 無条件 update の 2 step。間に TOCTOU race window |
| `resplit-server.ts` (`tryClaimDecomposing`) | 条件付き UPDATE で 1 step claim |
| `categorize-server.ts` | 条件付き UPDATE (`task_category IS NULL`) で 1 step claim |

新規 AI 機能を追加するとき、どちらを踏襲すべきか規約が無く、近場の旧 decompose を真似すると race window が増えるリスクがあった。decompose の race window は ADR-0021 §1 不変条件 (`decomposing で固まらない`) を破る経路でもある。

## Before → After (概念・フロー・メンタルモデル)

**Before:**

- AI 機能ごとに race guard pattern が独立判断。新規追加時の指針なし
- decompose は 2 step pattern で TOCTOU race window が残る → 並行 fire で `decomposing` で固まる / spurious `task_decompose_failed` を action_log に積む経路があった

**After:**

- AI 機能の race guard は「対象列を atomic に claim する条件付き UPDATE」が標準規約 (ADR-0042)
- 共通 helper は作らない。guard 列・許容 pre-state が機能ごとに違うため、pattern (規約) を共有するだけで十分
  - decompose: `.in("decompose_status", ["none", "failed"])` (auto 起動なので決着済を再分解しない)
  - resplit: `.neq("decompose_status", "decomposing")` (ユーザー明示クリックなので決着済も再分解 OK)
  - categorize: `.is("task_category", null)` (人間 override を上書きしない)
- decompose も同 pattern に揃え、claim 失敗 (race 敗北 / 直前確定) は `skipped/already_resolved` で吸収

## 追加したテスト (How verified)

- [x] `並行起動: claim が race で負けたら skipped/already_resolved (ADR 0042)` を追加。`claimReturnsExisting` mock 経路で claim 0 行更新を疑似し、generate / rpc が呼ばれず action_log にも積まれないことを検証
- [x] 既存 28 テスト (race / failure / category / size 等) は変更なしで pass
- [x] `npx vitest run src/entities/task/` 全 119 test pass (decompose / resplit / categorize / supabase-gateway)
- [x] `npx tsc --noEmit` クリーン
- [x] `npx eslint` クリーン

## このPRの範囲外 (Out of scope)

- 共通 helper 化 → ADR-0042 で「作らない」と判断済 (各 server の `tryClaim*` は数行の薄い実装で重複コストが低い)
- `SkipReason` vocab 拡張 (`already_decomposing` を追加するか) → race 敗北 / 既決着の区別は orchestrator にとって等価 (どちらも skip without firing) なので `already_resolved` に集約