### PR TITLE
feat(task-stack): estimated_minutes 不在時に task_size を主観ラベルとして添える (Closes #182)

### DIFF
--- a/docs/adr/0045-subjective-size-display-without-estimated-minutes.md
+++ b/docs/adr/0045-subjective-size-display-without-estimated-minutes.md
@@ -1,0 +1,65 @@
+# ADR 0045: `estimated_minutes` 不在時に `task_size` を主観ラベルとして添える
+
+- **Status**: Accepted
+- **Date**: 2026-05-04
+- **Related**: [ADR-0026](./0026-estimation-correction-display-style.md) / [ADR-0038](./0038-task-size-enum.md) / [ADR-0036](./0036-simplify-task-registration-workflow.md) / [ADR-0024](./0024-estimation-correction-by-category-median.md) / Issue #182 / Issue #170 / PR #181
+
+## Context
+
+[ADR-0036](./0036-simplify-task-registration-workflow.md) と [ADR-0038](./0038-task-size-enum.md) で「主観サイズ (`task_size`)」と「AI 推定の `estimated_minutes`」を別軸で並存させる方針を確定した。これにより TaskForm は `task_size` のみを必須入力とし、`estimated_minutes` は AI 分解時にのみ入る経路になった (#170 / PR #181)。
+
+その結果、**AI 分解が `skipped` / `failed` で親が残るケース** (= 短文単発タスク / AI が「分解不要」と判断したケース) では、親 task は `task_size` だけを持ち `estimated_minutes` は null になる。Stack View / 詳細パネルの見積もり表示は [ADR-0024](./0024-estimation-correction-by-category-median.md) 〜 [ADR-0026](./0026-estimation-correction-display-style.md) のラインで `estimated_minutes` を入力に動くため、**この経路で時間情報が UI から完全に消える** regression が入る (Issue #182)。
+
+短文単発タスクは「ユーザーが登録して上から順にやる」default 経路 ([ADR-0036](./0036-simplify-task-registration-workflow.md)) の中核ケースであり、Stack でこのカードに時間情報がゼロだと「次に何分くらい使うか」の感触が掴めない。Phase 4 行動分析の素材としても、ユーザーが Stack 上で時間感を持って意思決定できることが前提になる。
+
+[ADR-0038](./0038-task-size-enum.md) は「主観値を分単位の代表値に倒すのは限定的な場面のみ (例: TaskForm の初期値提示)」と明記しており、Stack View で安易に `TASK_SIZE_TO_MINUTES` で分換算するのは精神に反する。また `large` は代表分が null のため分換算戦略では `large` のときだけ表示が消える歪みも残る。
+
+「`estimated_minutes` 不在 + `task_size` あり」のときに UI でどう見せるかを、[ADR-0026](./0026-estimation-correction-display-style.md) (補正対象数値の併記) とは別判断として確定する必要がある。
+
+## Decision
+
+`estimated_minutes` が null かつ `task_size` が non-null のとき、Stack View カード (Top / Row) と詳細パネルヘッダで **`task_size` の表示ラベル (`30分` / `半日` / `1日超` 等) を主観値として添える**。分単位への換算 (`TASK_SIZE_TO_MINUTES` 経由) は使わない。
+
+- 視覚階層は `fg-faint` 相当 (= [ADR-0026](./0026-estimation-correction-display-style.md) で「補正なし」のときの元値表示と同じ階層)。補正対象の数値より一段控えめに置く
+- `task_size` ラベルは `TASK_SIZE_LABELS` の和文 (例: `30分` / `半日` / `1日超`) をそのまま出す。「主観」「目安」等のラベルは付けない ([ADR-0026](./0026-estimation-correction-display-style.md) のラベル無し原則を継承)
+- 詳細パネルのヘッダ自然文ライン (`あなたの見積もり N min ・ 同じ種類のタスクは平均 X 倍...`) は出さない (補正対象ではないため、自然文を出すと文意が破綻する)
+- `estimated_minutes` も `task_size` も null のときは何も出さない (従来通り)
+
+優先順は:
+
+1. 補正適用ケース (`estimated_minutes` あり + 補正条件成立): 補正後 + 元値の併記 ([ADR-0026](./0026-estimation-correction-display-style.md))
+2. 補正なしケース (`estimated_minutes` あり + 補正条件不成立): 元値のみ `fg-faint` ([ADR-0026](./0026-estimation-correction-display-style.md))
+3. **本 ADR の対象** (`estimated_minutes` null + `task_size` あり): `task_size` ラベルを `fg-faint`
+4. どちらも null: 何も出さない
+
+## Consequences
+
+### 肯定的影響
+
+- 短文単発タスクの Stack カードで時間感が消える regression が解消する。default 経路 ([ADR-0036](./0036-simplify-task-registration-workflow.md)) の中核ケースを救える
+- 主観値を分換算しないことで [ADR-0038](./0038-task-size-enum.md) の「主観と推定は別軸」の精神を UI 側でも貫ける。ラベル文言 (`30分` / `半日`) が分換算の数値と異なる文字種を持つため、ユーザーが「これは AI 推定ではなく自分が選んだ主観値」だと潜在的に区別できる
+- `large` (代表分 null) も `1日超` ラベルでそのまま表示できる。分換算戦略にあった「large だけ表示が消える」歪みが出ない
+- 補正対象の数値表示 ([ADR-0026](./0026-estimation-correction-display-style.md)) と表示位置・色階層を揃えるため、実装の差分は小さい (CorrectedEstimate 相当の helper を 1 枚足す程度)
+
+### 否定的影響・トレードオフ
+
+- Stack View 内に「分単位の数値」と「主観ラベル文字列」が混在する。`30min` (補正後) と `30分` (主観) のような近接表示が起きうるが、フォント・色・文字種で階層が出るので区別はつく想定
+- 主観ラベルは補正の対象ではないので、ユーザーから見ると「AI が補正していない時間表示」が混じる体験になる。ただし [ADR-0026](./0026-estimation-correction-display-style.md) の「補正の存在を明言しない」原則により、ユーザーが意識的に補正の有無を見ることはない
+- `task_size` を後から `estimated_minutes` に昇格させる (= AI 推定が後追いで入る) パスは現状の AI 分解では発生しない。将来 [Issue #173](https://github.com/y-oga-819/kozutsumi/issues/173) (秘書からの相談 mode) 等で「主観値を AI が時間値に翻訳する」経路が入る場合、本 ADR の判断と再整合が必要になる
+
+## Alternatives considered
+
+- **案 A (採用): `task_size` ラベルを主観値として添える** — 上記 Decision
+- **案 B: `TASK_SIZE_TO_MINUTES[size]` で分に倒して `fmtDuration` で表示** — Stack 表示が分単位に統一される利点はあるが、(1) [ADR-0038](./0038-task-size-enum.md) の「主観を分換算するのは限定的場面のみ」の精神に反する、(2) 主観値と補正後数値が同じ文字種 (`30分`) で並び区別不能になる、(3) `large` は代表分 null のため `large` だけ表示が消える歪みが残る。**不採用**
+- **案 C: 何も出さない (現状維持)** — regression を維持する選択。default 経路の中核ケースで時間感が消える体験悪化を許容することになり、[ADR-0036](./0036-simplify-task-registration-workflow.md) のシンプル化方針と矛盾する。**不採用**
+- **案 D: TaskForm submit 時に `task_size` を `estimated_minutes` に倒して書き込む** — [ADR-0038](./0038-task-size-enum.md) で明示的に棄却済み (主観と推定が同じ列に混ざり Phase 4 行動分析が分離不能になる)。本 ADR の対象範囲ではない
+
+## Notes
+
+- ラベル文言の決定は [ADR-0038](./0038-task-size-enum.md) Notes で「`large` の表示文言は実装で詰める」とされていた箇所が `TASK_SIZE_LABELS` (= `1日超`) として既に確定している。本 ADR でその選定をやり直しはしない
+- 補正後数値との視覚階層 (フォントサイズ・色) の具体トークンは実装の関心であり、本 ADR の supersede ではない
+- 本 ADR を supersede する trigger:
+  - 主観値も補正エンジン ([ADR-0024](./0024-estimation-correction-by-category-median.md)) の入力に取り込む方針に変える
+  - 主観値を分換算して `estimated_minutes` に倒す方針に変える ([ADR-0038](./0038-task-size-enum.md) の supersede と一体)
+  - 「補正の存在を明言しない」原則 ([ADR-0026](./0026-estimation-correction-display-style.md)) を覆す
+- dogfooding 観察項目: 主観ラベルと補正後数値が並んだときに「AI 推定じゃない」と読み取れるか、ラベル文字列の存在感が強すぎないか。観察結果次第で、装飾 (色トーンの細分化 / 「主観」プレフィックス) を別 issue で詰める余地を残す

--- a/src/features/task-detail/TaskDetailPanel.tsx
+++ b/src/features/task-detail/TaskDetailPanel.tsx
@@ -223,6 +223,12 @@ export function TaskDetailPanel({
                 <span aria-label="見積もり" className="text-[9px] tabular-nums text-fg-faint">
                   {fmtDuration(estimate.rawMinutes)}
                 </span>
+              ) : task.taskSize ? (
+                // ADR 0045: estimated_minutes 不在 + task_size あり → 主観ラベルを fg-faint で添える。
+                // 自然文ライン (「あなたの見積もり ... 平均 X 倍」) は補正対象でないため出さない。
+                <span aria-label="サイズ" className="text-[9px] text-fg-faint">
+                  {TASK_SIZE_LABELS[task.taskSize]}
+                </span>
               ) : null}
               {dep && (
                 <span className="rounded-[3px] bg-[#E85D0415] px-1.5 py-px font-jp text-[9px] text-accent-amber">

--- a/src/features/task-stack/CorrectedEstimate.test.tsx
+++ b/src/features/task-stack/CorrectedEstimate.test.tsx
@@ -13,9 +13,28 @@ import { CorrectedEstimate } from "./CorrectedEstimate";
  */
 
 describe("CorrectedEstimate", () => {
-  test("estimate=null のときは何も描画しない", () => {
+  test("estimate=null かつ taskSize 無しのときは何も描画しない", () => {
     const { container } = render(<CorrectedEstimate estimate={null} variant="top" />);
     expect(container.firstChild).toBeNull();
+  });
+
+  test("ADR 0045: estimate=null + task_size あり → 主観ラベルを faint で添える", () => {
+    const { getByText, getByLabelText } = render(
+      <CorrectedEstimate estimate={null} taskSize="30m" variant="top" />,
+    );
+    // TASK_SIZE_LABELS の和文ラベル (分換算ではなく文字種で主観値を区別)
+    expect(getByText("30分")).toBeTruthy();
+    // 視覚階層: fg-faint
+    expect(getByLabelText("サイズ").className).toMatch(/text-fg-faint/);
+    // 主観値は分換算しない (ADR 0038 の精神)
+    expect(getByLabelText("サイズ").className).not.toMatch(/tabular-nums/);
+  });
+
+  test("ADR 0045: large は『1日超』ラベルで表示される (代表分 null でも消えない)", () => {
+    const { getByText } = render(
+      <CorrectedEstimate estimate={null} taskSize="large" variant="top" />,
+    );
+    expect(getByText("1日超")).toBeTruthy();
   });
 
   test("補正なしは元値だけを faint で出す (現行 UI 後退無し)", () => {

--- a/src/features/task-stack/CorrectedEstimate.tsx
+++ b/src/features/task-stack/CorrectedEstimate.tsx
@@ -1,4 +1,6 @@
 import type { CorrectedEstimate as CorrectedEstimateValue } from "@/entities/task/correction";
+import { TASK_SIZE_LABELS } from "@/entities/task/task-size";
+import type { TaskSize } from "@/entities/task/types";
 import { fmtDuration } from "@/shared/lib/time";
 
 /**
@@ -6,7 +8,10 @@ import { fmtDuration } from "@/shared/lib/time";
  *
  * - 補正後を主表示 / 元値を muted で副表示。ラベル・取消線・矢印は使わない (ADR 0026)。
  * - 補正なし (`correctedMinutes === null`) は元値だけを既存と同じ trim で出す。
- * - `estimate === null` (元値も無い) は何も描画しない (caller は条件分岐不要)。
+ * - `estimate === null` でも `taskSize` があれば、ADR 0045 の方針で主観サイズラベル
+ *   (`TASK_SIZE_LABELS[taskSize]`) を fg-faint で添える。分換算 (`TASK_SIZE_TO_MINUTES`)
+ *   は使わず、文字種 (`30分` / `半日` / `1日超`) で主観値であることを潜在的に区別させる。
+ * - `estimate === null` かつ `taskSize` も無いときは何も描画しない。
  *
  * 区切り記号は ADR 0026 の方針に従い middle dot `·` を採用。
  *
@@ -16,15 +21,30 @@ import { fmtDuration } from "@/shared/lib/time";
  */
 type Props = {
   estimate: CorrectedEstimateValue | null;
+  /**
+   * estimated_minutes 不在時の主観サイズ fallback (ADR 0045)。
+   * `estimate === null` のときだけ参照され、non-null なら主観ラベルを fg-faint で出す。
+   */
+  taskSize?: TaskSize | null;
   variant: "top" | "row";
 };
 
-export function CorrectedEstimate({ estimate, variant }: Props) {
-  if (estimate === null) return null;
-
+export function CorrectedEstimate({ estimate, taskSize, variant }: Props) {
   const mainSizeClass = variant === "top" ? "text-[10px]" : "text-[9px]";
   // 元値は併記時に一段小さく出して階層を作る (ADR 0026: 大小コントラスト)。
   const rawSizeClass = variant === "top" ? "text-[9px]" : "text-[8px]";
+
+  if (estimate === null) {
+    // ADR 0045: estimated_minutes 不在 + task_size あり → 主観ラベルを fg-faint で添える。
+    if (taskSize) {
+      return (
+        <span aria-label="サイズ" className={`${mainSizeClass} text-fg-faint`}>
+          {TASK_SIZE_LABELS[taskSize]}
+        </span>
+      );
+    }
+    return null;
+  }
 
   if (estimate.correctedMinutes === null) {
     // 補正なし: 元値だけ、従来通り faint で表示する (UI 後退無し)。

--- a/src/features/task-stack/TaskRow.tsx
+++ b/src/features/task-stack/TaskRow.tsx
@@ -105,7 +105,9 @@ export function TaskRow({
           style={{ background: proj.color }}
         />
         <span className="flex-1 truncate font-jp text-[12px] text-fg-muted">{task.title}</span>
-        {estimate && <CorrectedEstimate estimate={estimate} variant="row" />}
+        {(estimate || task.taskSize) && (
+          <CorrectedEstimate estimate={estimate} taskSize={task.taskSize} variant="row" />
+        )}
       </div>
       {/* Row 2: dep event (右詰) */}
       {dep && (

--- a/src/features/task-stack/TopTaskCard.tsx
+++ b/src/features/task-stack/TopTaskCard.tsx
@@ -143,9 +143,9 @@ export function TopTaskCard({
                 中断: {pauseReasonLabel(pauseReason)}
               </span>
             )}
-            {estimate && (
+            {(estimate || task.taskSize) && (
               <span className="ml-auto">
-                <CorrectedEstimate estimate={estimate} variant="top" />
+                <CorrectedEstimate estimate={estimate} taskSize={task.taskSize} variant="top" />
               </span>
             )}
           </div>


### PR DESCRIPTION
## 概要 (What)

`estimated_minutes` 不在 + `task_size` あり時に Stack View / 詳細パネルで時間情報が消える regression を解消。`TASK_SIZE_LABELS` の和文 (`30分` / `半日` / `1日超`) を `fg-faint` で添える。

## 関連 Issue

Closes #182

## 背景 (Why)

[ADR-0036](../blob/main/docs/adr/0036-simplify-task-registration-workflow.md) / [ADR-0038](../blob/main/docs/adr/0038-task-size-enum.md) で「`task_size` 必須・`estimated_minutes` は AI 分解時のみ」になった結果、AI 分解が `skipped` / `failed` で親が残る短文単発タスクで、Stack カード / 詳細パネルから時間情報が完全に消える regression が #170 / PR #181 で入った。

短文単発タスクは default 経路 (登録 → 上から順にやる) の中核ケースで、Stack に時間感がゼロだと「次に何分くらい使うか」が掴めず体験悪化。

判断は [ADR-0045](../blob/main/docs/adr/0045-subjective-size-display-without-estimated-minutes.md) (新規) で確定:
- **採用**: 案 A (主観ラベルを `fg-faint` で添える、分換算しない)
- **棄却**: 案 B (`TASK_SIZE_TO_MINUTES` で分換算) — ADR 0038 の「主観を分換算するのは限定場面のみ」の精神に反する。`large` (代表分 null) の表示も消える歪みあり
- **棄却**: 案 C (現状維持) — regression 維持

## Before → After (概念・フロー・メンタルモデル)

**Before:**
時間情報の表示は `estimated_minutes` 軸の 1 系統。`null` なら何も出さない。

```
estimated_minutes あり + 補正条件成立 → 補正後 · 元値 (ADR 0026)
estimated_minutes あり + 補正条件不成立 → 元値 (faint)
estimated_minutes null → 何も出さない ← 短文単発で時間感が消える
```

**After:**
主観値 `task_size` が fallback として加わる。優先順は補正対象 > 元値 > 主観ラベル > 何もなし。

```
estimated_minutes あり + 補正条件成立 → 補正後 · 元値 (ADR 0026)
estimated_minutes あり + 補正条件不成立 → 元値 (faint)
estimated_minutes null + task_size あり → 主観ラベル (faint, ADR 0045)
両方 null → 何も出さない
```

文字種 (`30min` vs `30分` / `半日` / `1日超`) で「これは AI 推定ではなく自分が選んだ主観値」とユーザーが潜在的に区別できる。詳細パネルの自然文ライン (「あなたの見積もり... 平均 X 倍」) は補正対象でない場合は出さない (ADR 0026 の文意整合)。

## 追加したテスト (How verified)

- [x] `CorrectedEstimate.test.tsx`: `estimate=null` + `taskSize` あり時に `30分` ラベルが `fg-faint` で出ること、`tabular-nums` を持たないこと、`large` が `1日超` で消えないことを踏む
- [x] 既存 594 unit tests green (補正パスは無変更)
- [x] typecheck / lint / prettier 全て通過
- [ ] preview deploy で手動確認 (TaskForm から `task_size=30m` で短文タスクを登録し、AI 分解 `skipped` 後の親が Stack / 詳細パネルで `30分` を出すこと)

## リリース前チェックリスト (When / Before merge)

- [x] ドキュメント (ADR 0045) を追加した
- 他は該当なし

## このPRの範囲外 (Out of scope)

- 主観ラベルと補正後数値が並んだ時の装飾調整 (色トーン細分化 / 「主観」プレフィックス) — dogfooding 観察後に別 issue で詰める (ADR 0045 Notes)
- 主観値の AI 翻訳経路 ([Issue #173](https://github.com/y-oga-819/kozutsumi/issues/173) 秘書から相談 mode 等) — 将来 supersede 候補として ADR 0045 Notes に記載
- 184/185 (reorder atomic RPC) — 別セッション・別 PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01AmTA5B371dMWXitGdmC2Xe)_