### PR TITLE
fix(db): public.* から anon の暗黙 GRANT を REVOKE する (Closes #202)

### DIFF
--- a/supabase/migrations/20260505010000_revoke_anon_grants_on_public_tables.sql
+++ b/supabase/migrations/20260505010000_revoke_anon_grants_on_public_tables.sql
@@ -24,6 +24,15 @@
 -- * **default privileges は 2 ロール分**。本番では `pg_default_acl` の granting role が
 --   `postgres` と `supabase_admin` の両方に anon entry を持っているため、両方 REVOKE する。
 --   preview / 新規 project では両 entry が無いので no-op。
+-- * **supabase_admin の REVOKE は権限不足を許容する**。`ALTER DEFAULT PRIVILEGES FOR ROLE X`
+--   は実行 role が X の member であることを要求する。新しめの Supabase template では
+--   migration 実行 role (postgres) が supabase_admin の member ではなく、preview / 新規 project で
+--   `permission denied to change default privileges (42501)` で失敗する (本 migration の preview 適用で
+--   実例を踏んだ)。preview / 新規 project には supabase_admin の anon entry がそもそも無いため、
+--   実体的な不整合は発生しない (skip 安全)。
+--   本番は legacy template で `postgres` が `supabase_admin` の member である可能性が高いが、
+--   仮に member でなければ silent skip するため、適用後の `\dp` 検証で `anon` 行が
+--   消えているか必ず確認する (ADR-0019 の手動 workflow + 事前 / 事後比較で担保)。
 -- * **本番への適用は ADR-0019 の手動 workflow 経由**。事前に `\dp public.<table>` で anon GRANT が
 --   存在することを確認してから適用、適用後に anon 行が消えていることを検証する。
 -- * **anon REVOKE は authenticated / postgres / service_role 経路に影響しない**。それぞれ
@@ -59,5 +68,16 @@ revoke all on
 alter default privileges for role postgres in schema public
   revoke all on tables from anon;
 
-alter default privileges for role supabase_admin in schema public
-  revoke all on tables from anon;
+-- supabase_admin 分は権限不足を許容する (上記設計判断ノート参照)。
+-- 本番で postgres が supabase_admin の member なら REVOKE が効き、そうでなければ silent skip。
+-- 適用後の `\dp public.*` / `pg_default_acl` 検証で実効を確認する。
+do $$
+begin
+  alter default privileges for role supabase_admin in schema public
+    revoke all on tables from anon;
+  raise notice 'Revoked anon default privileges on supabase_admin in schema public.';
+exception
+  when insufficient_privilege then
+    raise notice 'Skipped supabase_admin default privileges REVOKE: migration role lacks membership. Verify post-apply via pg_default_acl.';
+end;
+$$;

--- a/supabase/migrations/20260505010000_revoke_anon_grants_on_public_tables.sql
+++ b/supabase/migrations/20260505010000_revoke_anon_grants_on_public_tables.sql
@@ -21,18 +21,16 @@
 --   defense-in-depth が崩れる経路がある。table-level でも anon を弾く。
 -- * **idempotent**。REVOKE は重複実行しても no-op。preview / 新規 project では既に anon GRANT が
 --   無いので何も変化しない (本番のみ実体変化)。
--- * **default privileges は 2 ロール分**。本番では `pg_default_acl` の granting role が
---   `postgres` と `supabase_admin` の両方に anon entry を持っているため、両方 REVOKE する。
---   preview / 新規 project では両 entry が無いので no-op。
--- * **supabase_admin の REVOKE は権限不足を許容する**。`ALTER DEFAULT PRIVILEGES FOR ROLE X`
---   は実行 role が X の member であることを要求する。新しめの Supabase template では
---   migration 実行 role (postgres) が supabase_admin の member ではなく、preview / 新規 project で
---   `permission denied to change default privileges (42501)` で失敗する (本 migration の preview 適用で
---   実例を踏んだ)。preview / 新規 project には supabase_admin の anon entry がそもそも無いため、
---   実体的な不整合は発生しない (skip 安全)。
---   本番は legacy template で `postgres` が `supabase_admin` の member である可能性が高いが、
---   仮に member でなければ silent skip するため、適用後の `\dp` 検証で `anon` 行が
---   消えているか必ず確認する (ADR-0019 の手動 workflow + 事前 / 事後比較で担保)。
+-- * **本 migration の射程は postgres role が触れる範囲のみ**。すなわち:
+--     - 既存 table の table-level GRANT (REVOKE ALL ON public.<table> FROM anon)
+--     - postgres ロールの default privileges (ALTER DEFAULT PRIVILEGES FOR ROLE postgres ...)
+--   `pg_default_acl` には本番のみ supabase_admin ロールの anon entry も存在するが、
+--   `ALTER DEFAULT PRIVILEGES FOR ROLE supabase_admin` は postgres が supabase_admin の
+--   member であることを要求し、新しめの Supabase template では member ではない
+--   (preview 適用で `permission denied to change default privileges (42501)` で実例を踏んだ)。
+--   migration では扱わず、本番のみ Supabase Studio (= supabase_admin 経路) から手動 SQL で REVOKE する。
+--   PR の release checklist に手動 SQL を明記。preview / 新規 project には supabase_admin の
+--   anon entry が無いため、本番限定の一回限り legacy cleanup として扱う。
 -- * **本番への適用は ADR-0019 の手動 workflow 経由**。事前に `\dp public.<table>` で anon GRANT が
 --   存在することを確認してから適用、適用後に anon 行が消えていることを検証する。
 -- * **anon REVOKE は authenticated / postgres / service_role 経路に影響しない**。それぞれ
@@ -59,25 +57,10 @@ revoke all on
   from anon;
 
 -- =====================================================================
--- 2. 今後新規 table を作っても anon に自動 GRANT が付かないようにする
+-- 2. 今後新規 table を作っても anon に自動 GRANT が付かないようにする (postgres role 分)
 -- =====================================================================
 --
--- 本番の `pg_default_acl` には postgres / supabase_admin 両ロールに anon entry が
--- 残っているため、両方 REVOKE する。preview / 新規 project では entry が無いため no-op。
+-- supabase_admin role 分は postgres から扱えないため migration では扱わない (上記設計判断ノート参照)。
 
 alter default privileges for role postgres in schema public
   revoke all on tables from anon;
-
--- supabase_admin 分は権限不足を許容する (上記設計判断ノート参照)。
--- 本番で postgres が supabase_admin の member なら REVOKE が効き、そうでなければ silent skip。
--- 適用後の `\dp public.*` / `pg_default_acl` 検証で実効を確認する。
-do $$
-begin
-  alter default privileges for role supabase_admin in schema public
-    revoke all on tables from anon;
-  raise notice 'Revoked anon default privileges on supabase_admin in schema public.';
-exception
-  when insufficient_privilege then
-    raise notice 'Skipped supabase_admin default privileges REVOKE: migration role lacks membership. Verify post-apply via pg_default_acl.';
-end;
-$$;

--- a/supabase/migrations/20260505010000_revoke_anon_grants_on_public_tables.sql
+++ b/supabase/migrations/20260505010000_revoke_anon_grants_on_public_tables.sql
@@ -1,0 +1,63 @@
+-- kozutsumi: public schema の全 table から anon role への暗黙 GRANT を REVOKE する (Issue #202)
+--
+-- References:
+-- * Issue #202: 本番 Supabase project の public.* に anon への ALL PRIVILEGES が残っている
+-- * docs/adr/0001-action-logs-from-phase1.md
+--     anon に grant しない (Phase 1 方針)。RLS で行アクセスは制御済み
+-- * docs/adr/0046-db-grants-fully-described-by-migrations.md
+--     public schema の table-level GRANT は migration が完全記述する原則。
+--     ADR-0046 の射程は authenticated 軸 (正しい暗黙 GRANT を保存・明示再宣言する) で、
+--     本 migration は anon 軸 (誤った暗黙 GRANT を REVOKE する) を補完する。
+--     両者は対象ロールが異なり、共存する判断 (ADR-0001 / 0046 と principle が一致した実装)。
+-- * supabase/migrations/20260504040000_grant_authenticated_to_public_tables.sql
+--     authenticated 軸の対となる migration (#200 / PR #201)
+--
+-- 設計判断:
+-- * **anon に table-level GRANT を残さない**。ADR-0001 で「anon に grant しない」と
+--   方針が決まっているが、古い Supabase project template の置き土産で本番の `pg_class.relacl` と
+--   `pg_default_acl` に anon への ALL PRIVILEGES が残っていた。RLS で行アクセスは
+--   `auth.uid() = user_id` (anon は auth.uid()=NULL) で守られているため実害は無いが、
+--   RLS が一瞬でも無効化される / 新規 table で RLS enable し忘れる、等で
+--   defense-in-depth が崩れる経路がある。table-level でも anon を弾く。
+-- * **idempotent**。REVOKE は重複実行しても no-op。preview / 新規 project では既に anon GRANT が
+--   無いので何も変化しない (本番のみ実体変化)。
+-- * **default privileges は 2 ロール分**。本番では `pg_default_acl` の granting role が
+--   `postgres` と `supabase_admin` の両方に anon entry を持っているため、両方 REVOKE する。
+--   preview / 新規 project では両 entry が無いので no-op。
+-- * **本番への適用は ADR-0019 の手動 workflow 経由**。事前に `\dp public.<table>` で anon GRANT が
+--   存在することを確認してから適用、適用後に anon 行が消えていることを検証する。
+-- * **anon REVOKE は authenticated / postgres / service_role 経路に影響しない**。それぞれ
+--   独立した role で接続する。
+
+-- =====================================================================
+-- 1. 既存 table から anon の GRANT を全て剥がす
+-- =====================================================================
+--
+-- 対象 table は ADR-0046 初回 migration (20260504040000) と同じ集合:
+--   - projects / tasks / events / task_time_entries / action_logs (initial_schema)
+--   - user_calendar_sync_state (20260424120000)
+--   - external_accounts / user_calendar_subscriptions (20260503100000)
+
+revoke all on
+    public.projects,
+    public.tasks,
+    public.events,
+    public.task_time_entries,
+    public.action_logs,
+    public.user_calendar_sync_state,
+    public.external_accounts,
+    public.user_calendar_subscriptions
+  from anon;
+
+-- =====================================================================
+-- 2. 今後新規 table を作っても anon に自動 GRANT が付かないようにする
+-- =====================================================================
+--
+-- 本番の `pg_default_acl` には postgres / supabase_admin 両ロールに anon entry が
+-- 残っているため、両方 REVOKE する。preview / 新規 project では entry が無いため no-op。
+
+alter default privileges for role postgres in schema public
+  revoke all on tables from anon;
+
+alter default privileges for role supabase_admin in schema public
+  revoke all on tables from anon;


### PR DESCRIPTION
## 概要 (What)

古い Supabase project template の置き土産で本番の `anon` role に public schema 全 table の `ALL PRIVILEGES` が当たっていた件を、migration で REVOKE して整合させる。RLS で実害は無いが、ADR-0001 の「anon に grant しない」方針と矛盾しており defense-in-depth の片鍵が外れている状態の解消。

## 関連 Issue

Closes #202

## 背景 (Why)

Issue #200 / PR #201 の調査過程で、本番 Supabase project の `pg_class.relacl` および `pg_default_acl` に `anon` への ALL PRIVILEGES が残っていることが判明した。原因は古い Supabase project 初期化 template が `GRANT ALL ON public.* TO anon, authenticated, service_role` 相当を流していたため。新しい template では strict 化されて `anon` が外れている (preview project では存在しない)。

実害は今のところ無い (RLS policy `user_id = auth.uid()` で `anon` の `auth.uid() = NULL` は常に行を返さない) が、

- `anon` key は `NEXT_PUBLIC_SUPABASE_ANON_KEY` として client bundle に埋め込まれ世界に公開されている
- RLS が一瞬でも disable される / 新規 table で RLS enable し忘れる / policy バイパス、等が起きた瞬間に世界中の誰でも全データに到達できる
- ADR-0001 / ADR-0046 の方針と現実が一致しない (構造的な信頼性が下がる)

ADR-0046 の射程は **authenticated 軸** (正しい暗黙 GRANT を保存・明示再宣言する) で、本 PR は **anon 軸** (誤った暗黙 GRANT を REVOKE する) を補完する。両者は対象ロールが異なり、ADR-0001 / 0046 の principle と整合方向の実装クリーンアップ (ADR は新規起こさない判断)。

## Before → After (概念・フロー・メンタルモデル)

**Before:**

- `anon` の table 権限は **Supabase project 初期化時の暗黙 default privileges** に依存
- 本番には ALL PRIVILEGES が当たっていて、preview / 新規 project には無い (環境差)
- RLS が gatekeeper として効いていれば実害は無いが、二重の鍵のうち table-level GRANT 側が外れている (defense-in-depth が崩れている)

**After:**

- `anon` には table-level GRANT も `pg_default_acl` の anon entry も存在しない
- RLS と table-level GRANT の両方で `anon` を弾く (defense-in-depth が成立)
- 本番 / preview / 新規環境の DB 状態が等価になる

## 経緯メモ: supabase_admin の default privileges REVOKE 失敗 → 権限不足許容に変更

初版 (commit `d9b523d`) では `ALTER DEFAULT PRIVILEGES FOR ROLE supabase_admin IN SCHEMA public REVOKE ALL ON TABLES FROM anon` を生で書いていたが、preview の自動 apply で `permission denied to change default privileges (SQLSTATE 42501)` で失敗した。`ALTER DEFAULT PRIVILEGES FOR ROLE X` は実行 role が X の member であることを要求するが、新しめの Supabase template では migration 実行 role (postgres) が supabase_admin の member ではないため。

preview / 新規 project には supabase_admin の anon entry がそもそも無い (本 issue の前提) ため silent skip しても実体的な不整合は起きない。修正版 (commit `f89b168`) で `DO ... EXCEPTION WHEN insufficient_privilege` パターンに変更:

- 本番: legacy template で postgres が supabase_admin member の **可能性が高い** → REVOKE が効く想定。member でなければ silent skip
- preview / 新規 project: postgres が supabase_admin member でない → silent skip。anon entry が無いので no-op として正しい

本番で skip された場合の検出は ADR-0019 の事前/事後 `\dp` 検証で担保する (適用後 `pg_default_acl` に supabase_admin の anon entry が残っていれば手動で Supabase Studio から REVOKE する)。

## 追加したテスト (How verified)

migration の効果は SQL を流して事前 / 事後比較で検証する (自動テストは無し)。

- [x] `npm test` 全 598 件 pass / `npm run lint` / `npm run typecheck` / `npm run format:check` clean
- [ ] PR push 後、`db-migrate-preview` workflow が green になること、log に `Applying migration 20260505010000_revoke_anon_grants_on_public_tables` 行が出ていることを確認
- [ ] preview project で検証 SQL を流し、`anon` の table-level GRANT 行が一切無いこと、`pg_default_acl` に `anon` entry が無いことを確認 (元々無いはずなので **no-op** であることの確認)
- [ ] 本番適用前に検証 SQL を流し、`anon` に ALL PRIVILEGES が当たっていることを再確認 (適用前提状態の担保)
- [ ] 本番適用後に検証 SQL を流し、`anon` 行が消えたことを確認 (`pg_default_acl` の supabase_admin entry も含む)
- [ ] 本番適用後にログイン経路 (`authenticated`) / DDL 経路 (`postgres`) / API 経路 (`service_role`) が引き続き機能することを確認

検証用 SQL (Issue #202 / PR #201 で使ったもの):

```sql
-- table-level GRANT
SELECT c.relname, COALESCE(g.grantee, '(none)'),
       string_agg(g.privilege_type, ', ' ORDER BY g.privilege_type)
FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
LEFT JOIN information_schema.role_table_grants g
  ON g.table_schema = n.nspname AND g.table_name = c.relname
 AND g.grantee IN ('authenticated', 'anon')
WHERE n.nspname = 'public' AND c.relkind = 'r'
GROUP BY c.relname, g.grantee ORDER BY c.relname, g.grantee;

-- default privileges
SELECT pg_get_userbyid(d.defaclrole), n.nspname,
       CASE d.defaclobjtype WHEN 'r' THEN 'table' WHEN 'S' THEN 'sequence'
                            WHEN 'f' THEN 'function' WHEN 'T' THEN 'type' END,
       d.defaclacl
FROM pg_default_acl d JOIN pg_namespace n ON n.oid = d.defaclnamespace
WHERE n.nspname = 'public';
```

## リリース前チェックリスト (When / Before merge)

- [x] マイグレーションの適用順を確認した (timestamp `20260505010000` で main 最新の `20260505000000_p3_204_decompose_global_stack_order` より後)
- [x] ADR は新規起票しない (ADR-0001 / 0046 の principle と整合方向の実装クリーンアップ)
- [ ] **本番への適用は ADR-0019 の手動 `db-migrate.yml` workflow で行う**。事前に `\dp public.<table>` で `anon` 行が存在することを確認 → apply → 適用後に `anon` 行が消えていることを確認 (supabase_admin の default privileges entry も含む)
- [ ] 本番で supabase_admin の anon entry が REVOKE されず残った場合、Supabase Studio から手動で `ALTER DEFAULT PRIVILEGES FOR ROLE supabase_admin IN SCHEMA public REVOKE ALL ON TABLES FROM anon;` を実行 (本番 postgres が supabase_admin member でなかった場合の fallback)

## このPRの範囲外 (Out of scope)

- `column-level` / `function-level` GRANT の体系化 (ADR-0046 の射程外、必要になった時点で別 ADR)
- `auth.*` / `storage.*` 等 Supabase 管理 schema の権限 (ADR-0046 の射程外、Supabase の default に従う)
- preview migration apply の信頼性向上 (silent skip 検知 / 同 timestamp 衝突 / pooler URL ガード) は #203 で別途扱う
