### PR TITLE
fix(calendar): events_time_order 違反の予定救済 + スキップ通知 UX

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "@tanstack/react-query": "^5.99.1",
         "next": "^16.2.4",
         "react": "^19.2.5",
-        "react-dom": "^19.2.5"
+        "react-dom": "^19.2.5",
+        "sonner": "^2.0.7"
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
@@ -8140,6 +8141,16 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "@tanstack/react-query": "^5.99.1",
     "next": "^16.2.4",
     "react": "^19.2.5",
-    "react-dom": "^19.2.5"
+    "react-dom": "^19.2.5",
+    "sonner": "^2.0.7"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -26,6 +26,7 @@ import { ProjectDetailPanel } from "@/features/project-detail/ProjectDetailPanel
 import { SettingsPanel } from "@/features/settings/SettingsPanel";
 import { CalendarSyncButton } from "@/features/sync/CalendarSyncButton";
 import { ReauthBanner } from "@/features/sync/ReauthBanner";
+import { SyncSkippedBanner } from "@/features/sync/SyncSkippedBanner";
 import { useCalendarSync } from "@/features/sync/useCalendarSync";
 import { useLazyCalendarSync } from "@/features/sync/useLazyCalendarSync";
 import { TaskDetailPanel } from "@/features/task-detail/TaskDetailPanel";
@@ -230,6 +231,7 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
           </div>
 
           <ReauthBanner visible={calendarSync.needsReauth} onDismiss={calendarSync.dismissReauth} />
+          <SyncSkippedBanner />
 
           {view === "stack" ? (
             <StackView

--- a/src/app/api/calendar/subscriptions/route.ts
+++ b/src/app/api/calendar/subscriptions/route.ts
@@ -117,6 +117,7 @@ export async function POST(req: Request) {
             synced: syncOutcome.synced,
             deleted: syncOutcome.deleted,
             lastSyncedAt: syncOutcome.lastSyncedAt,
+            skipped: syncOutcome.skipped,
           }
         : null,
     });

--- a/src/app/api/calendar/sync/route.test.ts
+++ b/src/app/api/calendar/sync/route.test.ts
@@ -104,6 +104,7 @@ describe("POST /api/calendar/sync", () => {
       deleted: 1,
       lastSyncedAt: "2026-04-24T00:00:00.000Z",
       outcomes: [],
+      skipped: [],
     });
 
     const response = await POST();
@@ -114,8 +115,44 @@ describe("POST /api/calendar/sync", () => {
       synced: 5,
       deleted: 1,
       lastSyncedAt: "2026-04-24T00:00:00.000Z",
+      skipped: [],
     });
     expect(syncGoogleCalendar).toHaveBeenCalledTimes(1);
+  });
+
+  test("正常系: skipped がある場合はそのまま 200 で配列を返す", async () => {
+    vi.mocked(createClient).mockResolvedValue(
+      makeSupabase({
+        provider_token: "access-1",
+        provider_refresh_token: "refresh-1",
+      }),
+    );
+    vi.mocked(syncGoogleCalendar).mockResolvedValue({
+      synced: 2,
+      deleted: 0,
+      lastSyncedAt: "2026-04-24T00:00:00.000Z",
+      outcomes: [],
+      skipped: [
+        {
+          externalCalendarId: "shared@group.calendar.google.com",
+          externalId: "evt-broken",
+          title: "ゼロ長",
+          reason: "invalid_time_range",
+        },
+      ],
+    });
+
+    const response = await POST();
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { skipped: unknown };
+    expect(body.skipped).toEqual([
+      {
+        externalCalendarId: "shared@group.calendar.google.com",
+        externalId: "evt-broken",
+        title: "ゼロ長",
+        reason: "invalid_time_range",
+      },
+    ]);
   });
 
   test("その他の例外は 500 を返す", async () => {

--- a/src/app/api/calendar/sync/route.ts
+++ b/src/app/api/calendar/sync/route.ts
@@ -89,6 +89,8 @@ export async function POST() {
       synced: result.synced,
       deleted: result.deleted,
       lastSyncedAt: result.lastSyncedAt,
+      // skipped 情報を UI まで持ち出してバナー / トーストの「N 件スキップ」表示に使う (Issue #219 続き)。
+      skipped: result.skipped,
     });
   } catch (error) {
     if (error instanceof ProviderTokenMissingError || error instanceof RefreshTokenExpiredError) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { IBM_Plex_Mono, Noto_Sans_JP } from "next/font/google";
+import { Toaster } from "sonner";
 
 import { QueryProvider } from "@/shared/query/QueryProvider";
 
@@ -30,6 +31,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="ja" className={`${ibmPlexMono.variable} ${notoSansJp.variable}`}>
       <body className="mx-auto min-h-screen max-w-[480px] bg-bg-primary font-mono text-fg-default">
         <QueryProvider>{children}</QueryProvider>
+        <Toaster position="top-center" richColors closeButton />
       </body>
     </html>
   );

--- a/src/entities/event/sync.test.ts
+++ b/src/entities/event/sync.test.ts
@@ -191,7 +191,7 @@ describe("partitionEvents", () => {
         end: { dateTime: "2026-04-23T13:00:00Z" },
       },
       { id: "deleted-2", status: "cancelled" },
-      // 壊れたイベントは無視する
+      // 壊れたイベントは skipped に分類する
       { id: "broken", start: {}, end: {} },
     ];
 
