### PR TITLE
feat(ai): AI 分解の件数上限 (MIN/MAX_CHILDREN) を撤廃 (Closes #215)

### DIFF
--- a/src/shared/ai/prompts/decompose.test.ts
+++ b/src/shared/ai/prompts/decompose.test.ts
@@ -26,14 +26,18 @@ describe("buildDecomposePrompt", () => {
     expect(prompt).toContain("未設定");
   });
 
-  test("出力形式の制約 (件数 / 自立タイトル / JSON のみ) が prompt に含まれる", () => {
+  test("出力形式の制約 (自然な単位 / 自立タイトル / JSON のみ) が prompt に含まれる (ADR 0049: 件数上限は持たない)", () => {
     const prompt = buildDecomposePrompt({
       title: "x",
       body: "",
       estimatedMinutes: null,
     });
 
-    expect(prompt).toContain("2〜7 件");
+    // ADR 0049: 静的な件数上限を持たず、AI に「自然な単位」で判断させる
+    expect(prompt).toContain("自然な単位");
+    expect(prompt).toContain("件数の上限は無く");
+    // 件数指示の旧文言 (X〜Y 件) が消えていることを明示
+    expect(prompt).not.toMatch(/\d+〜\d+ 件/);
     expect(prompt).toContain("空配列");
     expect(prompt).toContain("JSON 配列のみ");
     // ADR 0016 Notes「子タイトルの自立性」を担保する具体例
@@ -232,8 +236,8 @@ describe("parseDecomposeResponse", () => {
     expect(result).toEqual([]);
   });
 
-  test("8 件以上は先頭 7 件で切る (AI 暴走時の安全弁)", () => {
-    const items = Array.from({ length: 12 }, (_, i) => ({
+  test("ADR 0049: 件数の上限を持たず、30 件以上の分解もそのまま採用する", () => {
+    const items = Array.from({ length: 35 }, (_, i) => ({
       title: `子${i + 1}`,
       body: "",
       estimated_minutes: 15,
@@ -242,9 +246,9 @@ describe("parseDecomposeResponse", () => {
 
     const result = parseDecomposeResponse(JSON.stringify(items));
 
-    expect(result).toHaveLength(7);
+    expect(result).toHaveLength(35);
     expect(result?.[0].title).toBe("子1");
-    expect(result?.[6].title).toBe("子7");
+    expect(result?.[34].title).toBe("子35");
   });
 
   test("title が空 / 80 文字超過のエントリは捨て、残りを採用する", () => {

--- a/src/shared/ai/prompts/decompose.ts
+++ b/src/shared/ai/prompts/decompose.ts
@@ -54,8 +54,6 @@ export type DecomposedChild = {
   taskSize: TaskSizeValue | null;
 };
 
-const MIN_CHILDREN = 2;
-const MAX_CHILDREN = 7;
 const MAX_TITLE_LEN = 80;
 // 子 body は markdown で 200 文字程度を目標に prompt で誘導する。AI が暴走しても
 // task body 全体が肥大化しないよう 600 文字で hard cap する (truncate)。
@@ -67,7 +65,9 @@ const ALLOWED_ESTIMATE_BUCKETS = [5, 10, 15, 20, 30, 45, 60, 90, 120] as const;
 /**
  * Gemini に渡す prompt 文字列を構築する。
  *
- * - 出力数の上下限 (2〜7) を明示する。1 件しか出ないなら「分解不要」として空配列を返させる
+ * - 件数は AI の判断に委ねる (ADR 0049: 静的な上下限は持たない)。
+ *   章立て / 手順タスク / 旅程など自然な粒度が数十件規模になるケースを許容する。
+ *   1 件しか出ないなら「分解不要」として空配列を返させる
  *   (parser 側で 1 件は `skipped` 扱いに倒すフェイルセーフもあるが、prompt でも縛る)
  * - 子タイトルは親文脈なしで読めること、本文に親タスク情報を埋め込んで誘導する
  * - 出力は JSON 配列のみ。markdown fence や説明文が混じっても parser 側で剥がす前提
@@ -94,7 +94,7 @@ export function buildDecomposePrompt(parent: DecomposeInput): string {
     "あなたは個人特化のタスク管理アシスタント。次の親タスクを、実行可能な粒度の子タスクに分解する。",
     "",
     "# 分解の方針",
-    `- 子タスクは ${MIN_CHILDREN}〜${MAX_CHILDREN} 件。`,
+    "- 子タスクは「自然な単位」で分解する。件数の上限は無く、内容に応じて自分で判断する (章立てがある本なら章単位、複数手順タスクなら手順単位など)。",
     "- 親タスクが既に十分小さく分解の必要がないと判断したら、空配列 [] を返す。",
     "- 各子タスクの title は、親タスクの文脈なしで読んで意味が取れる短い独立した文言にする。",
     "  例 (悪): 「志望動機を書く」 / 例 (良): 「Dirbato 最終面接 志望動機 (パターン A) を書く」",
@@ -144,15 +144,15 @@ export function buildDecomposePrompt(parent: DecomposeInput): string {
  * - markdown fence (```json ... ```) を剥がす
  * - JSON 配列以外 / 解釈不能 → `null` (呼び出し側で「失敗」として親を `none` のまま残す)
  * - 空配列 → `[]` (呼び出し側で「分解不要」として親を `skipped` に倒す)
- * - 1 件のみ → `[]` 扱い (実質的な分解になっていないため)
- * - 件数オーバー (>7) → 先頭 7 件で切る (AI が暴走した時の安全弁)
+ * - 1 件のみ → `[]` 扱い (実質的な分解になっていないため。ADR 0049 で件数上限は撤廃したが、
+ *   この「1 件 → skipped」品質ガードは件数 cap ではないので残す)
  * - title が空 / 80 文字超過 → entry を捨てる (それ以外を採用)
  * - estimated_minutes が許容バケット外 → null に倒す (整数 / null 以外も null)
  *
  * 戻り値:
  *   `null`            : パース不能 (= AI 失敗扱い、`none` のまま残す)
  *   `[]`              : 分解不要 (= `skipped`)
- *   `DecomposedChild[]` (1+ 件): 採用する子配列
+ *   `DecomposedChild[]` (2+ 件): 採用する子配列
  */
 export function parseDecomposeResponse(text: string): DecomposedChild[] | null {
   const stripped = stripMarkdownFence(text).trim();
@@ -171,13 +171,14 @@ export function parseDecomposeResponse(text: string): DecomposedChild[] | null {
   for (const entry of parsed) {
     const child = normalizeChild(entry);
     if (child) children.push(child);
-    if (children.length >= MAX_CHILDREN) break;
   }
 
   // 1 件しか取れなかった = 実質「分解されていない」ので skipped 扱いに倒す。
   // ADR 0017 Decision 4 / vision「気づいたら細かくなってる」と整合させる
   // (1 → 1 の置き換えはユーザーから見て分解が起きたように見えない)。
-  if (children.length < MIN_CHILDREN) return [];
+  // ADR 0049 で「件数の上限」は撤廃したが、この「1 件 → []」は件数 cap ではなく
+  // 「実質分解されたか」の品質ガードなので残す。
+  if (children.length < 2) return [];
 
   return children;
 }


### PR DESCRIPTION
## 概要 (What)

AI タスク分解の `MIN_CHILDREN=2 / MAX_CHILDREN=7` の静的閾値を撤廃。件数の自然さは AI の判断に委ね、章立てのある本や複数手順タスクで数十件規模の分解を許容する。

## 関連 Issue

Closes #215

## 背景 (Why)

[ADR-0049](../blob/main/docs/adr/0049-remove-ai-decompose-children-count-limit.md) に従う。Phase 1/2 で「異常な大量出力を避ける」初期ガードとして入れた `2〜7 件` の閾値が、章立てのある本（8 章単位で割りたい）/ 複数手順タスク / 旅程組み立てなどで支配的に効き、AI が「自然な分け方」を出せなくなっていた。結果として user が手動で resplit する負担が増え、AI 分解の体感価値が下がっていた。

milestone 9「大量に分解されたタスクの進捗体験」は数十件規模の分解を前提にしているため、本 issue を片付けることで #166（ParallelogramProgress 大量分解 UX 再設計）の前提条件が揃う。

## Before → After (概念・フロー・メンタルモデル)

**Before:** 件数は「2〜7 件」という開発者が決めた静的属性で縛られていた。AI が章立てに沿って 12 件出しても、parser が先頭 7 件で切り捨てていた。

**After:** 件数は AI が内容に応じて判断する（属性ベースから行動ベースへ近づく）。アプリ側は件数を理由に reject しない。「1 件のみ → `[]`（skipped）」のフェイルソフトは件数 cap ではなく「実質分解されたか」の品質ガードとして残す（1 → 1 の置き換えはユーザーから見て分解が起きたように見えないため）。

## 追加したテスト (How verified)

- [x] `decompose.test.ts` 既存テストを ADR 0049 前提に更新（旧「2〜7 件」アサーションを「自然な単位 / 件数の上限は無く」に置換）
- [x] 35 件分解がそのまま採用されるケースを新規追加（旧「8 件以上は先頭 7 件で切る」テストを置換）
- [x] `npm run check`（format + lint + typecheck + 51 ファイル / 610 テスト）green
- [x] 既存呼び出し元（`decompose-server.ts` / `resplit-server.ts`）に件数依存ロジック無しを確認

## このPRの範囲外 (Out of scope)

- 大量分解時の UI 破綻（`ParallelogramProgress` が 10 件超で破綻する件） → #166 で扱う
- 大粒度子タスクの自動再分解ループ → #212
- AI 分解での Web 検索 / Skills 等のドメイン知識補強 → #209 / #210
- 異常出力（数百件超など）の検知 → 必要が顕在化したら別 ADR で起票（事前最適化しない）

---
_Generated by [Claude Code](https://claude.ai/code/session_01URsWtEkKNvqgm6RduJCpUr)_