### PR TITLE
fix(e2e): drop 座標を upper-quarter に変更し reorder 系の flake を解消 (Closes #191)

### DIFF
--- a/e2e/golden-path.spec.ts
+++ b/e2e/golden-path.spec.ts
@@ -53,9 +53,11 @@ test("Phase 1 golden path", async ({ signedInPage: page }) => {
 
   const startX = gripBBox.x + gripBBox.width / 2;
   const startY = gripBBox.y + gripBBox.height / 2;
-  // rowA の上端より上にドロップ → findDropTarget が i=0 を返し B が top に挿入される。
+  // rowA の upper-quarter にドロップ → findDropTarget が i=0 を返し B が top に挿入される。
+  // 上端固定 offset (+4 等) は row 高さの微変動で upper half を踏み外す flake の元
+  // (#191 を参照)。height に比例した余裕を取る。
   const endX = startX;
-  const endY = rowABox.y + 4;
+  const endY = rowABox.y + Math.floor(rowABox.height / 4);
 
   await page.mouse.move(startX, startY);
   await page.mouse.down();

--- a/e2e/task-group-reorder.spec.ts
+++ b/e2e/task-group-reorder.spec.ts
@@ -248,10 +248,14 @@ async function pollVisibleOrder(
 /**
  * 親バッジ (`role=button`, `aria-label="親グループ並び替え: <親名>"`) を起点にした
  * グループドラッグ。`sourceTitle` の行に乗っている親バッジを掴んで、
- * `targetTitle` の上端より少し下に落とす (= target の midline より上)。
+ * `targetTitle` の upper-quarter に落とす (= target の midline より上)。
  *
  * バッジは text-[9px] の小さな要素のため、boundingBox 取得前に visible / scroll
  * を明示的に待つ (CI 環境でレイアウト確定前に measure すると drag 不発になる)。
+ *
+ * drop 座標は target row の upper-quarter (top + height/4)。+4 等の上端固定 offset は
+ * row 高さの微変動 (TopTaskCard の async load / DropIndicator 挿入等) で upper half を
+ * 踏み外す flake の元になるため、height に比例した余裕を取る。
  */
 async function dragGroupAboveRow(
   page: Page,
@@ -273,7 +277,7 @@ async function dragGroupAboveRow(
   const startX = badgeBox.x + badgeBox.width / 2;
   const startY = badgeBox.y + badgeBox.height / 2;
   const endX = startX;
-  const endY = targetBox.y + 4;
+  const endY = targetBox.y + Math.floor(targetBox.height / 4);
 
   await page.mouse.move(startX, startY);
   await page.mouse.down();
@@ -304,7 +308,8 @@ async function dragRowAboveRowByGrip(
   const startX = gripBox.x + gripBox.width / 2;
   const startY = gripBox.y + gripBox.height / 2;
   const endX = startX;
-  const endY = targetBox.y + 4;
+  // target の upper-quarter を狙う (上端固定 offset は row 高さの微変動で flake るため)。
+  const endY = targetBox.y + Math.floor(targetBox.height / 4);
 
   await page.mouse.move(startX, startY);
   await page.mouse.down();

--- a/e2e/task-reorder.spec.ts
+++ b/e2e/task-reorder.spec.ts
@@ -42,7 +42,7 @@ test.describe("DnD 並び替え (task_reordered + tasks.stack_order)", () => {
 
     // task_reordered ログが、つかんだ task の id + 該当 from/to で 1 件以上残る。
     // findDropTarget は「半分より上」で from を返す挙動なので to_position=0。
-    // (task A の box top + 4 を狙うので、midpoint より上 → 0 が選ばれる)
+    // (dragRowAboveRow は upper-quarter を狙うので、midpoint より上 → 0 が選ばれる)
     const movedC = await getTaskByTitle(admin, userId, titles[2]);
     const reorderLog = await waitForActionLog(
       admin,
@@ -139,6 +139,13 @@ async function getProjectId(
  * `sourceTitle` の grip を掴んで `targetTitle` の上端より少し下にドロップする。
  * useStackDnD は HTML5 DnD ではなく custom pointer events なので mouse API で
  * pointermove を複数回 emit する必要がある (5px 以上動かさないと drag 判定が立たない)。
+ *
+ * drop 座標は target row の upper-quarter (top + height/4) を狙う:
+ *   - findDropTarget は `clientY < rect.top + rect.height/2` で idx を返す
+ *   - 上端固定 + 数 px の oFFset (ex. +4) は、TopTaskCard の async load (projects /
+ *     correction factors / now 経過時間 badge) や DropIndicator (h-0.5) 挿入で
+ *     row 高さが微変動した際に upper half を踏み外して隣 idx に落ちる flake を生む
+ *   - height/4 なら row 高さが伸縮しても midpoint の半分の余裕で upper half に残る
  */
 async function dragRowAboveRow(
   page: Page,
@@ -158,7 +165,7 @@ async function dragRowAboveRow(
   const startY = gripBox.y + gripBox.height / 2;
   // target の midline より上に落とす → findDropTarget が target idx を返す。
   const endX = startX;
-  const endY = targetBox.y + 4;
+  const endY = targetBox.y + Math.floor(targetBox.height / 4);
 
   await page.mouse.move(startX, startY);
   await page.mouse.down();


### PR DESCRIPTION
## 概要 (What)

DnD e2e (`task-reorder` / `task-group-reorder` / `golden-path`) で起きていた「target row の上端 +4px に drop しても `to_position` が想定と一致しない」flake を解消する。drop 座標を `top + height/4` に変更し、row 高さの微変動をピクセル余裕で吸収させる。

## 関連 Issue

Closes #191

## 背景 (Why)

`findDropTarget` は `clientY < rect.top + height/2` で row idx を返す。e2e ヘルパは target の `top + 4` に drop するので、数学的には upper half に入る。しかし CI では `TopTaskCard` の async load (projects / correction factors / now の経過時間 badge) や `DropIndicator` (h-0.5) 挿入で row 高さが数 px 揺れた瞬間に upper half を踏み外し、隣 row の midpoint 側へ落ちて `to_position` が +1 ズレる。

retry で通る低頻度 flake だが、頻度が増えると「本物の regression を flake として見逃す」リスクが出るので恒久対応する。

## Before → After (概念・フロー・メンタルモデル)

**Before:** drop 座標は target row の絶対 offset (`top + 4`)。row 高さの揺らぎ吸収は 4px だけ。row 高さが ±数 px 揺れた瞬間に midpoint 判定の境界を超える。

**After:** drop 座標は target row の相対位置 (`top + height/4`, upper-quarter)。midpoint まで `height/4` の余裕があるので row 高さが伸縮しても upper half に確実に残る。ピクセル絶対値ではなく row 内の比率で「上半分のだいぶ上の方」を狙う設計に倒した。

## 追加したテスト (How verified)

新しい assertion は追加していない。既存の `task-reorder.spec.ts` / `task-group-reorder.spec.ts` / `golden-path.spec.ts` が同じ意図で safer 座標を踏むだけなので、green を保つことが「同じシナリオが flake せず通る」ことの確認になる。

- [x] `npm run typecheck` / `lint` / `format:check` / `test` (vitest 581 件) green
- [ ] preview deploy / CI で `task-reorder.spec.ts:20` と `task-group-reorder.spec.ts:128` が複数回 green であることを確認

## このPRの範囲外 (Out of scope)

- e2e flake のもう 1 つの根本原因候補だった「`now` 駆動の row 再レンダリングによる layout 揺らぎ」自体の抑止 (今回は drop 座標の余裕で吸収する方向で十分と判断)
- 個別 / グループ reorder の atomic RPC 化 (#184 / #185 で別途扱う)