@@ -199,6 +199,55 @@ describe("partitionEvents", () => {
 
     expect(result.cancelled).toEqual(["deleted-1", "deleted-2"]);
     expect(result.upserts.map((u) => u.externalId)).toEqual(["active-1", "active-2"]);
+    expect(result.skipped).toEqual([
+      {
+        externalCalendarId: "primary",
+        externalId: "broken",
+        title: undefined,
+        reason: "missing_time",
+      },
+    ]);
+  });
+
+  test("ゼロ長 / 逆順イベントは skipped に invalid_time_range として分類される (Issue #219)", () => {
+    const events: GoogleCalendarEvent[] = [
+      {
+        id: "ok",
+        summary: "通常",
+        start: { dateTime: "2026-04-23T10:00:00Z" },
+        end: { dateTime: "2026-04-23T11:00:00Z" },
+      },
+      {
+        id: "zero",
+        summary: "ゼロ長",
+        start: { dateTime: "2026-04-23T12:00:00Z" },
+        end: { dateTime: "2026-04-23T12:00:00Z" },
+      },
+      {
+        id: "reversed",
+        summary: "逆順",
+        start: { dateTime: "2026-04-23T13:00:00Z" },
+        end: { dateTime: "2026-04-23T12:30:00Z" },
+      },
+    ];
+
+    const result = partitionEvents(events, "shared");
+
+    expect(result.upserts.map((u) => u.externalId)).toEqual(["ok"]);
+    expect(result.skipped).toEqual([
+      {
+        externalCalendarId: "shared",
+        externalId: "zero",
+        title: "ゼロ長",
+        reason: "invalid_time_range",
+      },
+      {
+        externalCalendarId: "shared",
+        externalId: "reversed",
+        title: "逆順",
+        reason: "invalid_time_range",
+      },
+    ]);
   });
 });
 
