### PR TITLE
feat(task-detail): project 編集 + cascade 伝播 (Closes #171)

### DIFF
--- a/e2e/task-project-edit.spec.ts
+++ b/e2e/task-project-edit.spec.ts
@@ -122,7 +122,11 @@ test.describe("project 編集 + 親-子-兄弟への伝播 (Issue #171 / ADR-003
     await page.reload();
 
     const stack = page.getByRole("list", { name: "タスクスタック" });
-    const parentRow = stack.getByRole("listitem").filter({ hasText: "親 cascade テスト" });
+    // 親行は子の親バッジ (`⤷ 親 cascade テスト`) と本文がマッチして strict mode 違反するので、
+    // 子バッジ持ちを `hasNotText: "⤷"` で除外して親自身の listitem だけに絞る。
+    const parentRow = stack
+      .getByRole("listitem")
+      .filter({ hasText: "親 cascade テスト", hasNotText: "⤷" });
     await expect(parentRow).toBeVisible();
     await parentRow.getByText("親 cascade テスト").first().click();
 
@@ -283,7 +287,10 @@ test.describe("project 編集 + 親-子-兄弟への伝播 (Issue #171 / ADR-003
     await page.reload();
 
     const stack = page.getByRole("list", { name: "タスクスタック" });
-    const parentRow = stack.getByRole("listitem").filter({ hasText: "親 (cancel)" });
+    // 親行は子の親バッジと衝突するので `hasNotText: "⤷"` で子バッジ持ちを除外する。
+    const parentRow = stack
+      .getByRole("listitem")
+      .filter({ hasText: "親 (cancel)", hasNotText: "⤷" });
     await parentRow.getByText("親 (cancel)").first().click();
 
     await page.getByRole("button", { name: new RegExp(`${projectName}\\s+を変更`) }).click();

--- a/e2e/task-project-edit.spec.ts
+++ b/e2e/task-project-edit.spec.ts
@@ -1,0 +1,349 @@
+import { createAdminClient, getTaskByTitle, seedTask, waitForActionLog } from "./db";
+import { expect, test } from "./fixtures";
+
+/**
+ * Issue #171 / ADR-0039:
+ *   タスク詳細パネルからの project 変更と、親→子 / 子→兄弟+親 への伝播。
+ *
+ * 単独タスクは確認 dialog なしで即変更、親 (子あり) と子 (兄弟+親あり) は
+ * 影響件数を見せる確認 dialog 経由で変更する (UI は #171 で確定)。
+ *
+ * 不変条件:
+ * - DB: 影響範囲全行の `tasks.project_id` が新値に揃う
+ * - action_log: `task_project_changed` が **1 ログ** 発火し、`propagation` と
+ *   `affected_task_ids` payload で「1 操作 → N 行更新」を再構成可能 (ADR-0035 / -0039)
+ * - 親と子で project_id が乖離する状態は作られない (ADR-0039 不変条件)
+ */
+
+test.describe("project 編集 + 親-子-兄弟への伝播 (Issue #171 / ADR-0039)", () => {
+  test("単独タスク: dialog なしで project が即更新され、propagation=single の log が残る", async ({
+    signedInPageWithProject: page,
+    projectName,
+    testUserId: userId,
+  }) => {
+    const admin = createAdminClient();
+
+    // signedInPageWithProject が UI で作った project1 を引き当て、admin で project2 を別途作る。
+    const project1 = await fetchProjectId(admin, userId, projectName);
+    const project2 = await seedAdminProject(admin, userId, "別 project (単独)");
+
+    // 単独タスク (parent も子もなし) を seed。decompose_status='none' で Stack に出る。
+    const seededLone = await seedTask(admin, {
+      userId,
+      projectId: project1,
+      title: "単独タスク P",
+      stackOrder: 0,
+    });
+
+    await page.reload();
+
+    const stack = page.getByRole("list", { name: "タスクスタック" });
+    const row = stack.getByRole("listitem").filter({ hasText: "単独タスク P" });
+    await expect(row).toBeVisible();
+    // タイトル文字を狙うと TopTaskCard onClick で詳細パネルが開く
+    // (task-category-override / dependency-event spec と同じ pattern)。
+    await row.getByText("単独タスク P").first().click();
+
+    // project ボタン → select の order は project / size / category。
+    // 「<project1> を変更」が出る。
+    await page.getByRole("button", { name: new RegExp(`${projectName}\\s+を変更`) }).click();
+    // 編集中の最初の <select> が project (依存イベントは onChangeDependency が出ないと出ない、
+    // task_size / task_category はそれぞれ独立 button → select なので、編集中のものは 1 件)。
+    await page.locator("select").first().selectOption({ value: project2 });
+
+    // 単独タスクは dialog 出ずに即発火 (ADR-0039: 単独は当該行のみ変更)。
+    await expect(page.getByRole("dialog", { name: "プロジェクト変更の確認" })).toHaveCount(0);
+
+    // DB: 単独タスクの project_id が project2 になる。
+    await expect
+      .poll(async () => (await getTaskByTitle(admin, userId, "単独タスク P")).project_id, {
+        message: "tasks.project_id should equal project2",
+        timeout: 5_000,
+      })
+      .toBe(project2);
+
+    // action_log: propagation=single, affected_task_ids=[target] のみ。
+    const log = await waitForActionLog(
+      admin,
+      userId,
+      (l) =>
+        l.action_type === "task_project_changed" &&
+        (l.metadata as { task_id?: string }).task_id === seededLone.id,
+      { description: "task_project_changed (single) log" },
+    );
+    const meta = log.metadata as {
+      from?: string | null;
+      to?: string | null;
+      propagation?: string;
+      affected_task_ids?: string[];
+    };
+    expect(meta.from).toBe(project1);
+    expect(meta.to).toBe(project2);
+    expect(meta.propagation).toBe("single");
+    expect(meta.affected_task_ids).toEqual([seededLone.id]);
+  });
+
+  test("親タスク (子あり): dialog 経由で親 + 全子の project_id が一括変更され、propagation=with_children", async ({
+    signedInPageWithProject: page,
+    projectName,
+    testUserId: userId,
+  }) => {
+    const admin = createAdminClient();
+
+    const project1 = await fetchProjectId(admin, userId, projectName);
+    const project2 = await seedAdminProject(admin, userId, "別 project (親→子)");
+
+    // 親 + 子 2 件を seed。親の decompose_status は 'none' にして Stack に出るようにする
+    // (ADR-0016: leaf-parent ケース。'decomposed' だと親は Stack に出ないので詳細を Stack 経由で
+    // 開けない)。「子を持つ none 親」は実運用では稀だが、ADR-0016 / -0018 の状態遷移上は
+    // 矛盾しない (decompose 試行前 / 失敗 / skipped の親はそのまま Stack に出る)。
+    const parent = await seedTask(admin, {
+      userId,
+      projectId: project1,
+      title: "親 cascade テスト",
+      stackOrder: 0,
+      decomposeStatus: "none",
+    });
+    const child1 = await seedTask(admin, {
+      userId,
+      projectId: project1,
+      title: "子 cascade テスト 1",
+      stackOrder: 1,
+      parentTaskId: parent.id,
+    });
+    const child2 = await seedTask(admin, {
+      userId,
+      projectId: project1,
+      title: "子 cascade テスト 2",
+      stackOrder: 2,
+      parentTaskId: parent.id,
+    });
+
+    await page.reload();
+
+    const stack = page.getByRole("list", { name: "タスクスタック" });
+    const parentRow = stack.getByRole("listitem").filter({ hasText: "親 cascade テスト" });
+    await expect(parentRow).toBeVisible();
+    await parentRow.getByText("親 cascade テスト").first().click();
+
+    await page.getByRole("button", { name: new RegExp(`${projectName}\\s+を変更`) }).click();
+    await page.locator("select").first().selectOption({ value: project2 });
+
+    // 親 (子あり) は dialog 経由。文言には子件数 (2 件) と移動先 project 名が出る (issue #171)。
+    const dialog = page.getByRole("dialog", { name: "プロジェクト変更の確認" });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText(/2 件の子タスクも.*別 project \(親→子\)/)).toBeVisible();
+    await dialog.getByRole("button", { name: "変更する" }).click();
+    await expect(dialog).toHaveCount(0);
+
+    // DB: 親 + 全子の project_id が project2 に揃う (ADR-0039 不変条件: 親と子で乖離させない)。
+    await expect
+      .poll(
+        async () => {
+          const [p, c1, c2] = await Promise.all([
+            getTaskByTitle(admin, userId, "親 cascade テスト"),
+            getTaskByTitle(admin, userId, "子 cascade テスト 1"),
+            getTaskByTitle(admin, userId, "子 cascade テスト 2"),
+          ]);
+          return [p.project_id, c1.project_id, c2.project_id];
+        },
+        { timeout: 5_000 },
+      )
+      .toEqual([project2, project2, project2]);
+
+    // action_log: 1 操作 = 1 ログ + payload に伝播範囲。affected_task_ids は順序を保証しないので集合で比較。
+    const log = await waitForActionLog(
+      admin,
+      userId,
+      (l) =>
+        l.action_type === "task_project_changed" &&
+        (l.metadata as { task_id?: string }).task_id === parent.id,
+      { description: "task_project_changed (with_children) log" },
+    );
+    const meta = log.metadata as {
+      propagation?: string;
+      affected_task_ids?: string[];
+      to?: string | null;
+    };
+    expect(meta.propagation).toBe("with_children");
+    expect(meta.to).toBe(project2);
+    expect(new Set(meta.affected_task_ids)).toEqual(new Set([parent.id, child1.id, child2.id]));
+  });
+
+  test("子タスク: dialog 経由で親 + 全兄弟 + 子 の project_id が一括変更され、propagation=with_siblings_and_parent", async ({
+    signedInPageWithProject: page,
+    projectName,
+    testUserId: userId,
+  }) => {
+    const admin = createAdminClient();
+
+    const project1 = await fetchProjectId(admin, userId, projectName);
+    const project2 = await seedAdminProject(admin, userId, "別 project (子→兄弟+親)");
+
+    const parent = await seedTask(admin, {
+      userId,
+      projectId: project1,
+      title: "親 (子経由テスト)",
+      stackOrder: 0,
+      decomposeStatus: "none",
+    });
+    const target = await seedTask(admin, {
+      userId,
+      projectId: project1,
+      title: "子 target (子経由テスト)",
+      stackOrder: 1,
+      parentTaskId: parent.id,
+    });
+    const sibling = await seedTask(admin, {
+      userId,
+      projectId: project1,
+      title: "兄弟 (子経由テスト)",
+      stackOrder: 2,
+      parentTaskId: parent.id,
+    });
+
+    await page.reload();
+
+    const stack = page.getByRole("list", { name: "タスクスタック" });
+    const targetRow = stack.getByRole("listitem").filter({ hasText: "子 target (子経由テスト)" });
+    await expect(targetRow).toBeVisible();
+    await targetRow.getByText("子 target (子経由テスト)").first().click();
+
+    await page.getByRole("button", { name: new RegExp(`${projectName}\\s+を変更`) }).click();
+    await page.locator("select").first().selectOption({ value: project2 });
+
+    // 子は dialog 経由。文言は「親タスクと N 件の兄弟タスクも...」(target を除く兄弟数)。
+    const dialog = page.getByRole("dialog", { name: "プロジェクト変更の確認" });
+    await expect(dialog).toBeVisible();
+    await expect(
+      dialog.getByText(/親タスクと 1 件の兄弟タスクも.*別 project \(子→兄弟\+親\)/),
+    ).toBeVisible();
+    await dialog.getByRole("button", { name: "変更する" }).click();
+    await expect(dialog).toHaveCount(0);
+
+    // DB: 親 + target 子 + 兄弟、すべての project_id が揃う。
+    await expect
+      .poll(
+        async () => {
+          const [p, t, s] = await Promise.all([
+            getTaskByTitle(admin, userId, "親 (子経由テスト)"),
+            getTaskByTitle(admin, userId, "子 target (子経由テスト)"),
+            getTaskByTitle(admin, userId, "兄弟 (子経由テスト)"),
+          ]);
+          return [p.project_id, t.project_id, s.project_id];
+        },
+        { timeout: 5_000 },
+      )
+      .toEqual([project2, project2, project2]);
+
+    // action_log: action_logs.task_id は user が直接編集した行 (= target 子)。
+    const log = await waitForActionLog(
+      admin,
+      userId,
+      (l) =>
+        l.action_type === "task_project_changed" &&
+        (l.metadata as { task_id?: string }).task_id === target.id,
+      { description: "task_project_changed (with_siblings_and_parent) log" },
+    );
+    const meta = log.metadata as {
+      propagation?: string;
+      affected_task_ids?: string[];
+      to?: string | null;
+    };
+    expect(meta.propagation).toBe("with_siblings_and_parent");
+    expect(meta.to).toBe(project2);
+    expect(new Set(meta.affected_task_ids)).toEqual(new Set([parent.id, target.id, sibling.id]));
+  });
+
+  test("確認 dialog の キャンセル: DB / action_log は変化しない", async ({
+    signedInPageWithProject: page,
+    projectName,
+    testUserId: userId,
+  }) => {
+    const admin = createAdminClient();
+
+    const project1 = await fetchProjectId(admin, userId, projectName);
+    const project2 = await seedAdminProject(admin, userId, "別 project (cancel)");
+
+    const parent = await seedTask(admin, {
+      userId,
+      projectId: project1,
+      title: "親 (cancel)",
+      stackOrder: 0,
+      decomposeStatus: "none",
+    });
+    await seedTask(admin, {
+      userId,
+      projectId: project1,
+      title: "子 (cancel)",
+      stackOrder: 1,
+      parentTaskId: parent.id,
+    });
+
+    await page.reload();
+
+    const stack = page.getByRole("list", { name: "タスクスタック" });
+    const parentRow = stack.getByRole("listitem").filter({ hasText: "親 (cancel)" });
+    await parentRow.getByText("親 (cancel)").first().click();
+
+    await page.getByRole("button", { name: new RegExp(`${projectName}\\s+を変更`) }).click();
+    await page.locator("select").first().selectOption({ value: project2 });
+
+    const dialog = page.getByRole("dialog", { name: "プロジェクト変更の確認" });
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole("button", { name: "キャンセル" }).click();
+    await expect(dialog).toHaveCount(0);
+
+    // DB は project1 のまま。ログ非同期書き込みも待つために少し空ける。
+    await page.waitForTimeout(500);
+    const parentRow2 = await getTaskByTitle(admin, userId, "親 (cancel)");
+    const childRow = await getTaskByTitle(admin, userId, "子 (cancel)");
+    expect(parentRow2.project_id).toBe(project1);
+    expect(childRow.project_id).toBe(project1);
+
+    // action_log にも task_project_changed は 0 件。
+    const { data: logs } = await admin
+      .from("action_logs")
+      .select("*")
+      .eq("user_id", userId)
+      .eq("action_type", "task_project_changed");
+    expect(logs?.length ?? 0).toBe(0);
+  });
+});
+
+// =====================================================================
+// helpers (本 spec ローカル)
+// =====================================================================
+
+async function fetchProjectId(
+  admin: ReturnType<typeof createAdminClient>,
+  userId: string,
+  projectName: string,
+): Promise<string> {
+  const { data, error } = await admin
+    .from("projects")
+    .select("id")
+    .eq("user_id", userId)
+    .eq("name", projectName)
+    .single();
+  if (error || !data) {
+    throw new Error(`[e2e] project '${projectName}' not found for user ${userId}`);
+  }
+  return (data as { id: string }).id;
+}
+
+async function seedAdminProject(
+  admin: ReturnType<typeof createAdminClient>,
+  userId: string,
+  name: string,
+): Promise<string> {
+  const { data, error } = await admin
+    .from("projects")
+    .insert({ user_id: userId, name, color: "#5B8DEF", is_primary: false })
+    .select("id")
+    .single();
+  if (error || !data) {
+    throw new Error(`[e2e] seed project '${name}' failed: ${error?.message ?? "no row"}`);
+  }
+  return (data as { id: string }).id;
+}

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -119,6 +119,7 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
     updateDependency,
     updateCategory,
     updateSize,
+    updateTaskProject,
     reorder,
     reorderGroup,
     createTaskWithAi,
@@ -261,6 +262,7 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
             <TaskDetailPanel
               task={detailTask}
               events={events}
+              tasks={tasks}
               now={nowMs}
               onClose={() => setDetailId(null)}
               onUpdate={updateBody}
@@ -269,6 +271,7 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
               onChangeDependency={updateDependency}
               onChangeCategory={updateCategory}
               onChangeSize={updateSize}
+              onChangeProject={updateTaskProject}
               aiEnabled={aiEnabled}
               latestDecomposeLog={decomposeLogQuery.data ?? null}
               isDecomposeLogLoading={decomposeLogQuery.isPending}

--- a/src/app/useDashboardMutations.ts
+++ b/src/app/useDashboardMutations.ts
@@ -9,7 +9,7 @@ import type { CreateEventInput, UpdateEventInput } from "@/entities/event/gatewa
 import type { Event, EventVisibilityOverride } from "@/entities/event/types";
 import type { CreateProjectInput, UpdateProjectInput } from "@/entities/project/gateway";
 import type { Project } from "@/entities/project/types";
-import type { CreateTaskInput } from "@/entities/task/gateway";
+import type { CreateTaskInput, ProjectCascadeMode } from "@/entities/task/gateway";
 import type { Task, TaskCategory, TaskSize } from "@/entities/task/types";
 import {
   insertAtTopPlusOne,
@@ -41,6 +41,13 @@ export type DashboardMutations = {
    * payload schema を別 issue で確定する必要があるため)。
    */
   updateSize: (id: string, taskSize: TaskSize | null) => void;
+  /**
+   * Issue #171 / ADR 0039: タスクの project_id 編集と親→子 / 子→兄弟+親 への伝播。
+   * cache から target の親子関係を判定して mode を決め、対応する RPC (atomic) または
+   * 単独 update を呼ぶ。1 操作 = 1 ログ (`task_project_changed`) + payload に伝播範囲。
+   * - 同値選択は no-op (mutation 自体を呼ばない)。
+   */
+  updateTaskProject: (id: string, projectId: string | null) => void;
   /** DnD でのタスク並び替え。action_log: TASK_REORDERED。 */
   reorder: (fromId: string, toId: string) => void;
   /**
@@ -254,6 +261,96 @@ export function useDashboardMutations(): DashboardMutations {
       taskGateway.reorder(entries),
     // DnD は optimistic で UI 側は onMutate で即反映、サーバー同期は背面で進める。
   });
+
+  // Issue #171 / ADR 0039: 詳細パネルからの project 編集 + 親→子 / 子→兄弟+親 伝播。
+  // mutation 引数:
+  //   id            : ユーザーが直接編集した task id (action_logs.task_id 列に入る)
+  //   projectId     : 新しい project_id (null で「未指定」)
+  //   mode          : "single" | "with_children" | "with_siblings_and_parent"
+  //   affectedIds   : 影響を受ける全 task id (target を含む) — onMutate / log で使う
+  //   from          : 旧 project_id (action_log の payload `from` 用)
+  //
+  // mode 判定と affected_ids の算出は wrapper (updateTaskProject) 側で cache を読んで行う。
+  // ここでは「先に確定した範囲を atomic に変える」ことだけに集中する。
+  const updateTaskProjectMutation = useMutation({
+    mutationFn: ({
+      id,
+      projectId,
+      mode,
+    }: {
+      id: string;
+      projectId: string | null;
+      mode: ProjectCascadeMode;
+      affectedIds: string[];
+      from: string | null;
+    }) => taskGateway.updateTaskProjectCascade(id, projectId, mode),
+    onMutate: async ({ id, projectId, mode, affectedIds, from }) => {
+      await queryClient.cancelQueries({ queryKey: dashboardKeys.tasks });
+      const previous = queryClient.getQueryData<Task[]>(dashboardKeys.tasks);
+      // 楽観: 影響範囲全 task の projectId を一括書き換え。Task.projectId は
+      // 空文字を「未指定」として保持する慣習 (fromRow で `row.project_id ?? ""`) なので、
+      // null は "" に揃える。
+      const next = projectId ?? "";
+      const affectedSet = new Set(affectedIds);
+      queryClient.setQueryData<Task[]>(dashboardKeys.tasks, (prev) =>
+        (prev ?? []).map((t) => (affectedSet.has(t.id) ? { ...t, projectId: next } : t)),
+      );
+      // 1 操作 = 1 ログ。propagation と affected_task_ids で N 行更新を再構成可能にする (ADR 0039)。
+      log(ACTION_TYPES.TASK_PROJECT_CHANGED, {
+        task_id: id,
+        from,
+        to: projectId,
+        propagation: mode,
+        affected_task_ids: affectedIds,
+      });
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(dashboardKeys.tasks, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.tasks });
+    },
+  });
+
+  const updateTaskProject = useCallback(
+    (id: string, projectId: string | null) => {
+      const cached = queryClient.getQueryData<Task[]>(dashboardKeys.tasks) ?? [];
+      const target = cached.find((t) => t.id === id);
+      if (!target) return;
+      // Task.projectId は "" を「未指定」として保持しているので、null と "" を同一視する。
+      const from = target.projectId === "" ? null : target.projectId;
+      const to = projectId === "" ? null : projectId;
+      if (from === to) return; // 同値選択は no-op
+
+      // mode 判定:
+      //   - target が子 (parentTaskId not null) → 親 + 全兄弟に伝播
+      //   - target が親 (parentTaskId is null) かつ子が居る → 全子に伝播
+      //   - それ以外 (単独タスク) → 当該行のみ
+      let mode: ProjectCascadeMode;
+      let affectedIds: string[];
+      if (target.parentTaskId !== null) {
+        mode = "with_siblings_and_parent";
+        const parentId = target.parentTaskId;
+        affectedIds = [
+          parentId,
+          ...cached.filter((t) => t.parentTaskId === parentId).map((t) => t.id),
+        ];
+      } else {
+        const childIds = cached.filter((t) => t.parentTaskId === id).map((t) => t.id);
+        if (childIds.length > 0) {
+          mode = "with_children";
+          affectedIds = [id, ...childIds];
+        } else {
+          mode = "single";
+          affectedIds = [id];
+        }
+      }
+
+      updateTaskProjectMutation.mutate({ id, projectId: to, mode, affectedIds, from });
+    },
+    [queryClient, updateTaskProjectMutation],
+  );
 
   // createTaskWithAi が cache を append + AI trigger 完了後に .finally invalidate
   // するので、ここでは onSuccess invalidate を持たない (issue #167)。旧実装では
@@ -640,6 +737,7 @@ export function useDashboardMutations(): DashboardMutations {
       updateDependencyMutation.mutate({ id, dependsOnEventId }),
     updateCategory: (id, taskCategory) => updateCategoryMutation.mutate({ id, taskCategory }),
     updateSize: (id, taskSize) => updateSizeMutation.mutate({ id, taskSize }),
+    updateTaskProject,
     reorder,
     reorderGroup,
     createTaskWithAi,

--- a/src/entities/action-log/logger.test.ts
+++ b/src/entities/action-log/logger.test.ts
@@ -195,6 +195,7 @@ describe("ACTION_TYPES", () => {
       TASK_DELETED: "task_deleted",
       TASK_TITLE_CHANGED: "task_title_changed",
       TASK_CATEGORY_CHANGED: "task_category_changed",
+      TASK_PROJECT_CHANGED: "task_project_changed",
       TASK_DEPENDENCY_SET: "task_dependency_set",
       TASK_DEPENDENCY_CLEARED: "task_dependency_cleared",
       INTERRUPTION_PUSHED: "interruption_pushed",

--- a/src/entities/action-log/logger.ts
+++ b/src/entities/action-log/logger.ts
@@ -25,6 +25,7 @@ export const ACTION_TYPES = Object.freeze({
   TASK_DELETED: "task_deleted",
   TASK_TITLE_CHANGED: "task_title_changed",
   TASK_CATEGORY_CHANGED: "task_category_changed",
+  TASK_PROJECT_CHANGED: "task_project_changed",
   TASK_DEPENDENCY_SET: "task_dependency_set",
   TASK_DEPENDENCY_CLEARED: "task_dependency_cleared",
   INTERRUPTION_PUSHED: "interruption_pushed",

--- a/src/entities/action-log/types.ts
+++ b/src/entities/action-log/types.ts
@@ -7,6 +7,7 @@ export type ActionType =
   | "task_deleted"
   | "task_title_changed"
   | "task_category_changed"
+  | "task_project_changed"
   | "task_dependency_set"
   | "task_dependency_cleared"
   | "interruption_pushed"
@@ -124,6 +125,19 @@ export type ActionMetadataMap = {
     task_id: string;
     from: string | null;
     to: string;
+  };
+  // Issue #171 / ADR 0039: タスクの project_id 変更 (親→子 / 子→兄弟+親 への伝播も含む)。
+  // 1 操作 = 1 ログ + payload に伝播範囲を持たせる方針。
+  // - task_id は user が直接編集した行 (action_logs.task_id 列にもこの値が入る)
+  // - propagation: "single" は単独行のみ更新 / "with_children" は親+全子 / "with_siblings_and_parent" は子+親+全兄弟
+  // - affected_task_ids は target を含む全 update 対象 id (Phase 4 で 1 操作 → N 行更新を再構成可能にする)
+  // from/to は project_id の文字列 (uuid) または null (= 未指定)。
+  task_project_changed: {
+    task_id: string;
+    from: string | null;
+    to: string | null;
+    propagation: "single" | "with_children" | "with_siblings_and_parent";
+    affected_task_ids: string[];
   };
   // Phase 2 #53: 依存イベントの設定 / 解除。Phase 4 で「依存設定が着手順に効いたか」の分析データに使う。
   task_dependency_set: {

--- a/src/entities/task/gateway.ts
+++ b/src/entities/task/gateway.ts
@@ -38,6 +38,14 @@ export type UpdateTaskInput = {
 };
 
 /**
+ * Issue #171 / ADR 0039: project 編集の伝播モード。
+ * - single                       : 単独タスク (親も子もない) で当該行のみ変更
+ * - with_children                : 親タスクを変更し、同じ parent_task_id を持つ全子に伝播
+ * - with_siblings_and_parent     : 子タスクを変更し、親と全兄弟に伝播
+ */
+export type ProjectCascadeMode = "single" | "with_children" | "with_siblings_and_parent";
+
+/**
  * 判断 5 (auth 隠蔽): `user_id` は interface に現れず、具象実装内で
  * `auth.getUser()` 相当を解決する。
  */
@@ -45,6 +53,17 @@ export interface TaskGateway {
   list(): Promise<Task[]>;
   create(input: CreateTaskInput): Promise<Task>;
   update(id: string, patch: UpdateTaskInput): Promise<Task>;
+  /**
+   * Issue #171 / ADR 0039: project_id を atomic に変更する。
+   * mode で伝播範囲を切り替える (with_children / with_siblings_and_parent は RPC 経由で 1 トランザクション)。
+   * 戻り値の affectedTaskIds は変更が走った全 task id (target を含む) で、Phase 4 の
+   * action_log payload に詰めて 1 操作 → N 行更新を再構成可能にする。
+   */
+  updateTaskProjectCascade(
+    taskId: string,
+    newProjectId: string | null,
+    mode: ProjectCascadeMode,
+  ): Promise<{ affectedTaskIds: string[] }>;
   reorder(entries: readonly { id: string; stackOrder: number | null }[]): Promise<void>;
   delete(id: string): Promise<void>;
   deleteAllForCurrentUser(): Promise<void>;

--- a/src/entities/task/supabase-gateway.ts
+++ b/src/entities/task/supabase-gateway.ts
@@ -4,7 +4,7 @@ import { ACTION_TYPES, log } from "@/entities/action-log/logger";
 import type { Database, Tables, TablesInsert, TablesUpdate } from "@/shared/types/database";
 
 import type { CorrectionFactor } from "./correction";
-import type { CreateTaskInput, TaskGateway, UpdateTaskInput } from "./gateway";
+import type { CreateTaskInput, ProjectCascadeMode, TaskGateway, UpdateTaskInput } from "./gateway";
 import type { Task } from "./types";
 
 type Sb = SupabaseClient<Database>;
@@ -95,6 +95,36 @@ export class SupabaseTaskGateway implements TaskGateway {
       .single();
     if (error) throw error;
     return fromRow(data);
+  }
+
+  async updateTaskProjectCascade(
+    taskId: string,
+    newProjectId: string | null,
+    mode: ProjectCascadeMode,
+  ): Promise<{ affectedTaskIds: string[] }> {
+    if (mode === "single") {
+      // 単独タスクは既存の update 経路で十分 (RPC の atomic 担保が要らない)。
+      // returning なし update + id を 1 件返す。
+      const { error } = await this.supabase
+        .from("tasks")
+        .update({ project_id: newProjectId } satisfies TablesUpdate<"tasks">)
+        .eq("id", taskId);
+      if (error) throw error;
+      return { affectedTaskIds: [taskId] };
+    }
+
+    // with_children / with_siblings_and_parent は RPC 経由で 1 トランザクション化 (ADR 0039)。
+    // 戻り値は影響を受けた task id 配列 (target を含む)。
+    const fnName =
+      mode === "with_children"
+        ? "fn_update_task_project_with_children"
+        : "fn_update_task_project_with_siblings_and_parent";
+    const { data, error } = await this.supabase.rpc(fnName, {
+      p_task_id: taskId,
+      p_new_project_id: newProjectId,
+    });
+    if (error) throw error;
+    return { affectedTaskIds: data ?? [] };
   }
 
   async reorder(entries: readonly { id: string; stackOrder: number | null }[]): Promise<void> {

--- a/src/features/task-detail/TaskDetailPanel.test.tsx
+++ b/src/features/task-detail/TaskDetailPanel.test.tsx
@@ -501,6 +501,157 @@ describe("TaskDetailPanel - task_size override (#170 / ADR 0038)", () => {
   });
 });
 
+// Issue #171 / ADR 0039: project 編集 UI と親→子 / 子→兄弟+親 への伝播確認 dialog。
+// 体験は category と揃える: ボタン → select → 値選択。
+// ただし伝播ありのとき (子持ち親 / 子) は select 後に確認 dialog を経由してから callback が呼ばれる。
+// 単独タスクは dialog なしで即発火。
+describe("TaskDetailPanel - project edit (Issue #171 / ADR 0039)", () => {
+  const multipleProjects: Project[] = [
+    { id: "slo", name: "SLO推進", color: "#2D9F45", isPrimary: true, createdAt: "" },
+    { id: "career", name: "転職活動", color: "#E85D04", isPrimary: false, createdAt: "" },
+  ];
+
+  function renderWithProjects(overrides: Partial<TaskDetailPanelProps>) {
+    const props: TaskDetailPanelProps = {
+      task: baseTask,
+      events: [],
+      onClose: noop,
+      onUpdate: noop,
+      onToggleDone: noop,
+      ...overrides,
+    };
+    return rtlRender(
+      <ProjectsProvider projects={multipleProjects}>
+        <CorrectionFactorsProvider factors={[]}>
+          <TaskDetailPanel {...props} />
+        </CorrectionFactorsProvider>
+      </ProjectsProvider>,
+    );
+  }
+
+  test("onChangeProject 未指定なら project 編集 UI を出さない (旧呼び出し互換)", () => {
+    const { queryByText } = renderPanel();
+    expect(queryByText("プロジェクト")).toBeNull();
+  });
+
+  test("onChangeProject 指定時、デフォルトは「<現在 project> を変更」ボタン", () => {
+    const { getByText } = renderWithProjects({ onChangeProject: vi.fn() });
+    expect(getByText(/SLO推進\s+を変更/)).toBeTruthy();
+  });
+
+  test("project 未設定 (空文字) なら「未設定 を変更」ボタン", () => {
+    const { getByText } = renderWithProjects({
+      task: { ...baseTask, projectId: "" },
+      onChangeProject: vi.fn(),
+    });
+    expect(getByText(/未設定\s+を変更/)).toBeTruthy();
+  });
+
+  test("ボタン押下で <select> に切り替わり、現在値が反映されている", () => {
+    const { getByText, getAllByRole } = renderWithProjects({ onChangeProject: vi.fn() });
+    fireEvent.click(getByText(/SLO推進\s+を変更/));
+    // 依存イベント / category / size と並ぶので select が複数になる前提。
+    // project は最初に出るので getAllByRole("combobox")[0] が project select。
+    const project = getAllByRole("combobox")[0] as HTMLSelectElement;
+    expect(project.value).toBe("slo");
+    const values = Array.from(project.options).map((o) => o.value);
+    expect(values).toEqual(["", "slo", "career"]);
+  });
+
+  test("単独タスク (tasks 未指定) で別 project を選ぶと dialog 出ずに即 onChangeProject を呼ぶ", () => {
+    const onChangeProject = vi.fn();
+    const { getByText, getAllByRole, queryByRole } = renderWithProjects({ onChangeProject });
+    fireEvent.click(getByText(/SLO推進\s+を変更/));
+    fireEvent.change(getAllByRole("combobox")[0], { target: { value: "career" } });
+    expect(onChangeProject).toHaveBeenCalledWith("t1", "career");
+    expect(queryByRole("dialog", { name: "プロジェクト変更の確認" })).toBeNull();
+  });
+
+  test("「未設定」(空文字) を選ぶと onChangeProject(taskId, null) を呼ぶ", () => {
+    const onChangeProject = vi.fn();
+    const { getByText, getAllByRole } = renderWithProjects({ onChangeProject });
+    fireEvent.click(getByText(/SLO推進\s+を変更/));
+    fireEvent.change(getAllByRole("combobox")[0], { target: { value: "" } });
+    expect(onChangeProject).toHaveBeenCalledWith("t1", null);
+  });
+
+  test("同値選択は onChangeProject を呼ばない", () => {
+    const onChangeProject = vi.fn();
+    const { getByText, getAllByRole } = renderWithProjects({ onChangeProject });
+    fireEvent.click(getByText(/SLO推進\s+を変更/));
+    fireEvent.change(getAllByRole("combobox")[0], { target: { value: "slo" } });
+    expect(onChangeProject).not.toHaveBeenCalled();
+  });
+
+  test("親タスク (子あり) で別 project を選ぶと dialog が出て onChangeProject はまだ呼ばれない", () => {
+    const onChangeProject = vi.fn();
+    const parent: Task = { ...baseTask, id: "parent" };
+    const child1: Task = { ...baseTask, id: "c1", parentTaskId: "parent" };
+    const child2: Task = { ...baseTask, id: "c2", parentTaskId: "parent" };
+    const { getByText, getAllByRole, getByRole } = renderWithProjects({
+      task: parent,
+      tasks: [parent, child1, child2],
+      onChangeProject,
+    });
+    fireEvent.click(getByText(/SLO推進\s+を変更/));
+    fireEvent.change(getAllByRole("combobox")[0], { target: { value: "career" } });
+    expect(onChangeProject).not.toHaveBeenCalled();
+    expect(getByRole("dialog", { name: "プロジェクト変更の確認" })).toBeTruthy();
+    // 件数文言: 子タスクが 2 件
+    expect(getByText(/2 件の子タスクも.*転職活動/)).toBeTruthy();
+  });
+
+  test("親タスク dialog: confirm で onChangeProject を呼んで dialog を閉じる", () => {
+    const onChangeProject = vi.fn();
+    const parent: Task = { ...baseTask, id: "parent" };
+    const child: Task = { ...baseTask, id: "c1", parentTaskId: "parent" };
+    const { getByText, getAllByRole, getByRole, queryByRole } = renderWithProjects({
+      task: parent,
+      tasks: [parent, child],
+      onChangeProject,
+    });
+    fireEvent.click(getByText(/SLO推進\s+を変更/));
+    fireEvent.change(getAllByRole("combobox")[0], { target: { value: "career" } });
+    fireEvent.click(getByRole("button", { name: "変更する" }));
+    expect(onChangeProject).toHaveBeenCalledWith("parent", "career");
+    expect(queryByRole("dialog", { name: "プロジェクト変更の確認" })).toBeNull();
+  });
+
+  test("親タスク dialog: cancel で onChangeProject は呼ばれず dialog を閉じる", () => {
+    const onChangeProject = vi.fn();
+    const parent: Task = { ...baseTask, id: "parent" };
+    const child: Task = { ...baseTask, id: "c1", parentTaskId: "parent" };
+    const { getByText, getAllByRole, getByRole, queryByRole } = renderWithProjects({
+      task: parent,
+      tasks: [parent, child],
+      onChangeProject,
+    });
+    fireEvent.click(getByText(/SLO推進\s+を変更/));
+    fireEvent.change(getAllByRole("combobox")[0], { target: { value: "career" } });
+    fireEvent.click(getByRole("button", { name: "キャンセル" }));
+    expect(onChangeProject).not.toHaveBeenCalled();
+    expect(queryByRole("dialog", { name: "プロジェクト変更の確認" })).toBeNull();
+  });
+
+  test("子タスクで別 project を選ぶと「親タスクと N 件の兄弟タスクも...」文言を表示する", () => {
+    const onChangeProject = vi.fn();
+    const parent: Task = { ...baseTask, id: "parent" };
+    const target: Task = { ...baseTask, id: "child-target", parentTaskId: "parent" };
+    const sibling: Task = { ...baseTask, id: "sibling", parentTaskId: "parent" };
+    const { getByText, getAllByRole, getByRole } = renderWithProjects({
+      task: target,
+      tasks: [parent, target, sibling],
+      onChangeProject,
+    });
+    fireEvent.click(getByText(/SLO推進\s+を変更/));
+    fireEvent.change(getAllByRole("combobox")[0], { target: { value: "career" } });
+    // 兄弟は target を除いて 1 件
+    expect(getByText(/親タスクと 1 件の兄弟タスクも.*転職活動/)).toBeTruthy();
+    fireEvent.click(getByRole("button", { name: "変更する" }));
+    expect(onChangeProject).toHaveBeenCalledWith("child-target", "career");
+  });
+});
+
 // AI 分解情報エリア (P3-15 / ADR 0021 §3)。
 // 親が `latestDecomposeLog` か `onTriggerDecompose` を渡したときだけセクションが描画される。
 describe("TaskDetailPanel - AI 分解情報エリア (P3-15)", () => {

--- a/src/features/task-detail/TaskDetailPanel.tsx
+++ b/src/features/task-detail/TaskDetailPanel.tsx
@@ -16,6 +16,11 @@ import { TASK_CATEGORY_VALUES, TASK_SIZE_VALUES } from "../../shared/types/datab
 export type TaskDetailPanelProps = {
   task: Task;
   events: Event[];
+  /**
+   * Issue #171 / ADR 0039: project 変更時の伝播モード判定 (親/子/単独) と影響件数表示に使う。
+   * 渡されない場合は `[]` 扱い (= 単独タスクとして扱う、テスト / 旧呼び出し互換)。
+   */
+  tasks?: readonly Task[];
   /** 現在時刻 (ms)。依存イベントの相対時刻 / 候補絞り込みに使う。省略時は呼び出し時刻。 */
   now?: number;
   onClose: () => void;
@@ -42,6 +47,14 @@ export type TaskDetailPanelProps = {
    */
   onChangeSize?: (id: string, size: TaskSize | null) => void;
   /**
+   * Issue #171 / ADR 0039: タスクの project_id 編集。
+   * 親/子の場合は確認 dialog を経由してから callback が呼ばれる (伝播範囲を視認させる)。
+   * 単独タスクの場合は dialog を挟まず即発火する (UX 軽さを優先)。
+   * 伝播の atomic 担保 + action_log は呼び出し側 (useDashboardMutations) の責務。
+   * 未指定なら project 編集 UI を出さない (旧呼び出し / テスト互換)。
+   */
+  onChangeProject?: (id: string, projectId: string | null) => void;
+  /**
    * AI 分解の最新試行ログ (`task_decomposed` / `task_decompose_failed` /
    * `task_decompose_skipped` の最新 1 件)。なければ null。
    * 親が undefined を渡した場合は AI 分解情報エリアを描画しない (旧呼び出し互換)。
@@ -67,6 +80,7 @@ export type TaskDetailPanelProps = {
 export function TaskDetailPanel({
   task,
   events,
+  tasks,
   now,
   onClose,
   onUpdate,
@@ -75,18 +89,26 @@ export function TaskDetailPanel({
   onChangeDependency,
   onChangeCategory,
   onChangeSize,
+  onChangeProject,
   latestDecomposeLog,
   isDecomposeLogLoading,
   aiEnabled = true,
   onTriggerDecompose,
   onTriggerResplit,
 }: TaskDetailPanelProps) {
-  const { projectsById } = useProjects();
+  const { projects, projectsById } = useProjects();
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(task.body || "");
   const [editingDep, setEditingDep] = useState(false);
   const [editingCategory, setEditingCategory] = useState(false);
   const [editingSize, setEditingSize] = useState(false);
+  const [editingProject, setEditingProject] = useState(false);
+  // 確認 dialog のペンディング状態 (mode != "single" のとき表示)。
+  const [pendingProjectChange, setPendingProjectChange] = useState<{
+    nextProjectId: string | null;
+    mode: "with_children" | "with_siblings_and_parent";
+    affectedCount: number;
+  } | null>(null);
   // パネル open 時刻を「今」として固定する。パネル中に分跨ぎしても候補や相対時刻が
   // ばたつかないようにするのが目的 (相対時刻はあくまで判断補助)。
   const [openedAt] = useState<number>(() => now ?? Date.now());
@@ -94,6 +116,32 @@ export function TaskDetailPanel({
   const nowDate = useMemo(() => new Date(nowMs), [nowMs]);
   const proj = getProject(projectsById, task.projectId);
   const dep = task.dependsOnEventId ? events.find((e) => e.id === task.dependsOnEventId) : null;
+
+  // Issue #171 / ADR 0039: project 編集の伝播モードと影響件数を cache から計算する。
+  // tasks 未指定 (テスト) は単独扱い。
+  const projectChangeContext = useMemo(() => {
+    const allTasks = tasks ?? [];
+    if (task.parentTaskId !== null) {
+      // 子: 親 + 全兄弟に伝播 (target を含む全行を update)
+      const siblings = allTasks.filter(
+        (t) => t.parentTaskId === task.parentTaskId && t.id !== task.id,
+      );
+      return {
+        mode: "with_siblings_and_parent" as const,
+        // ダイアログの「N 件の兄弟タスクも」表示用 (親 1 件は別文言で示す)
+        affectedSiblingCount: siblings.length,
+      };
+    }
+    const children = allTasks.filter((t) => t.parentTaskId === task.id);
+    if (children.length > 0) {
+      return {
+        mode: "with_children" as const,
+        // ダイアログの「N 件の子タスクも」表示用
+        affectedChildCount: children.length,
+      };
+    }
+    return { mode: "single" as const };
+  }, [task.id, task.parentTaskId, tasks]);
   const done = isDone(task);
   const factors = useCorrectionFactors();
   // P3-9 / #93、ADR 0026: 補正後 + 元値の組。null ならヘッダの見積もり表示自体を出さない。
@@ -124,273 +172,419 @@ export function TaskDetailPanel({
     onTriggerDecompose !== undefined ||
     onTriggerResplit !== undefined;
 
+  // 確認 dialog の from / to の表示名 (未指定 は「未設定」)。
+  const projectChangeFromName = task.projectId ? proj.name : "未設定";
+  const projectChangeToName = pendingProjectChange?.nextProjectId
+    ? (projectsById[pendingProjectChange.nextProjectId]?.name ?? "未設定")
+    : "未設定";
+
   return (
-    <div className="fixed inset-0 z-[200] flex flex-col">
-      <div onClick={onClose} className="absolute inset-0 bg-black/60 backdrop-blur-[4px]" />
+    <>
+      {pendingProjectChange && onChangeProject && (
+        <ProjectChangeConfirmDialog
+          taskTitle={task.title}
+          fromName={projectChangeFromName}
+          toName={projectChangeToName}
+          mode={pendingProjectChange.mode}
+          affectedCount={pendingProjectChange.affectedCount}
+          onCancel={() => setPendingProjectChange(null)}
+          onConfirm={() => {
+            onChangeProject(task.id, pendingProjectChange.nextProjectId);
+            setPendingProjectChange(null);
+          }}
+        />
+      )}
+      <div className="fixed inset-0 z-[200] flex flex-col">
+        <div onClick={onClose} className="absolute inset-0 bg-black/60 backdrop-blur-[4px]" />
 
-      <div
-        className="relative mt-auto flex max-h-[85vh] animate-panel-slide-up flex-col rounded-t-2xl bg-bg-surface"
-        style={{
-          borderTop: `2px solid ${proj.color}40`,
-        }}
-      >
-        <div className="flex justify-center px-0 pb-1 pt-2.5">
-          <div className="h-[3px] w-8 rounded-[2px] bg-bg-divider" />
-        </div>
+        <div
+          className="relative mt-auto flex max-h-[85vh] animate-panel-slide-up flex-col rounded-t-2xl bg-bg-surface"
+          style={{
+            borderTop: `2px solid ${proj.color}40`,
+          }}
+        >
+          <div className="flex justify-center px-0 pb-1 pt-2.5">
+            <div className="h-[3px] w-8 rounded-[2px] bg-bg-divider" />
+          </div>
 
-        <div className="px-5 pb-3 pt-2">
-          <div className="mb-2 flex items-center gap-2">
-            <div className="h-2 w-2 rounded-full" style={{ background: proj.color }} />
-            <span className="font-jp text-[10px] text-fg-subtle">{proj.name}</span>
-            {estimate?.correctedMinutes !== null && estimate !== null ? (
-              // ADR 0026 詳細パネル: ヘッダは補正後だけを大きく出し、元値と倍率は title 下の自然文で添える。
-              <span
-                aria-label={`${fmtDuration(estimate.correctedMinutes)} を確保`}
-                className="text-[10px] tabular-nums text-fg-muted"
+          <div className="px-5 pb-3 pt-2">
+            <div className="mb-2 flex items-center gap-2">
+              <div className="h-2 w-2 rounded-full" style={{ background: proj.color }} />
+              <span className="font-jp text-[10px] text-fg-subtle">{proj.name}</span>
+              {estimate?.correctedMinutes !== null && estimate !== null ? (
+                // ADR 0026 詳細パネル: ヘッダは補正後だけを大きく出し、元値と倍率は title 下の自然文で添える。
+                <span
+                  aria-label={`${fmtDuration(estimate.correctedMinutes)} を確保`}
+                  className="text-[10px] tabular-nums text-fg-muted"
+                >
+                  {fmtDuration(estimate.correctedMinutes)}
+                </span>
+              ) : estimate ? (
+                <span aria-label="見積もり" className="text-[9px] tabular-nums text-fg-faint">
+                  {fmtDuration(estimate.rawMinutes)}
+                </span>
+              ) : null}
+              {dep && (
+                <span className="rounded-[3px] bg-[#E85D0415] px-1.5 py-px font-jp text-[9px] text-accent-amber">
+                  ← {formatRelativeTime(dep.startTime, nowDate)} {dep.title}
+                </span>
+              )}
+              <div className="flex-1" />
+              <button
+                onClick={() => {
+                  onToggleDone(task.id);
+                  onClose();
+                }}
+                className="cursor-pointer rounded-[4px] px-2.5 py-[3px] font-jp text-[10px]"
+                style={{
+                  background: done ? "#27272a" : proj.color,
+                  color: done ? "#8B949E" : "#fff",
+                }}
               >
-                {fmtDuration(estimate.correctedMinutes)}
-              </span>
-            ) : estimate ? (
-              <span aria-label="見積もり" className="text-[9px] tabular-nums text-fg-faint">
-                {fmtDuration(estimate.rawMinutes)}
-              </span>
-            ) : null}
-            {dep && (
-              <span className="rounded-[3px] bg-[#E85D0415] px-1.5 py-px font-jp text-[9px] text-accent-amber">
-                ← {formatRelativeTime(dep.startTime, nowDate)} {dep.title}
-              </span>
+                {done ? "未完了に戻す" : "完了にする"}
+              </button>
+            </div>
+            <h2 className="m-0 font-jp text-[16px] font-bold leading-[1.4] text-fg-strong">
+              {task.title}
+            </h2>
+            {estimate?.correctedMinutes !== null && estimate !== null && (
+              // ADR 0026 詳細パネル: 元値を自然文で添え、補正の存在を明言しない文脈的な文言で倍率を示す。
+              // 「補正係数」「補正済み」等の言い回しは出さない。
+              <p className="mt-1 font-jp text-[10px] leading-[1.5] text-fg-subtle">
+                あなたの見積もり {fmtDuration(estimate.rawMinutes)} ・ 同じ種類のタスクは平均{" "}
+                {formatFactor(estimate.factor!)} 倍かかっています
+              </p>
             )}
-            <div className="flex-1" />
-            <button
-              onClick={() => {
-                onToggleDone(task.id);
-                onClose();
-              }}
-              className="cursor-pointer rounded-[4px] px-2.5 py-[3px] font-jp text-[10px]"
-              style={{
-                background: done ? "#27272a" : proj.color,
-                color: done ? "#8B949E" : "#fff",
-              }}
-            >
-              {done ? "未完了に戻す" : "完了にする"}
-            </button>
           </div>
-          <h2 className="m-0 font-jp text-[16px] font-bold leading-[1.4] text-fg-strong">
-            {task.title}
-          </h2>
-          {estimate?.correctedMinutes !== null && estimate !== null && (
-            // ADR 0026 詳細パネル: 元値を自然文で添え、補正の存在を明言しない文脈的な文言で倍率を示す。
-            // 「補正係数」「補正済み」等の言い回しは出さない。
-            <p className="mt-1 font-jp text-[10px] leading-[1.5] text-fg-subtle">
-              あなたの見積もり {fmtDuration(estimate.rawMinutes)} ・ 同じ種類のタスクは平均{" "}
-              {formatFactor(estimate.factor!)} 倍かかっています
-            </p>
+
+          {onChangeDependency && (
+            <div className="px-5 pb-2">
+              <div className="flex items-center gap-2">
+                <span className="font-jp text-[10px] text-fg-weak">依存イベント</span>
+                {editingDep ? (
+                  <select
+                    autoFocus
+                    value={task.dependsOnEventId ?? ""}
+                    onChange={(e) => {
+                      const next = e.target.value === "" ? null : e.target.value;
+                      onChangeDependency(task.id, next);
+                      setEditingDep(false);
+                    }}
+                    onBlur={() => setEditingDep(false)}
+                    className="flex-1 rounded border border-bg-divider bg-bg-elevated px-2 py-1 text-[11px] text-fg-default outline-none focus:border-accent-blue"
+                  >
+                    <option value="">なし</option>
+                    {depCandidates.map((ev) => (
+                      <option key={ev.id} value={ev.id}>
+                        {formatRelativeTime(ev.startTime, nowDate)} {ev.title}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setEditingDep(true)}
+                    className="cursor-pointer rounded-[4px] border border-bg-divider bg-transparent px-2 py-[3px] font-jp text-[10px] text-fg-subtle"
+                  >
+                    {dep ? `${formatRelativeTime(dep.startTime, nowDate)} ${dep.title}` : "なし"}{" "}
+                    を変更
+                  </button>
+                )}
+              </div>
+            </div>
           )}
-        </div>
 
-        {onChangeDependency && (
-          <div className="px-5 pb-2">
-            <div className="flex items-center gap-2">
-              <span className="font-jp text-[10px] text-fg-weak">依存イベント</span>
-              {editingDep ? (
-                <select
-                  autoFocus
-                  value={task.dependsOnEventId ?? ""}
-                  onChange={(e) => {
-                    const next = e.target.value === "" ? null : e.target.value;
-                    onChangeDependency(task.id, next);
-                    setEditingDep(false);
-                  }}
-                  onBlur={() => setEditingDep(false)}
-                  className="flex-1 rounded border border-bg-divider bg-bg-elevated px-2 py-1 text-[11px] text-fg-default outline-none focus:border-accent-blue"
-                >
-                  <option value="">なし</option>
-                  {depCandidates.map((ev) => (
-                    <option key={ev.id} value={ev.id}>
-                      {formatRelativeTime(ev.startTime, nowDate)} {ev.title}
-                    </option>
-                  ))}
-                </select>
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => setEditingDep(true)}
-                  className="cursor-pointer rounded-[4px] border border-bg-divider bg-transparent px-2 py-[3px] font-jp text-[10px] text-fg-subtle"
-                >
-                  {dep ? `${formatRelativeTime(dep.startTime, nowDate)} ${dep.title}` : "なし"}{" "}
-                  を変更
-                </button>
-              )}
+          {onChangeSize && (
+            <div className="px-5 pb-2">
+              <div className="flex items-center gap-2">
+                <span className="font-jp text-[10px] text-fg-weak">サイズ</span>
+                {editingSize ? (
+                  <select
+                    autoFocus
+                    value={task.taskSize ?? ""}
+                    onChange={(e) => {
+                      const raw = e.target.value;
+                      const next = raw === "" ? null : (raw as TaskSize);
+                      if (next !== (task.taskSize ?? null)) {
+                        onChangeSize(task.id, next);
+                      }
+                      setEditingSize(false);
+                    }}
+                    onBlur={() => setEditingSize(false)}
+                    className="flex-1 rounded border border-bg-divider bg-bg-elevated px-2 py-1 text-[11px] text-fg-default outline-none focus:border-accent-blue"
+                  >
+                    <option value="">未設定</option>
+                    {TASK_SIZE_VALUES.map((value) => (
+                      <option key={value} value={value}>
+                        {TASK_SIZE_LABELS[value]}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setEditingSize(true)}
+                    className="cursor-pointer rounded-[4px] border border-bg-divider bg-transparent px-2 py-[3px] font-jp text-[10px] text-fg-subtle"
+                  >
+                    {task.taskSize ? TASK_SIZE_LABELS[task.taskSize] : "未設定"} を変更
+                  </button>
+                )}
+              </div>
             </div>
-          </div>
-        )}
+          )}
 
-        {onChangeSize && (
-          <div className="px-5 pb-2">
-            <div className="flex items-center gap-2">
-              <span className="font-jp text-[10px] text-fg-weak">サイズ</span>
-              {editingSize ? (
-                <select
-                  autoFocus
-                  value={task.taskSize ?? ""}
-                  onChange={(e) => {
-                    const raw = e.target.value;
-                    const next = raw === "" ? null : (raw as TaskSize);
-                    if (next !== (task.taskSize ?? null)) {
-                      onChangeSize(task.id, next);
-                    }
-                    setEditingSize(false);
-                  }}
-                  onBlur={() => setEditingSize(false)}
-                  className="flex-1 rounded border border-bg-divider bg-bg-elevated px-2 py-1 text-[11px] text-fg-default outline-none focus:border-accent-blue"
-                >
-                  <option value="">未設定</option>
-                  {TASK_SIZE_VALUES.map((value) => (
-                    <option key={value} value={value}>
-                      {TASK_SIZE_LABELS[value]}
-                    </option>
-                  ))}
-                </select>
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => setEditingSize(true)}
-                  className="cursor-pointer rounded-[4px] border border-bg-divider bg-transparent px-2 py-[3px] font-jp text-[10px] text-fg-subtle"
-                >
-                  {task.taskSize ? TASK_SIZE_LABELS[task.taskSize] : "未設定"} を変更
-                </button>
-              )}
+          {onChangeProject && (
+            <div className="px-5 pb-2">
+              <div className="flex items-center gap-2">
+                <span className="font-jp text-[10px] text-fg-weak">プロジェクト</span>
+                {editingProject ? (
+                  <select
+                    autoFocus
+                    value={task.projectId || ""}
+                    onChange={(e) => {
+                      const raw = e.target.value;
+                      const next = raw === "" ? null : raw;
+                      setEditingProject(false);
+                      const current = task.projectId === "" ? null : task.projectId;
+                      if (current === next) return; // 同値は no-op
+                      if (projectChangeContext.mode === "single") {
+                        onChangeProject(task.id, next);
+                        return;
+                      }
+                      // 親 / 子: 影響件数を見せる確認 dialog 経由
+                      setPendingProjectChange({
+                        nextProjectId: next,
+                        mode: projectChangeContext.mode,
+                        affectedCount:
+                          projectChangeContext.mode === "with_children"
+                            ? projectChangeContext.affectedChildCount
+                            : projectChangeContext.affectedSiblingCount,
+                      });
+                    }}
+                    onBlur={() => setEditingProject(false)}
+                    className="flex-1 rounded border border-bg-divider bg-bg-elevated px-2 py-1 text-[11px] text-fg-default outline-none focus:border-accent-blue"
+                  >
+                    <option value="">未設定</option>
+                    {projects.map((p) => (
+                      <option key={p.id} value={p.id}>
+                        {p.name}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setEditingProject(true)}
+                    className="cursor-pointer rounded-[4px] border border-bg-divider bg-transparent px-2 py-[3px] font-jp text-[10px] text-fg-subtle"
+                  >
+                    {task.projectId ? proj.name : "未設定"} を変更
+                  </button>
+                )}
+              </div>
             </div>
-          </div>
-        )}
+          )}
 
-        {onChangeCategory && (
-          <div className="px-5 pb-2">
-            <div className="flex items-center gap-2">
-              <span className="font-jp text-[10px] text-fg-weak">タスク種類</span>
-              {editingCategory ? (
-                <select
-                  autoFocus
-                  value={task.taskCategory ?? ""}
-                  onChange={(e) => {
-                    const raw = e.target.value;
-                    const next = raw === "" ? null : (raw as TaskCategory);
-                    if (next !== (task.taskCategory ?? null)) {
-                      onChangeCategory(task.id, next);
-                    }
-                    setEditingCategory(false);
-                  }}
-                  onBlur={() => setEditingCategory(false)}
-                  className="flex-1 rounded border border-bg-divider bg-bg-elevated px-2 py-1 text-[11px] text-fg-default outline-none focus:border-accent-blue"
-                >
-                  <option value="">未分類</option>
-                  {TASK_CATEGORY_VALUES.map((value) => (
-                    <option key={value} value={value}>
-                      {TASK_CATEGORY_LABELS[value]}
-                    </option>
-                  ))}
-                </select>
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => setEditingCategory(true)}
-                  className="cursor-pointer rounded-[4px] border border-bg-divider bg-transparent px-2 py-[3px] font-jp text-[10px] text-fg-subtle"
-                >
-                  {task.taskCategory ? TASK_CATEGORY_LABELS[task.taskCategory] : "未分類"} を変更
-                </button>
-              )}
+          {onChangeCategory && (
+            <div className="px-5 pb-2">
+              <div className="flex items-center gap-2">
+                <span className="font-jp text-[10px] text-fg-weak">タスク種類</span>
+                {editingCategory ? (
+                  <select
+                    autoFocus
+                    value={task.taskCategory ?? ""}
+                    onChange={(e) => {
+                      const raw = e.target.value;
+                      const next = raw === "" ? null : (raw as TaskCategory);
+                      if (next !== (task.taskCategory ?? null)) {
+                        onChangeCategory(task.id, next);
+                      }
+                      setEditingCategory(false);
+                    }}
+                    onBlur={() => setEditingCategory(false)}
+                    className="flex-1 rounded border border-bg-divider bg-bg-elevated px-2 py-1 text-[11px] text-fg-default outline-none focus:border-accent-blue"
+                  >
+                    <option value="">未分類</option>
+                    {TASK_CATEGORY_VALUES.map((value) => (
+                      <option key={value} value={value}>
+                        {TASK_CATEGORY_LABELS[value]}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setEditingCategory(true)}
+                    className="cursor-pointer rounded-[4px] border border-bg-divider bg-transparent px-2 py-[3px] font-jp text-[10px] text-fg-subtle"
+                  >
+                    {task.taskCategory ? TASK_CATEGORY_LABELS[task.taskCategory] : "未分類"} を変更
+                  </button>
+                )}
+              </div>
             </div>
-          </div>
-        )}
+          )}
 
-        {showDecomposeSection && (
-          <DecomposeInfoSection
-            task={task}
-            log={latestDecomposeLog}
-            isLoading={isDecomposeLogLoading ?? false}
-            aiEnabled={aiEnabled}
-            onTriggerDecompose={onTriggerDecompose}
-            onTriggerResplit={onTriggerResplit}
-          />
-        )}
+          {showDecomposeSection && (
+            <DecomposeInfoSection
+              task={task}
+              log={latestDecomposeLog}
+              isLoading={isDecomposeLogLoading ?? false}
+              aiEnabled={aiEnabled}
+              onTriggerDecompose={onTriggerDecompose}
+              onTriggerResplit={onTriggerResplit}
+            />
+          )}
 
-        <div className="mx-5 h-px bg-bg-border" />
+          <div className="mx-5 h-px bg-bg-border" />
 
-        <div className="flex-1 overflow-auto px-5 pb-6 pt-3">
-          {!editing ? (
-            <>
-              <div className="mb-2 flex justify-end gap-2">
-                {onDelete ? (
+          <div className="flex-1 overflow-auto px-5 pb-6 pt-3">
+            {!editing ? (
+              <>
+                <div className="mb-2 flex justify-end gap-2">
+                  {onDelete ? (
+                    <button
+                      onClick={() => {
+                        if (window.confirm("このタスクを削除しますか?")) {
+                          onDelete(task.id);
+                          onClose();
+                        }
+                      }}
+                      className="flex cursor-pointer items-center gap-1 rounded-[4px] border border-bg-divider bg-transparent px-2.5 py-[3px] text-[10px] text-accent-red"
+                    >
+                      削除
+                    </button>
+                  ) : null}
                   <button
                     onClick={() => {
-                      if (window.confirm("このタスクを削除しますか?")) {
-                        onDelete(task.id);
-                        onClose();
-                      }
+                      setDraft(task.body || "");
+                      setEditing(true);
                     }}
-                    className="flex cursor-pointer items-center gap-1 rounded-[4px] border border-bg-divider bg-transparent px-2.5 py-[3px] text-[10px] text-accent-red"
+                    className="flex cursor-pointer items-center gap-1 rounded-[4px] border border-bg-divider bg-transparent px-2.5 py-[3px] text-[10px] text-fg-subtle"
                   >
-                    削除
+                    <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
+                      <path
+                        d="M11.5 1.5L14.5 4.5 5 14H2V11L11.5 1.5Z"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                    編集
                   </button>
-                ) : null}
-                <button
-                  onClick={() => {
-                    setDraft(task.body || "");
-                    setEditing(true);
-                  }}
-                  className="flex cursor-pointer items-center gap-1 rounded-[4px] border border-bg-divider bg-transparent px-2.5 py-[3px] text-[10px] text-fg-subtle"
-                >
-                  <svg width="10" height="10" viewBox="0 0 16 16" fill="none">
-                    <path
-                      d="M11.5 1.5L14.5 4.5 5 14H2V11L11.5 1.5Z"
-                      stroke="currentColor"
-                      strokeWidth="1.5"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                  編集
-                </button>
-              </div>
-              {task.body ? (
-                <div>{renderMarkdown(task.body)}</div>
-              ) : (
-                <div className="py-5 text-center font-jp text-[12px] italic text-fg-faint">
-                  詳細を追加...
                 </div>
-              )}
-            </>
-          ) : (
-            <>
-              <textarea
-                value={draft}
-                onChange={(e) => setDraft(e.target.value)}
-                autoFocus
-                className="min-h-[200px] w-full resize-y rounded-lg border border-bg-divider bg-bg-elevated p-3 font-mono text-[12px] leading-[1.6] text-fg-default outline-none"
-                placeholder="Markdownで詳細を入力..."
-                onFocus={(e) => {
-                  e.target.style.borderColor = proj.color + "60";
-                }}
-                onBlur={(e) => {
-                  e.target.style.borderColor = "#27272a";
-                }}
-              />
-              <div className="mt-2.5 flex justify-end gap-2">
-                <button
-                  onClick={() => setEditing(false)}
-                  className="cursor-pointer rounded-[4px] border border-bg-divider bg-transparent px-3.5 py-1 font-jp text-[10px] text-fg-subtle"
-                >
-                  キャンセル
-                </button>
-                <button
-                  onClick={handleSave}
-                  className="cursor-pointer rounded-[4px] px-3.5 py-1 font-jp text-[10px] font-semibold text-fg-invert"
-                  style={{ background: proj.color }}
-                >
-                  保存
-                </button>
-              </div>
-            </>
-          )}
+                {task.body ? (
+                  <div>{renderMarkdown(task.body)}</div>
+                ) : (
+                  <div className="py-5 text-center font-jp text-[12px] italic text-fg-faint">
+                    詳細を追加...
+                  </div>
+                )}
+              </>
+            ) : (
+              <>
+                <textarea
+                  value={draft}
+                  onChange={(e) => setDraft(e.target.value)}
+                  autoFocus
+                  className="min-h-[200px] w-full resize-y rounded-lg border border-bg-divider bg-bg-elevated p-3 font-mono text-[12px] leading-[1.6] text-fg-default outline-none"
+                  placeholder="Markdownで詳細を入力..."
+                  onFocus={(e) => {
+                    e.target.style.borderColor = proj.color + "60";
+                  }}
+                  onBlur={(e) => {
+                    e.target.style.borderColor = "#27272a";
+                  }}
+                />
+                <div className="mt-2.5 flex justify-end gap-2">
+                  <button
+                    onClick={() => setEditing(false)}
+                    className="cursor-pointer rounded-[4px] border border-bg-divider bg-transparent px-3.5 py-1 font-jp text-[10px] text-fg-subtle"
+                  >
+                    キャンセル
+                  </button>
+                  <button
+                    onClick={handleSave}
+                    className="cursor-pointer rounded-[4px] px-3.5 py-1 font-jp text-[10px] font-semibold text-fg-invert"
+                    style={{ background: proj.color }}
+                  >
+                    保存
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+/**
+ * Issue #171 / ADR 0039: project 変更時の伝播確認 dialog。
+ * 親 (子あり) または子 (兄弟あり) のときだけ呼び出される。単独タスクは dialog なしで即発火 (UX 軽さ優先)。
+ *
+ * 文言:
+ * - with_children          : 「N 件の子タスクも「{toName}」に移動します」 (件数のみ表示、タイトル列挙はしない)
+ * - with_siblings_and_parent: 「親タスクと N 件の兄弟タスクも「{toName}」に移動します」
+ *
+ * 表示は from / to を縦並び (project 名が長い可能性に備えた判断、issue #171 で確定)。
+ */
+function ProjectChangeConfirmDialog({
+  taskTitle,
+  fromName,
+  toName,
+  mode,
+  affectedCount,
+  onCancel,
+  onConfirm,
+}: {
+  taskTitle: string;
+  fromName: string;
+  toName: string;
+  mode: "with_children" | "with_siblings_and_parent";
+  affectedCount: number;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const cascadeMessage =
+    mode === "with_children"
+      ? `このタスクは親タスクです。${affectedCount} 件の子タスクも「${toName}」に移動します。`
+      : `親タスクと ${affectedCount} 件の兄弟タスクも「${toName}」に移動します。`;
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="プロジェクト変更の確認"
+      className="fixed inset-0 z-[300] flex items-center justify-center"
+    >
+      <div onClick={onCancel} className="absolute inset-0 bg-black/70 backdrop-blur-[4px]" />
+      <div className="relative mx-5 max-w-[360px] rounded-lg bg-bg-surface p-5 shadow-2xl">
+        <h3 className="mb-3 font-jp text-[13px] font-semibold text-fg-strong">
+          プロジェクトを変更しますか?
+        </h3>
+        <p className="mb-3 font-jp text-[11px] leading-[1.5] text-fg-default">「{taskTitle}」</p>
+        <div className="mb-3 flex flex-col items-center gap-1 rounded border border-bg-divider bg-bg-elevated px-3 py-2 font-jp text-[11px] text-fg-default">
+          <span>{fromName}</span>
+          <span aria-hidden="true" className="text-fg-faint">
+            ↓
+          </span>
+          <span className="font-semibold">{toName}</span>
+        </div>
+        <p className="mb-4 font-jp text-[11px] leading-[1.5] text-fg-subtle">{cascadeMessage}</p>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="cursor-pointer rounded-[4px] border border-bg-divider bg-transparent px-3 py-[5px] font-jp text-[11px] text-fg-subtle"
+          >
+            キャンセル
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="cursor-pointer rounded-[4px] bg-accent-blue px-3 py-[5px] font-jp text-[11px] font-semibold text-fg-invert"
+          >
+            変更する
+          </button>
         </div>
       </div>
     </div>

--- a/src/shared/types/database.ts
+++ b/src/shared/types/database.ts
@@ -383,6 +383,24 @@ export type Database = {
         };
         Returns: Json;
       };
+      // ADR 0039 / Issue #171: 親 task の project_id 変更を全子に atomic 伝播する。
+      // 戻り値は影響を受けた task id 配列 (親自身 + 全子)。
+      fn_update_task_project_with_children: {
+        Args: {
+          p_task_id: string;
+          p_new_project_id: string | null;
+        };
+        Returns: string[];
+      };
+      // ADR 0039 / Issue #171: 子 task の project_id 変更を親と全兄弟に atomic 伝播する。
+      // 戻り値は影響を受けた task id 配列 (target 子 + 親 + 全兄弟)。
+      fn_update_task_project_with_siblings_and_parent: {
+        Args: {
+          p_task_id: string;
+          p_new_project_id: string | null;
+        };
+        Returns: string[];
+      };
     };
     Enums: {
       task_status: "idle" | "active" | "paused" | "done";

--- a/supabase/migrations/20260504020000_p3_171_task_project_cascade_fns.sql
+++ b/supabase/migrations/20260504020000_p3_171_task_project_cascade_fns.sql
@@ -1,0 +1,153 @@
+-- kozutsumi Phase 3 派生 (issue #171 / ADR 0039): tasks.project_id の親-子-兄弟伝播 RPC を追加
+--
+-- References:
+-- * docs/adr/0039-task-project-edit-and-cascade.md
+--   ADR-0039 が決めた伝播ルールを atomic に実装する:
+--     - 親の project_id を変更 → 同じ parent_task_id を持つ全子も同じ project_id に
+--     - 子の project_id を変更 → 親と同じ parent_task_id を持つ全兄弟も同じ project_id に
+--     - 単独タスクは当該行のみ (RPC ではなく既存の update 経路で十分なので扱わない)
+-- * docs/adr/0036-simplify-task-registration-workflow.md (シンプル世界観: 後から修正できる前提)
+-- * docs/adr/0019-db-migration-via-manual-github-actions.md / 0020 (本番適用は手動 workflow)
+-- * supabase/migrations/20260503000000_p3_decompose_parent_task_fn.sql
+--   (fn_decompose_parent_task と同じ security invoker + atomic update パターン)
+--
+-- 設計判断:
+-- - RPC を 2 本に分ける (1 本に内部判定で寄せない)。
+--   呼び出し側 (frontend) で親/子/単独の判定 + 影響件数の事前計算を確認 dialog に出す
+--   ため、入口を分けたほうが UI 側の責任分解がきれい (ADR-0039 Notes 「視認性は実装の関心」)。
+-- - 戻り値は影響を受けた task id 配列。呼び出し側はこれを action_log の
+--   `affected_task_ids` payload (1 操作 = 1 ログ + 範囲) に詰めて Phase 4 学習素材化する。
+-- - action_logs への記録は呼び出し側 (useDashboardMutations) で行う。RPC 内で log すると
+--   失敗時のロールバック範囲が広がり、楽観更新と整合させづらい (fn_decompose_parent_task と同じ方針)。
+
+-- =====================================================================
+-- fn_update_task_project_with_children
+-- =====================================================================
+--
+-- 引数:
+--   p_task_id          : 親タスクの id (parent_task_id is null である前提)
+--   p_new_project_id   : 新しい project_id (null で「未指定」)
+--
+-- 戻り値:
+--   uuid[]             : 影響を受けた task id 配列 (親自身 + 全子)
+--
+-- 想定呼び出し: target が親 (parent_task_id is null) かつ子が 1 件以上居る場合のみ。
+-- target が単独 (子なし) の場合は呼び出し側で update 経路に倒すこと。
+-- target が子 (parent_task_id not null) を渡されたら例外で弾く (ガード)。
+
+create or replace function public.fn_update_task_project_with_children(
+  p_task_id uuid,
+  p_new_project_id uuid
+) returns uuid[]
+language plpgsql
+security invoker
+set search_path = public, pg_temp
+as $$
+declare
+  v_user_id uuid;
+  v_parent_task_id uuid;
+  v_affected uuid[] := '{}';
+begin
+  -- 1. target row を読む (RLS で別 user は 0 行 → v_user_id is null)
+  select user_id, parent_task_id
+    into v_user_id, v_parent_task_id
+    from public.tasks
+   where id = p_task_id;
+
+  if v_user_id is null then
+    raise exception 'fn_update_task_project_with_children: target task not found or not authorized: %', p_task_id;
+  end if;
+
+  -- 2. ガード: target は親 (parent_task_id is null) であること
+  if v_parent_task_id is not null then
+    raise exception 'fn_update_task_project_with_children: target must be a parent task (parent_task_id is null), got %', p_task_id;
+  end if;
+
+  -- 3. 親自身 + 全子 (parent_task_id = p_task_id) を 1 文で update し、影響 id を回収
+  with updated as (
+    update public.tasks
+       set project_id = p_new_project_id
+     where id = p_task_id
+        or parent_task_id = p_task_id
+     returning id
+  )
+  select array_agg(id) into v_affected from updated;
+
+  return v_affected;
+end;
+$$;
+
+comment on function public.fn_update_task_project_with_children(uuid, uuid) is
+  'Issue #171 / ADR 0039: 親 task の project_id 変更を全子に atomic 伝播する。security invoker (RLS 適用)。';
+
+-- =====================================================================
+-- fn_update_task_project_with_siblings_and_parent
+-- =====================================================================
+--
+-- 引数:
+--   p_task_id          : 子タスクの id (parent_task_id is not null である前提)
+--   p_new_project_id   : 新しい project_id (null で「未指定」)
+--
+-- 戻り値:
+--   uuid[]             : 影響を受けた task id 配列 (target 子 + 親 + 全兄弟)
+--
+-- 想定呼び出し: target が子 (parent_task_id not null) の場合のみ。
+-- target が親 / 単独を渡されたら例外で弾く (ガード)。
+
+create or replace function public.fn_update_task_project_with_siblings_and_parent(
+  p_task_id uuid,
+  p_new_project_id uuid
+) returns uuid[]
+language plpgsql
+security invoker
+set search_path = public, pg_temp
+as $$
+declare
+  v_user_id uuid;
+  v_parent_id uuid;
+  v_affected uuid[] := '{}';
+begin
+  -- 1. target row を読む
+  select user_id, parent_task_id
+    into v_user_id, v_parent_id
+    from public.tasks
+   where id = p_task_id;
+
+  if v_user_id is null then
+    raise exception 'fn_update_task_project_with_siblings_and_parent: target task not found or not authorized: %', p_task_id;
+  end if;
+
+  -- 2. ガード: target は子 (parent_task_id is not null) であること
+  if v_parent_id is null then
+    raise exception 'fn_update_task_project_with_siblings_and_parent: target must be a child task (parent_task_id is not null), got %', p_task_id;
+  end if;
+
+  -- 3. 親 + 同じ parent_task_id を持つ全行 (target 子 + 全兄弟) を一括 update。
+  --    1 文で id = v_parent_id OR parent_task_id = v_parent_id を update することで、
+  --    親と兄弟を 1 トランザクション内の 1 文で揃える。
+  with updated as (
+    update public.tasks
+       set project_id = p_new_project_id
+     where id = v_parent_id
+        or parent_task_id = v_parent_id
+     returning id
+  )
+  select array_agg(id) into v_affected from updated;
+
+  return v_affected;
+end;
+$$;
+
+comment on function public.fn_update_task_project_with_siblings_and_parent(uuid, uuid) is
+  'Issue #171 / ADR 0039: 子 task の project_id 変更を親と全兄弟に atomic 伝播する。security invoker (RLS 適用)。';
+
+-- =====================================================================
+-- 権限
+-- =====================================================================
+--
+-- ADR-0039 / 既存 RPC (fn_decompose_parent_task / fn_resplit_child_task) と揃え、
+-- authenticated ロールにのみ execute を許可。anon には grant しない。
+-- security invoker なので RLS は呼び出し元の auth.uid() 一致で効く (kozutsumi の Phase 1 方針 / ADR 0001)。
+
+grant execute on function public.fn_update_task_project_with_children(uuid, uuid) to authenticated;
+grant execute on function public.fn_update_task_project_with_siblings_and_parent(uuid, uuid) to authenticated;


### PR DESCRIPTION
## 概要 (What)

タスク詳細パネルから project を編集できるようにし、ADR-0039 の伝播ルール（親 → 全子 / 子 → 親 + 全兄弟）を atomic に実装する。

## 関連 Issue

Closes #171

## 背景 (Why)

- ADR-0039 で「project は登録時任意にし、後から修正できる + 親-子-兄弟で伝播する」と決めたが、編集経路が未実装で gateway の `UpdateTaskInput.projectId` が dead path 化していた
- 親登録時に project をミスすると `fn_decompose_parent_task` 経由で生成された子が誤った project を継承し、復旧手段が「1 件ずつ手動編集」しかなかった
- ADR-0039 の不変条件「親と子で project は乖離させない」を UI 操作レベルで担保する必要がある

参照: [ADR-0039](../blob/main/docs/adr/0039-task-project-edit-and-cascade.md) / [ADR-0036](../blob/main/docs/adr/0036-simplify-task-registration-workflow.md) / [ADR-0035](../blob/main/docs/adr/0035-action-log-payload-schema-and-actor-type.md) §2 (i)

## Before → After (概念・フロー・メンタルモデル)

**Before:**

- TaskDetailPanel に project 編集 UI なし
- 親 project ミス → 子が誤った project で量産 → 1 件ずつ手で直す
- 行動ログ: project 変更操作のシグナルが存在しない

**After:**

- TaskDetailPanel から project 編集可。単独 / 親 / 子の 3 経路で挙動が変わる
  - 単独タスク: dialog なしで即変更
  - 親 (子あり) / 子: 影響件数を見せる確認 dialog 経由 → 確定で atomic に伝播
- 「親と子で project は揃う」をユーザー操作レベルで保証 (dialog で「N 件の子も移動します」と明示)
- action_log: 1 操作 = 1 ログ (`task_project_changed`) + payload に `propagation` / `affected_task_ids`
  - Phase 4 で「1 操作 → N 行更新」を 1 ログから再構成可能 (ADR-0035 §2 i 準拠、`triggered_by` で N ログにしない)

## 追加したテスト (How verified)

- [x] unit: TaskDetailPanel.test.tsx — project 編集 UI / 単独 / 親 (with_children) / 子 (with_siblings_and_parent) / 同値 no-op / dialog cancel (11 ケース追加、計 73 pass)
- [x] unit: action-log/logger.test.ts — `TASK_PROJECT_CHANGED` を ACTION_TYPES に組み込んだ
- [x] e2e: task-project-edit.spec.ts — 単独 / 親→子 / 子→兄弟+親 / cancel の 4 ケース。DB の project_id と action_log payload の `propagation` / `affected_task_ids` を assert
- [x] `npm run check` (format / lint / typecheck / 592 unit tests) all green

カバーできていない領域:
- 親が `decompose_status='decomposed'` のときの編集導線（Stack に親が出ない）。本 PR では `decompose_status='none'` の親で e2e カバー。実運用での「decomposed 親の project 編集」は別 issue で導線（子バッジ → 親詳細へ）を整備したら追加する

## リリース前チェックリスト (When / Before merge)

- [ ] **#187 (preview env 分離) のマージ + 本ブランチへの取り込み**。preview deploy で migration + frontend を 1 PR で動作確認するために必要
- [ ] 本番 DB に migration を ADR-0019 の手動 GitHub Actions 経由で先に適用してから merge する（merge 直後の prod deploy で frontend が `fn_update_task_project_with_children` を呼ぶため、後付け適用だと一時的に function not found エラーになる）
- [ ] preview deploy で 3 経路 (単独 / 親 / 子) を実機確認

## このPRの範囲外 (Out of scope)

- TaskForm 登録時の project 任意化 — #170 で実装済み
- `decompose_status='decomposed'` 親への編集導線（子から親詳細を開く UI 等） — 別 issue
- project マスタ自体の追加 / 削除 / リネーム — 既存の ProjectDetailPanel 経路で対応済み
- 親と子で project が異なる状態を許容する設計 — ADR-0039 で棄却済み（supersede が必要）


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxpCLkksxWQBzvaHnSM8Zv)_