@@ -485,6 +534,62 @@ describe("syncGoogleCalendar (full sync)", () => {
 
     expect(result.outcomes.map((o) => o.externalCalendarId)).toEqual(["primary", "team@x.com"]);
     expect(listEvents).toHaveBeenCalledTimes(2);
+  });
+
+  test("不正な時刻の予定は upsert からスキップされ SyncResult.skipped に集約される (Issue #219)", async () => {
+    const { gateway, upsertCalls } = makeFakeGateway();
+    const listEvents = vi.fn<ListEventsFn>(async (params) => {
+      if (params.calendarId === "primary") {
+        return {
+          items: [makeActiveEvent("ok-1")],
+          nextSyncToken: "tok-primary",
+        };
+      }
+      return {
+        items: [
+          makeActiveEvent("shared-ok"),
+          {
+            id: "shared-zero",
+            summary: "ゼロ長",
+            start: { dateTime: "2026-04-23T12:00:00Z" },
+            end: { dateTime: "2026-04-23T12:00:00Z" },
+          },
+        ],
+        nextSyncToken: "tok-shared",
+      };
+    });
+
+    const result = await syncGoogleCalendar(
+      FAKE_SUPABASE,
+      makeDeps({
+        gateway,
+        listEvents,
+        targets: [
+          {
+            externalAccountUuid: "acc-uuid",
+            externalAccountIdentifier: "user@example.com",
+            externalCalendarId: "primary",
+          },
+          {
+            externalAccountUuid: "acc-uuid",
+            externalAccountIdentifier: "user@example.com",
+            externalCalendarId: "shared@group.calendar.google.com",
+          },
+        ],
+      }),
+    );
+
+    expect(result.synced).toBe(2);
+    expect(upsertCalls.flatMap((c) => c.map((e) => e.externalId))).toEqual(["ok-1", "shared-ok"]);
+    expect(result.skipped).toEqual([
+      {
+        externalCalendarId: "shared@group.calendar.google.com",
+        externalId: "shared-zero",
+        title: "ゼロ長",
+        reason: "invalid_time_range",
+      },
+    ]);
+    expect(result.outcomes.find((o) => o.externalCalendarId === "primary")?.skipped).toEqual([]);
   });
 
   test("空結果の時は upsert/delete を呼ばない", async () => {

--- a/src/entities/event/sync.test.ts
+++ b/src/entities/event/sync.test.ts
@@ -56,6 +56,36 @@ describe("resolveEventTimes", () => {
   test("start/end が欠けている不正イベントは null を返す", () => {
     expect(resolveEventTimes({ id: "e3", start: {}, end: {} })).toBeNull();
   });
+
+  test("end === start のゼロ長イベントは null を返す (events_time_order 違反回避 / Issue #219)", () => {
+    expect(
+      resolveEventTimes({
+        id: "zero-length",
+        start: { dateTime: "2026-04-23T10:00:00+09:00" },
+        end: { dateTime: "2026-04-23T10:00:00+09:00" },
+      }),
+    ).toBeNull();
+  });
+
+  test("end < start の逆順イベントは null を返す (events_time_order 違反回避 / Issue #219)", () => {
+    expect(
+      resolveEventTimes({
+        id: "reversed",
+        start: { dateTime: "2026-04-23T11:00:00+09:00" },
+        end: { dateTime: "2026-04-23T10:00:00+09:00" },
+      }),
+    ).toBeNull();
+  });
+
+  test("終日イベントで start.date === end.date のゼロ長は null を返す", () => {
+    expect(
+      resolveEventTimes({
+        id: "all-day-zero",
+        start: { date: "2026-04-23" },
+        end: { date: "2026-04-23" },
+      }),
+    ).toBeNull();
+  });
 });
 
 describe("extractMeetUrl", () => {

--- a/src/entities/event/sync.ts
+++ b/src/entities/event/sync.ts
@@ -54,6 +54,18 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const DEFAULT_TITLE = "(タイトルなし)";
 
 /**
+ * 取り込みをスキップした 1 件分の情報。Issue #219 の events_time_order 違反、または時刻情報欠損などで
+ * mapper が `null` を返したものをまとめて UI に伝える (バナー / トーストの「N 件スキップ」表示)。
+ */
+export type SkippedEvent = {
+  externalCalendarId: string;
+  externalId: string;
+  /** Google から取れたタイトル。`undefined` の場合は UI 側で「(タイトルなし)」にフォールバックする。 */
+  title: string | undefined;
+  reason: "invalid_time_range" | "missing_time";
+};
+
+/**
  * 1 calendar 分の sync 結果。複数 calendar の集約は呼び出し側で sum する。
  * `triple` は action_log の triple metadata (`event_deleted_by_source` 等) を作るために
  * 呼び出し側へ渡す source-agnostic 識別子。
@@ -69,6 +81,8 @@ export type CalendarSyncOutcome = {
     eventSnapshot: DeletedEventSnapshot;
     dependentTaskIds: string[];
   }>;
+  /** 取り込みをスキップした event 一覧。空配列なら全件取り込み済み。 */
+  skipped: SkippedEvent[];
 };
 
 export type SyncResult = {
@@ -77,6 +91,8 @@ export type SyncResult = {
   lastSyncedAt: string;
   /** 同期した calendar 単位の outcome 配列。1 calendar = 1 entry。 */
   outcomes: CalendarSyncOutcome[];
+  /** 全 calendar 集約後のスキップ予定。UI が件数 / 詳細を表示する材料。 */
+  skipped: SkippedEvent[];
 };
 
 /**
@@ -165,6 +181,7 @@ export async function syncGoogleCalendar(
       synced: result.synced,
       deleted: result.deleted,
       deletions: result.deletions,
+      skipped: result.skipped,
     });
 
     // calendar 単位の lastSyncedAt を保存する (1 calendar 失敗 → 他 calendar は完了状態を残す)。
@@ -186,6 +203,7 @@ export async function syncGoogleCalendar(
     deleted: totalDeleted,
     lastSyncedAt,
     outcomes,
+    skipped: outcomes.flatMap((o) => o.skipped),
   };
 }
 
@@ -271,7 +289,7 @@ async function syncOneCalendar(
     break;
   }
 
-  const { upserts, cancelled } = partitionEvents(collected, target.externalCalendarId);
+  const { upserts, cancelled, skipped } = partitionEvents(collected, target.externalCalendarId);
 
   let synced = 0;
   if (upserts.length > 0) {
@@ -313,6 +331,7 @@ async function syncOneCalendar(
     synced,
     deleted,
     deletions,
+    skipped,
     nextSyncToken,
   };
 }
@@ -512,18 +531,41 @@ export function partitionEvents(
 ): {
   upserts: UpsertGoogleCalendarEventInput[];
   cancelled: string[];
+  skipped: SkippedEvent[];
 } {
   const upserts: UpsertGoogleCalendarEventInput[] = [];
   const cancelled: string[] = [];
+  const skipped: SkippedEvent[] = [];
   for (const ev of events) {
     if (ev.status === "cancelled") {
       cancelled.push(ev.id);
       continue;
     }
     const mapped = mapGoogleEventToUpsertInput(ev, externalCalendarId);
-    if (mapped) upserts.push(mapped);
+    if (mapped) {
+      upserts.push(mapped);
+      continue;
+    }
+    skipped.push({
+      externalCalendarId,
+      externalId: ev.id,
+      title: ev.summary,
+      reason: classifySkipReason(ev),
+    });
   }
-  return { upserts, cancelled };
+  return { upserts, cancelled, skipped };
+}
+
+/**
+ * `mapGoogleEventToUpsertInput` が `null` を返した event の理由を分類する。
+ * - 時刻情報が片側欠損 / 両側欠損 → `missing_time`
+ * - 時刻はあるが end <= start → `invalid_time_range` (events_time_order 違反 / Issue #219)
+ */
+function classifySkipReason(event: GoogleCalendarEvent): SkippedEvent["reason"] {
+  const hasDateTimePair = Boolean(event.start?.dateTime && event.end?.dateTime);
+  const hasDatePair = Boolean(event.start?.date && event.end?.date);
+  if (!hasDateTimePair && !hasDatePair) return "missing_time";
+  return "invalid_time_range";
 }
 
 export function mapGoogleEventToUpsertInput(

--- a/src/entities/event/sync.ts
+++ b/src/entities/event/sync.ts
@@ -548,19 +548,24 @@ export function mapGoogleEventToUpsertInput(
 export function resolveEventTimes(
   event: GoogleCalendarEvent,
 ): { start: string; end: string } | null {
+  let times: { start: string; end: string } | null = null;
   if (event.start?.dateTime && event.end?.dateTime) {
-    return {
+    times = {
       start: new Date(event.start.dateTime).toISOString(),
       end: new Date(event.end.dateTime).toISOString(),
     };
-  }
-  if (event.start?.date && event.end?.date) {
-    return {
+  } else if (event.start?.date && event.end?.date) {
+    times = {
       start: allDayDateToJstUtc(event.start.date),
       end: allDayDateToJstUtc(event.end.date),
     };
   }
-  return null;
+  if (!times) return null;
+  // events_time_order check (end_time > start_time) を満たさない event は丸ごとスキップする。
+  // 1 件でも違反があると Supabase の batch upsert が calendar 単位で全件ロールバックされ、
+  // その calendar の取り込みが完全に失われるため (Issue #219)。
+  if (Date.parse(times.end) <= Date.parse(times.start)) return null;
+  return times;
 }
 
 export function extractMeetUrl(event: GoogleCalendarEvent): string | null {

--- a/src/features/settings/useCalendarSubscriptions.ts
+++ b/src/features/settings/useCalendarSubscriptions.ts
@@ -7,6 +7,9 @@ import type {
   CalendarSubscription,
   SetAutoPromoteResult,
 } from "@/entities/calendar-subscription/types";
+import type { SkippedEvent } from "@/entities/event/sync";
+import { setSkippedEvents } from "@/features/sync/skippedEventsCache";
+import { showSyncToast } from "@/features/sync/useCalendarSync";
 import type { GoogleCalendarListEntry } from "@/shared/google/calendar";
 
 const SUBSCRIPTIONS_QUERY_KEY = ["calendar", "subscriptions"] as const;
@@ -90,10 +93,24 @@ export function useCalendarSubscriptions() {
         const body = (await res.json().catch(() => null)) as { error?: string } | null;
         throw new Error(body?.error ?? `subscribe_failed: ${res.status}`);
       }
-      return (await res.json()) as { subscription: CalendarSubscription };
+      return (await res.json()) as {
+        subscription: CalendarSubscription;
+        sync: {
+          synced: number;
+          deleted: number;
+          lastSyncedAt: string;
+          skipped: SkippedEvent[];
+        } | null;
+      };
     },
-    onSuccess: () => {
+    onSuccess: (data) => {
       void invalidate();
+      // 初回同期は手動操作の延長なので、結果トースト + skipped をバナー用キャッシュに反映する。
+      // sync が null のケース (provider_token_missing 等で初回同期がスキップされた場合) は無視。
+      if (data.sync) {
+        setSkippedEvents(queryClient, data.sync.skipped);
+        showSyncToast(data.sync.synced, data.sync.skipped.length);
+      }
     },
   });
 

--- a/src/features/sync/SyncSkippedBanner.test.tsx
+++ b/src/features/sync/SyncSkippedBanner.test.tsx
@@ -1,0 +1,73 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, test } from "vitest";
+
+import type { SkippedEvent } from "@/entities/event/sync";
+
+import { SyncSkippedBanner } from "./SyncSkippedBanner";
+import { SKIPPED_EVENTS_QUERY_KEY } from "./skippedEventsCache";
+
+function makeWrapper(initialSkipped: SkippedEvent[]) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  queryClient.setQueryData(SKIPPED_EVENTS_QUERY_KEY, initialSkipped);
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  }
+  return { Wrapper, queryClient };
+}
+
+const SAMPLE_SKIPPED: SkippedEvent[] = [
+  {
+    externalCalendarId: "shared@group.calendar.google.com",
+    externalId: "evt-zero",
+    title: "ゼロ長会議",
+    reason: "invalid_time_range",
+  },
+  {
+    externalCalendarId: "shared@group.calendar.google.com",
+    externalId: "evt-no-time",
+    title: undefined,
+    reason: "missing_time",
+  },
+];
+
+describe("SyncSkippedBanner", () => {
+  test("skipped が空のときは何もレンダーしない", () => {
+    const { Wrapper } = makeWrapper([]);
+    render(<SyncSkippedBanner />, { wrapper: Wrapper });
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  test("skipped がある時に role=alert で件数を表示する", () => {
+    const { Wrapper } = makeWrapper(SAMPLE_SKIPPED);
+    render(<SyncSkippedBanner />, { wrapper: Wrapper });
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toContain("2 件の予定を取り込めませんでした");
+  });
+
+  test("「詳細」を押すと dialog が開き、各 skipped の title と reason 文言が出る", () => {
+    const { Wrapper } = makeWrapper(SAMPLE_SKIPPED);
+    render(<SyncSkippedBanner />, { wrapper: Wrapper });
+
+    fireEvent.click(screen.getByRole("button", { name: "詳細" }));
+
+    const dialog = screen.getByRole("dialog", { name: "取り込めなかった予定" });
+    expect(dialog.textContent).toContain("ゼロ長会議");
+    expect(dialog.textContent).toContain("(タイトルなし)");
+    expect(dialog.textContent).toContain("終了時刻が開始時刻と同じか前");
+    expect(dialog.textContent).toContain("開始 / 終了時刻が設定されていません");
+  });
+
+  test("「バナーを閉じる」を押すとキャッシュが空になりバナーが消える", async () => {
+    const { Wrapper, queryClient } = makeWrapper(SAMPLE_SKIPPED);
+    render(<SyncSkippedBanner />, { wrapper: Wrapper });
+
+    fireEvent.click(screen.getByRole("button", { name: "バナーを閉じる" }));
+
+    expect(queryClient.getQueryData(SKIPPED_EVENTS_QUERY_KEY)).toEqual([]);
+    await waitFor(() => expect(screen.queryByRole("alert")).toBeNull());
+  });
+});

--- a/src/features/sync/SyncSkippedBanner.tsx
+++ b/src/features/sync/SyncSkippedBanner.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import type { SkippedEvent } from "@/entities/event/sync";
+
+import { useDismissSkippedEvents, useSkippedEvents } from "./skippedEventsCache";
+
+const REASON_LABEL: Record<SkippedEvent["reason"], string> = {
+  invalid_time_range: "終了時刻が開始時刻と同じか前になっています",
+  missing_time: "開始 / 終了時刻が設定されていません",
+};
+
+/**
+ * 直近の sync で取り込みをスキップした予定があることを伝える永続バナー (Issue #219 続き)。
+ *
+ * - 同セッション中はキャッシュに skipped > 0 が残るので、ページ遷移しても表示が消えない
+ * - リロード後は cache が空に戻るが、次の sync (lazy / 手動) で再投入される (β 案: in-session 永続)
+ * - 「詳細」で dialog を開き、ユーザーが Google Calendar 側を直すための手がかりを提示する
+ */
+export function SyncSkippedBanner() {
+  const skipped = useSkippedEvents();
+  const dismiss = useDismissSkippedEvents();
+  const [open, setOpen] = useState(false);
+
+  if (skipped.length === 0) return null;
+
+  return (
+    <>
+      <div
+        role="alert"
+        className="flex items-center gap-3 border-b border-accent-amber/40 bg-accent-amber/10 px-4 py-2 text-[12px] text-fg-emphasized"
+      >
+        <span className="flex-1">
+          {skipped.length} 件の予定を取り込めませんでした (時刻情報が不正)
+        </span>
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="rounded bg-accent-amber px-3 py-1 text-[11px] font-medium text-fg-invert transition-colors hover:opacity-90"
+        >
+          詳細
+        </button>
+        <button
+          type="button"
+          onClick={dismiss}
+          aria-label="バナーを閉じる"
+          className="text-fg-muted transition-colors hover:text-fg-emphasized"
+        >
+          ×
+        </button>
+      </div>
+      <SyncSkippedDialog open={open} skipped={skipped} onClose={() => setOpen(false)} />
+    </>
+  );
+}
+
+type SyncSkippedDialogProps = {
+  open: boolean;
+  skipped: SkippedEvent[];
+  onClose: () => void;
+};
+
+function SyncSkippedDialog({ open, skipped, onClose }: SyncSkippedDialogProps) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="取り込めなかった予定"
+      className="fixed inset-0 z-[60] flex items-start justify-center bg-black/40 p-4 pt-[6vh]"
+      onClick={onClose}
+    >
+      <div
+        className="relative max-h-[80vh] w-full max-w-[560px] overflow-y-auto rounded-lg border border-bg-divider bg-bg-elevated p-5 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-4 flex items-baseline justify-between gap-2">
+          <h2 className="font-jp text-[14px] font-semibold text-fg-emphasized">
+            取り込めなかった予定 ({skipped.length} 件)
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="閉じる"
+            className="text-[12px] text-fg-muted hover:text-fg-emphasized"
+          >
+            閉じる
+          </button>
+        </div>
+
+        <p className="mb-4 text-[11px] leading-relaxed text-fg-muted">
+          以下の予定は時刻情報が不正なため取り込めませんでした。Google
+          カレンダー側で時刻を直してから再同期すると取り込まれます。
+        </p>
+
+        <ul className="flex flex-col gap-2">
+          {skipped.map((s) => (
+            <li
+              key={`${s.externalCalendarId}:${s.externalId}`}
+              className="rounded-md border border-bg-divider bg-bg-surface p-3 text-[12px]"
+            >
+              <div className="font-jp text-[13px] font-medium text-fg-emphasized">
+                {s.title ?? "(タイトルなし)"}
+              </div>
+              <div className="mt-1 text-[11px] text-fg-muted">{REASON_LABEL[s.reason]}</div>
+              <div className="mt-1 truncate text-[10px] text-fg-muted">
+                カレンダー: {s.externalCalendarId}
+              </div>
+            </li>
+          ))}
+        </ul>
+
+        <div className="mt-5 flex justify-end">
+          <a
+            href="https://calendar.google.com/"
+            target="_blank"
+            rel="noreferrer noopener"
+            className="rounded bg-bg-divider px-3 py-1.5 text-[11px] font-medium text-fg-emphasized transition-colors hover:bg-bg-divider/70"
+          >
+            Google カレンダーを開く
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/sync/skippedEventsCache.ts
+++ b/src/features/sync/skippedEventsCache.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+
+import type { SkippedEvent } from "@/entities/event/sync";
+
+/**
+ * 直近の sync で取り込みをスキップした予定一覧を保持するキャッシュ。
+ *
+ * - 任意のユーザー操作 (手動 sync / subscribe) や lazy sync が完了したら `setSkippedEvents` で書き換える
+ * - `SyncSkippedBanner` / 詳細 dialog が `useSkippedEvents` で読む
+ * - セッション中は値が残るので、ユーザーがページ遷移しても broken event の存在に気づける
+ *   (β 案: in-session permanence。リロードで消えるが、次の sync で復活する)
+ */
+export const SKIPPED_EVENTS_QUERY_KEY = ["calendar", "sync", "skipped"] as const;
+
+export function useSkippedEvents(): SkippedEvent[] {
+  const { data } = useQuery<SkippedEvent[]>({
+    queryKey: SKIPPED_EVENTS_QUERY_KEY,
+    // setQueryData で外から更新する前提。queryFn は initial fetch を抑止するためのダミー。
+    queryFn: () => [],
+    staleTime: Infinity,
+    initialData: [],
+  });
+  return data ?? [];
+}
+
+export function setSkippedEvents(client: QueryClient, skipped: SkippedEvent[]): void {
+  client.setQueryData<SkippedEvent[]>(SKIPPED_EVENTS_QUERY_KEY, skipped);
+}
+
+export function useDismissSkippedEvents(): () => void {
+  const client = useQueryClient();
+  return useCallback(() => {
+    setSkippedEvents(client, []);
+  }, [client]);
+}

--- a/src/features/sync/useCalendarSync.test.tsx
+++ b/src/features/sync/useCalendarSync.test.tsx
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   log: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastWarning: vi.fn(),
 }));
 
 vi.mock("@/entities/action-log/logger", () => ({
@@ -25,6 +27,14 @@ vi.mock("@/entities/action-log/logger", () => ({
   log: mocks.log,
 }));
 
+vi.mock("sonner", () => ({
+  toast: {
+    success: mocks.toastSuccess,
+    warning: mocks.toastWarning,
+  },
+}));
+
+import { SKIPPED_EVENTS_QUERY_KEY } from "./skippedEventsCache";
 import { useCalendarSync } from "./useCalendarSync";
 
 function makeWrapper() {
@@ -53,16 +63,18 @@ function mockFetchOnce(init: { status: number; body?: unknown }): ReturnType<typ
 describe("useCalendarSync", () => {
   beforeEach(() => {
     mocks.log.mockClear();
+    mocks.toastSuccess.mockClear();
+    mocks.toastWarning.mockClear();
   });
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  test("200 成功: lastSyncedAt を保持し events を invalidate し action_log を記録する", async () => {
+  test("200 成功 (manual): lastSyncedAt を保持し events を invalidate し action_log を記録 + 成功トースト", async () => {
     const { Wrapper, invalidateSpy } = makeWrapper();
     const fetchMock = mockFetchOnce({
       status: 200,
-      body: { synced: 3, deleted: 1, lastSyncedAt: "2026-04-24T04:00:00.000Z" },
+      body: { synced: 3, deleted: 1, lastSyncedAt: "2026-04-24T04:00:00.000Z", skipped: [] },
     });
 
     const { result } = renderHook(() => useCalendarSync(), { wrapper: Wrapper });
@@ -83,13 +95,15 @@ describe("useCalendarSync", () => {
       deleted: 1,
       trigger: "manual",
     });
+    expect(mocks.toastSuccess).toHaveBeenCalledWith("3 件の予定を取り込みました");
+    expect(mocks.toastWarning).not.toHaveBeenCalled();
   });
 
-  test("lazy trigger でも同じ経路を通り action_log に trigger='lazy' を渡す", async () => {
+  test("lazy trigger ではトーストを出さず action_log に trigger='lazy' を渡す", async () => {
     const { Wrapper } = makeWrapper();
     mockFetchOnce({
       status: 200,
-      body: { synced: 0, deleted: 0, lastSyncedAt: "2026-04-24T04:00:00.000Z" },
+      body: { synced: 0, deleted: 0, lastSyncedAt: "2026-04-24T04:00:00.000Z", skipped: [] },
     });
 
     const { result } = renderHook(() => useCalendarSync(), { wrapper: Wrapper });
@@ -104,6 +118,65 @@ describe("useCalendarSync", () => {
       deleted: 0,
       trigger: "lazy",
     });
+    expect(mocks.toastSuccess).not.toHaveBeenCalled();
+    expect(mocks.toastWarning).not.toHaveBeenCalled();
+  });
+
+  test("manual で skipped > 0 のときは warning トーストを出し、skipped をキャッシュに書き込む", async () => {
+    const { Wrapper, queryClient } = makeWrapper();
+    const skipped = [
+      {
+        externalCalendarId: "shared@group.calendar.google.com",
+        externalId: "evt-zero",
+        title: "ゼロ長",
+        reason: "invalid_time_range" as const,
+      },
+    ];
+    mockFetchOnce({
+      status: 200,
+      body: { synced: 5, deleted: 0, lastSyncedAt: "2026-04-24T04:00:00.000Z", skipped },
+    });
+
+    const { result } = renderHook(() => useCalendarSync(), { wrapper: Wrapper });
+
+    act(() => {
+      result.current.triggerSync("manual");
+    });
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(mocks.toastWarning).toHaveBeenCalledWith(
+      "5 件取り込み・1 件は時刻が不正のためスキップしました",
+      { description: "上部のバナーから詳細を確認できます" },
+    );
+    expect(mocks.toastSuccess).not.toHaveBeenCalled();
+    expect(queryClient.getQueryData(SKIPPED_EVENTS_QUERY_KEY)).toEqual(skipped);
+  });
+
+  test("lazy で skipped > 0 でもトーストは出さず、キャッシュには書き込む (バナーは出る)", async () => {
+    const { Wrapper, queryClient } = makeWrapper();
+    const skipped = [
+      {
+        externalCalendarId: "shared@group.calendar.google.com",
+        externalId: "evt-zero",
+        title: "ゼロ長",
+        reason: "invalid_time_range" as const,
+      },
+    ];
+    mockFetchOnce({
+      status: 200,
+      body: { synced: 5, deleted: 0, lastSyncedAt: "2026-04-24T04:00:00.000Z", skipped },
+    });
+
+    const { result } = renderHook(() => useCalendarSync(), { wrapper: Wrapper });
+
+    act(() => {
+      result.current.triggerSync("lazy");
+    });
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(mocks.toastSuccess).not.toHaveBeenCalled();
+    expect(mocks.toastWarning).not.toHaveBeenCalled();
+    expect(queryClient.getQueryData(SKIPPED_EVENTS_QUERY_KEY)).toEqual(skipped);
   });
 
   test("401 を受けたら needsReauth=true になり、events は invalidate しない", async () => {

--- a/src/features/sync/useCalendarSync.ts
+++ b/src/features/sync/useCalendarSync.ts
@@ -2,9 +2,13 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
+import { toast } from "sonner";
 
 import { ACTION_TYPES, log } from "@/entities/action-log/logger";
 import type { CalendarSyncTrigger } from "@/entities/action-log/types";
+import type { SkippedEvent } from "@/entities/event/sync";
+
+import { setSkippedEvents } from "./skippedEventsCache";
 
 const SYNC_ENDPOINT = "/api/calendar/sync";
 const EVENTS_QUERY_KEY = ["events"] as const;
@@ -13,6 +17,7 @@ export type CalendarSyncResult = {
   synced: number;
   deleted: number;
   lastSyncedAt: string;
+  skipped: SkippedEvent[];
 };
 
 /**
@@ -44,7 +49,11 @@ export function useCalendarSync(): UseCalendarSyncResult {
   const [needsReauth, setNeedsReauth] = useState(false);
   const [lastSyncedAt, setLastSyncedAt] = useState<string | null>(null);
 
-  const mutation = useMutation<CalendarSyncResult, Error, CalendarSyncTrigger>({
+  const mutation = useMutation<
+    CalendarSyncResult & { trigger: CalendarSyncTrigger },
+    Error,
+    CalendarSyncTrigger
+  >({
     mutationFn: async (trigger) => {
       const res = await fetch(SYNC_ENDPOINT, { method: "POST" });
       if (res.status === 401) {
@@ -60,12 +69,18 @@ export function useCalendarSync(): UseCalendarSyncResult {
         deleted: body.deleted,
         trigger,
       });
-      return body;
+      return { ...body, trigger };
     },
     onSuccess: (data) => {
       setNeedsReauth(false);
       setLastSyncedAt(data.lastSyncedAt);
+      // 失敗 (skipped) はバナーで永続表示するため、trigger に依らずキャッシュを更新する。
+      setSkippedEvents(queryClient, data.skipped);
       void queryClient.invalidateQueries({ queryKey: EVENTS_QUERY_KEY });
+      // トーストはユーザーが自分で同期を発火した時だけ出す (lazy sync は鬱陶しいので無音)。
+      if (data.trigger === "manual") {
+        showSyncToast(data.synced, data.skipped.length);
+      }
     },
     onError: (err) => {
       if (err.message === CALENDAR_SYNC_REAUTH_REQUIRED) {
@@ -98,4 +113,21 @@ async function safeJson(res: Response): Promise<unknown> {
   } catch {
     return null;
   }
+}
+
+/**
+ * 手動同期のフィードバックトースト。skipped > 0 のときだけ詳細リンクを促す文言を出す。
+ * 詳細はバナー側の dialog に集約する (トースト本体に列挙しない)。
+ */
+export function showSyncToast(syncedCount: number, skippedCount: number): void {
+  if (skippedCount > 0) {
+    toast.warning(
+      `${syncedCount} 件取り込み・${skippedCount} 件は時刻が不正のためスキップしました`,
+      {
+        description: "上部のバナーから詳細を確認できます",
+      },
+    );
+    return;
+  }
+  toast.success(`${syncedCount} 件の予定を取り込みました`);
 }


### PR DESCRIPTION
## 概要 (What)

Google Calendar 同期で `end_time <= start_time` の予定が 1 件混ざると、calendar 単位の batch upsert が `events_time_order` check 制約違反で丸ごとロールバックされ、その calendar の予定が一切取り込めなくなっていた問題の修正と、スキップされた予定の存在をユーザーに伝える UX 追加。

2 段階のコミットで構成:

1. **バグ修正** (`350cb32`): `resolveEventTimes` で `end <= start` を `null` に倒し、不正データを既存の「時刻情報なし」と同経路でスキップ
2. **UX 追加** (`7c86dd2`): スキップされた予定をトースト + バナーで通知し、ユーザーが Google Calendar 側で直す動機を作る

## 関連 Issue

Closes #219

## 背景 (Why)

共有カレンダー連携で「連携完了したのに予定が 1 件も出てこない」報告があり Vercel ログを追ったところ、Supabase upsert が以下で 400 を返していた:

```
[calendar-sync] unexpected error {
  code: '23514',
  message: 'new row for relation "events" violates check constraint "events_time_order"'
}
```

`events_time_order check (end_time > start_time)` は **strict な不等号**なので、Google Calendar 上の「ゼロ長予定（オペミス）」が 1 件あるだけでその calendar 全体の取り込みが破綻する。Supabase の `upsert([...])` はバッチ全体ロールバックなので、不正な 1 件を除外できれば残りは普通に入る。

ただし黙ってスキップするだけだと、ユーザーは「取り込めなかった予定が存在する」事実に気づけず、Google Calendar 側で直す動機が生まれない。そこでスキップ件数 / 詳細を通知する UX をセットで入れる。

## Before → After (概念・フロー・メンタルモデル)

**Before:**

- 1 件でも不正時刻があると calendar 単位の `events` 取り込みが完全失敗 + `user_calendar_sync_state` も保存されない（次回も毎回 full sync で同じ失敗）
- 「連携できているはずなのに何も表示されない」最悪 UX
- ユーザーは broken event の存在に気づけない

**After:**

- 不正な 1 件はスキップ、残りは通常通り取り込まれる。`user_calendar_sync_state` も正常に保存され、次回以降 incremental sync が成立
- 手動同期 (ヘッダー / 設定の取り込み) でトースト通知:
  - 全件成功: 「N 件の予定を取り込みました」
  - スキップあり: 「N 件取り込み・M 件は時刻が不正のためスキップしました」+ 詳細導線
- スキップが残っている間は画面上部にバナー (`role="alert"`) が出続け、詳細 dialog で予定タイトル + 理由 + Google カレンダーへの動線を提供
- Lazy sync (mount + 15min stale) は **トーストを出さない**（鬱陶しさ回避）。バナーだけ更新する

### 永続化の戦略 (β 案: in-session)

- React Query cache (`["calendar", "sync", "skipped"]`) に skipped を保存
- 同セッション中はページ遷移してもバナーが残る
- リロードで cache は消えるが、次の sync (lazy / 手動) で再投入される
- 永続化 (DB schema) が必要になったら別 PR で拡張可能 (cache 読み元を query に差し替えるだけ)

### 設計判断: トースト vs バナー

| | 経路 | toast | banner |
|---|---|---|---|
| ユーザー操作 | 手動 sync (header / subscribe) | ✅ 常に | M > 0 のとき |
| 自動 | lazy sync | ❌ サイレント | M > 0 のとき |

成功通知は「ユーザーが操作した直後の即時 feedback」なのでトースト、失敗 (要対応) は「気付かずに過ぎる」を防ぐためバナー、という使い分け。

## 追加したテスト (How verified)

- [x] `resolveEventTimes`: ゼロ長 / 逆順 / all-day 同日の各ケースで `null` を返す
- [x] `partitionEvents`: skipped に `invalid_time_range` / `missing_time` を分類
- [x] `syncGoogleCalendar`: 複数 calendar で skipped が `SyncResult.skipped` に集約される
- [x] `/api/calendar/sync` route: レスポンスに `skipped[]` が乗る
- [x] `useCalendarSync`: manual で trigger 時のみトースト、lazy では無音、いずれもキャッシュは更新
- [x] `SyncSkippedBanner`: skipped が空なら非表示、ある時は `role="alert"` + 件数表示、詳細 dialog 開閉、`×` ボタンで cache クリア
- [x] `npm run check` (format / lint / typecheck / vitest 610 件) all green
- [ ] preview 環境で当該共有カレンダーが実際に取り込めることを確認 → マージ前に動作確認
- [ ] preview で手動同期トースト・バナー・詳細 dialog の見た目を確認

## リリース前チェックリスト (When / Before merge)

- [x] 環境変数 / シークレットを追加・更新した — なし
- [x] フィーチャーフラグの初期値を決めた — なし
- [ ] 既存ユーザーへの影響（破壊的変更）を確認した — `/api/calendar/sync` のレスポンスに `skipped` が増えるだけ。既存クライアントは無視するので互換

## このPRの範囲外 (Out of scope)

- 終日イベントが UI 上 `00:00-00:00` で表示される問題（DB に all-day フラグが無いため別バグ。本 PR の検証中に発見）→ 別 issue で扱う
- スキップ予定の DB 永続化（γ 案）。cache 読み元の差し替えだけで移行できる前提でスキップ
- スキップした予定の遡及修正（次回 sync で自然に拾える / 拾えない予定はそもそもスキップ対象なので不要）