### PR TITLE
fix(calendar): 終日 / ゼロ長 event を heuristic で取り込み・表示する (ADR-0050)

### DIFF
--- a/docs/adr/0050-zero-and-full-day-event-handling.md
+++ b/docs/adr/0050-zero-and-full-day-event-handling.md
@@ -1,0 +1,76 @@
+# ADR 0050: ゼロ長 / 終日イベントを heuristic で扱う
+
+- **Status**: Accepted
+- **Date**: 2026-05-06
+- **Related**: Issue #221 / Issue #222 / [ADR-0033](./0033-events-cross-source-uniqueness.md) / [ADR-0049](./0049-primary-calendar-id-as-resolved-real-id.md)
+
+## Context
+
+Google Calendar から取り込む event のうち、kozutsumi 上で「特殊な時間幅」をもつ 2 種類の扱いが未整理だった。
+
+1. **終日 event** (Issue #221)
+   - Google API は `start.date` / `end.date` (date-only, exclusive) で表現する
+   - sync mapper は `start.date` / `end.date` を JST 00:00 として 24h の `[start, end)` に正規化して `events.start_time` / `end_time` に保存する
+   - DB 上は `start = JST 00:00`, `end = 翌 JST 00:00`、終日フラグそのものは捨てている
+   - UI は `HH:mm-HH:mm` で出すため「`00:00 - 00:00`」と表示され、終日であることが分からない
+2. **ゼロ長 event** (Issue #222)
+   - `18:00 までに学童のお迎え` のように `start === end` で登録される締切系の予定
+   - DB 制約 `events_time_order check (end_time > start_time)` (strict) で弾かれて取り込みに失敗する
+   - PR #220 (Issue #219 救済) でゼロ長は「skipped」に分類していたが、実害がある締切系は取り込みたい
+
+両者は表面的には別 issue だが、内側では同じ問題を抱える:
+
+- DB 上 `start_time` / `end_time` だけ持っていて、event の「種類」(timed / 終日 / 締切) を表す軸がない
+- UI が `HH:mm-HH:mm` 一辺倒で、特殊な時間幅を上手く表現できない
+- 将来 multi-tz 対応 (ADR-0049 でも触れた将来課題) が入ると、終日の JST 固定 heuristic は破綻する
+
+## Decision
+
+「ゼロ長 / 終日 を含む特殊な時間幅 event」を **DB schema を変えずに heuristic で扱う**。
+
+具体的には:
+
+1. **DB 制約**: `events_time_order` を `end_time > start_time` から `end_time >= start_time` に緩める。逆順 (`end < start`) は引き続き不正データとして弾く。
+2. **sync mapper**: `resolveEventTimes` の skip 条件を「逆順のみ」に縮める。ゼロ長は upsert に乗せる。
+3. **判定の集約**: `src/shared/lib/time.ts` に純粋関数として `isAllDayEvent(event)` / `isDeadlineEvent(event)` を 1 つずつ置く。heuristic は以下:
+   - `isAllDayEvent`: start_time が JST 00:00 ぴったり、かつ duration が 24h の正の倍数
+   - `isDeadlineEvent`: `start_time === end_time`
+4. **UI 分岐**: 上記 2 関数を読むコンポーネントで、`HH:mm-HH:mm` 表示の代わりに以下を出す:
+   - 終日: 「終日」 pill。複数日の終日は期間も補足
+   - ゼロ長: ⏰ アイコン + `HH:mm` (締切感)
+   - DayTimeline では終日 event を時刻判定 (`isPast` / `isNow` / `isNext`) から除外し、常に「今日中」として上段に表示する
+
+判定 heuristic は **必ずこの 2 関数経由** で行い、UI / 表示計算ロジックに散らさない。
+
+## Consequences
+
+### 肯定的影響
+
+- DB migration 1 枚 + heuristic 関数 1 ペアで両 issue を一気に解決できる (低コスト)
+- 終日 / 締切系の予定が UI 上で意味のある形で可視化される
+- heuristic の集約点が 1 箇所なので、将来 schema 化 (`is_all_day` 等のカラム追加) するときの差し替えが容易
+
+### 否定的影響・トレードオフ
+
+- **マルチタイムゾーン対応を入れた瞬間に終日 heuristic は破綻する**: `start_time = JST 00:00` 前提なので、別 tz のユーザーが終日予定を作ったら誤判定する。kozutsumi が単一ユーザー前提で JST 固定 (ADR-0049 で言及された将来課題) のため、現状は許容する。
+- ユーザーが意図的に `00:00 - 24:00` (JST) の timed event を作った場合は終日と誤判定される。頻度はほぼゼロ・実害も低いと判断。
+- `events_time_order` を緩めることで「end < start」だけが invariant になる。完全にゼロ長を弾く性質を失うため、DB 直叩きで意図しないデータが入る余地がある。code 側 (sync mapper / event form validation) で網羅する前提で受け入れる。
+
+## Alternatives considered
+
+- **DB スキーマに `is_all_day` (boolean) を追加 (案 A)**
+  - 確実・曖昧さなし。multi-tz 対応時にも壊れない
+  - 不採用理由: 現時点で実害が出ていない (単一ユーザー / JST 固定) のに対して、migration + sync mapper / UI 双方の改修コストが大きい。実害が出てから移行する方が筋が良い。本 ADR を supersede する trigger として `Notes` に残す。
+- **ゼロ長 event を許容しない (案 X)**
+  - DB 制約を strict のまま保ち、ユーザーに「`18:00-18:30`」等で登録してもらう
+  - 不採用理由: Google Calendar 側でユーザーが既に「`18:00`」だけで登録する習慣があり、kozutsumi 側の制約のために登録方法を変えるのは本末転倒。
+- **2 ADR に分割 (案 Y)**
+  - `events_time_order` 緩和と heuristic 表示は厳密には独立に supersede されうる
+  - 不採用理由: 「ゼロ長を許容したから heuristic を整える」「終日 heuristic を整えるなら同時にゼロ長も heuristic で扱う」という結合が強く、将来の supersede trigger も「schema で表現する」という共通の 1 つに集約される見込み。読みやすさを優先して 1 枚にした。
+
+## Notes
+
+- 本 ADR を supersede する代表的な trigger:
+  - kozutsumi がマルチタイムゾーン対応する → 終日 heuristic が破綻するので案 A (`is_all_day` カラム追加) に切り替える
+  - 「締切系」が独立したエンティティとして必要になる (例: 通知 / 順序付けで特殊扱い) → `events.kind` enum 等で表現する
+- 「終日」「締切」をスタック計画ロジックでどう扱うか (例: 終日は ToDo に降ろさない、締切は依存条件として task に紐づけられる) は将来の判断。本 ADR は表示と取り込みの正規化のみ扱う。

--- a/src/entities/event/sync.test.ts
+++ b/src/entities/event/sync.test.ts
@@ -57,14 +57,17 @@ describe("resolveEventTimes", () => {
     expect(resolveEventTimes({ id: "e3", start: {}, end: {} })).toBeNull();
   });
 
-  test("end === start のゼロ長イベントは null を返す (events_time_order 違反回避 / Issue #219)", () => {
+  test("end === start のゼロ長イベントは取り込む (ADR-0050 / Issue #222 締切系)", () => {
     expect(
       resolveEventTimes({
         id: "zero-length",
         start: { dateTime: "2026-04-23T10:00:00+09:00" },
         end: { dateTime: "2026-04-23T10:00:00+09:00" },
       }),
-    ).toBeNull();
+    ).toEqual({
+      start: "2026-04-23T01:00:00.000Z",
+      end: "2026-04-23T01:00:00.000Z",
+    });
   });
 
   test("end < start の逆順イベントは null を返す (events_time_order 違反回避 / Issue #219)", () => {
@@ -77,14 +80,17 @@ describe("resolveEventTimes", () => {
     ).toBeNull();
   });
 
-  test("終日イベントで start.date === end.date のゼロ長は null を返す", () => {
+  test("終日イベントで start.date === end.date のゼロ日終日も取り込む (ADR-0050)", () => {
     expect(
       resolveEventTimes({
         id: "all-day-zero",
         start: { date: "2026-04-23" },
         end: { date: "2026-04-23" },
       }),
-    ).toBeNull();
+    ).toEqual({
+      start: "2026-04-22T15:00:00.000Z",
+      end: "2026-04-22T15:00:00.000Z",
+    });
   });
 });
 
@@ -209,7 +215,7 @@ describe("partitionEvents", () => {
     ]);
   });
 
-  test("ゼロ長 / 逆順イベントは skipped に invalid_time_range として分類される (Issue #219)", () => {
+  test("ゼロ長は upsert に乗り、逆順だけ skipped に invalid_time_range として残る (ADR-0050)", () => {
     const events: GoogleCalendarEvent[] = [
       {
         id: "ok",
@@ -233,14 +239,8 @@ describe("partitionEvents", () => {
 
     const result = partitionEvents(events, "shared");
 
-    expect(result.upserts.map((u) => u.externalId)).toEqual(["ok"]);
+    expect(result.upserts.map((u) => u.externalId)).toEqual(["ok", "zero"]);
     expect(result.skipped).toEqual([
-      {
-        externalCalendarId: "shared",
-        externalId: "zero",
-        title: "ゼロ長",
-        reason: "invalid_time_range",
-      },
       {
         externalCalendarId: "shared",
         externalId: "reversed",
@@ -536,7 +536,7 @@ describe("syncGoogleCalendar (full sync)", () => {
     expect(listEvents).toHaveBeenCalledTimes(2);
   });
 
-  test("不正な時刻の予定は upsert からスキップされ SyncResult.skipped に集約される (Issue #219)", async () => {
+  test("逆順の予定は upsert からスキップされ SyncResult.skipped に集約される (Issue #219 / ADR-0050)", async () => {
     const { gateway, upsertCalls } = makeFakeGateway();
     const listEvents = vi.fn<ListEventsFn>(async (params) => {
       if (params.calendarId === "primary") {
@@ -549,10 +549,10 @@ describe("syncGoogleCalendar (full sync)", () => {
         items: [
           makeActiveEvent("shared-ok"),
           {
-            id: "shared-zero",
-            summary: "ゼロ長",
-            start: { dateTime: "2026-04-23T12:00:00Z" },
-            end: { dateTime: "2026-04-23T12:00:00Z" },
+            id: "shared-reversed",
+            summary: "逆順",
+            start: { dateTime: "2026-04-23T13:00:00Z" },
+            end: { dateTime: "2026-04-23T12:30:00Z" },
           },
         ],
         nextSyncToken: "tok-shared",
@@ -584,8 +584,8 @@ describe("syncGoogleCalendar (full sync)", () => {
     expect(result.skipped).toEqual([
       {
         externalCalendarId: "shared@group.calendar.google.com",
-        externalId: "shared-zero",
-        title: "ゼロ長",
+        externalId: "shared-reversed",
+        title: "逆順",
         reason: "invalid_time_range",
       },
     ]);

--- a/src/entities/event/sync.ts
+++ b/src/entities/event/sync.ts
@@ -559,7 +559,10 @@ export function partitionEvents(
 /**
  * `mapGoogleEventToUpsertInput` が `null` を返した event の理由を分類する。
  * - 時刻情報が片側欠損 / 両側欠損 → `missing_time`
- * - 時刻はあるが end <= start → `invalid_time_range` (events_time_order 違反 / Issue #219)
+ * - 時刻はあるが end < start (逆順) → `invalid_time_range` (events_time_order 違反 / Issue #219)
+ *
+ * ゼロ長 (`end === start`) は ADR-0050 / Issue #222 により締切系として取り込むので
+ * skip 対象から外している。
  */
 function classifySkipReason(event: GoogleCalendarEvent): SkippedEvent["reason"] {
   const hasDateTimePair = Boolean(event.start?.dateTime && event.end?.dateTime);
@@ -603,10 +606,11 @@ export function resolveEventTimes(
     };
   }
   if (!times) return null;
-  // events_time_order check (end_time > start_time) を満たさない event は丸ごとスキップする。
+  // events_time_order check (end_time >= start_time) を満たさない event は丸ごとスキップする。
   // 1 件でも違反があると Supabase の batch upsert が calendar 単位で全件ロールバックされ、
   // その calendar の取り込みが完全に失われるため (Issue #219)。
-  if (Date.parse(times.end) <= Date.parse(times.start)) return null;
+  // ゼロ長 (end === start) は ADR-0050 / Issue #222 により締切系として取り込む。
+  if (Date.parse(times.end) < Date.parse(times.start)) return null;
   return times;
 }
 

--- a/src/features/day-timeline/EventCard.tsx
+++ b/src/features/day-timeline/EventCard.tsx
@@ -1,7 +1,15 @@
 import { EVENT_SOURCE, type Event } from "../../entities/event/types";
 import { getProject } from "../../entities/project/projects";
 import { useProjects } from "../../entities/project/ProjectsContext";
-import { fmtDuration, formatClock, minutesOfDay } from "../../shared/lib/time";
+import {
+  allDayDayCount,
+  fmtDuration,
+  formatAllDayRange,
+  formatClock,
+  isAllDayEvent,
+  isDeadlineEvent,
+  minutesOfDay,
+} from "../../shared/lib/time";
 import { GoogleCalendarBadge } from "../../entities/event/GoogleCalendarBadge";
 
 type EventCardProps = {
@@ -13,11 +21,15 @@ type EventCardProps = {
 
 export function EventCard({ event, nowMin, isNextCandidate, onClick }: EventCardProps) {
   const { projectsById } = useProjects();
+  // ADR-0050: 終日 / ゼロ長 event は時刻判定 (past / now / next) を持たない。
+  // 終日は「今日中ずっと有効」、ゼロ長 (締切系) は時点で完結し past/now で揺れさせない。
+  const isAllDay = isAllDayEvent(event);
+  const isDeadline = !isAllDay && isDeadlineEvent(event);
   const evStart = minutesOfDay(event.startTime);
   const evEnd = minutesOfDay(event.endTime);
-  const isPast = evEnd <= nowMin;
-  const isNow = evStart <= nowMin && evEnd > nowMin;
-  const isNext = isNextCandidate && !isNow;
+  const isPast = !isAllDay && !isDeadline && evEnd <= nowMin;
+  const isNow = !isAllDay && !isDeadline && evStart <= nowMin && evEnd > nowMin;
+  const isNext = !isAllDay && !isDeadline && isNextCandidate && !isNow;
   const evColor = event.projectId ? getProject(projectsById, event.projectId).color : "#52525b";
   const hasAttachments = event.hasAttachments;
   const hasMeet = !!event.meetUrl;
@@ -36,10 +48,35 @@ export function EventCard({ event, nowMin, isNextCandidate, onClick }: EventCard
       }}
     >
       <div className="flex items-center gap-2">
-        <span className="shrink-0 text-[10px] tabular-nums text-fg-weak">
-          {formatClock(event.startTime)}–{formatClock(event.endTime)}
-        </span>
-        <span className="shrink-0 text-[9px] text-fg-faint">({fmtDuration(evEnd - evStart)})</span>
+        {isAllDay ? (
+          <span
+            aria-label="終日"
+            className="shrink-0 rounded-[3px] border border-bg-divider px-1.5 py-px font-jp text-[9px] text-fg-subtle"
+          >
+            終日
+          </span>
+        ) : isDeadline ? (
+          <span
+            aria-label={`${formatClock(event.startTime)} 締切`}
+            className="shrink-0 text-[10px] tabular-nums text-fg-weak"
+          >
+            ⏰ {formatClock(event.startTime)}
+          </span>
+        ) : (
+          <>
+            <span className="shrink-0 text-[10px] tabular-nums text-fg-weak">
+              {formatClock(event.startTime)}–{formatClock(event.endTime)}
+            </span>
+            <span className="shrink-0 text-[9px] text-fg-faint">
+              ({fmtDuration(evEnd - evStart)})
+            </span>
+          </>
+        )}
+        {isAllDay && allDayDayCount(event) > 1 ? (
+          <span className="shrink-0 text-[9px] tabular-nums text-fg-faint">
+            ({formatAllDayRange(event)})
+          </span>
+        ) : null}
         <span
           className={`flex-1 truncate font-jp text-[11px] ${
             isNow ? "font-medium text-fg-emphasized" : "font-normal text-fg-muted"

--- a/src/features/event-detail/EventDetailPanel.tsx
+++ b/src/features/event-detail/EventDetailPanel.tsx
@@ -7,7 +7,10 @@ import { getProject } from "../../entities/project/projects";
 import { useProjects } from "../../entities/project/ProjectsContext";
 import {
   fmtDuration,
+  formatAllDayRange,
   formatClock,
+  isAllDayEvent,
+  isDeadlineEvent,
   minutesOfDay,
   toDateTimeLocalInput,
 } from "../../shared/lib/time";
@@ -64,6 +67,9 @@ export function EventDetailPanel({
   const evStart = minutesOfDay(event.startTime);
   const evEnd = minutesOfDay(event.endTime);
   const duration = evEnd - evStart;
+  // ADR-0050: 終日 / ゼロ長 (締切系) は時刻 + duration の代わりに専用ラベルを出す。
+  const isAllDay = isAllDayEvent(event);
+  const isDeadline = !isAllDay && isDeadlineEvent(event);
   const isZoom = !!event.meetUrl?.includes("zoom");
   const meetLabel = event.meetUrl?.includes("zoom")
     ? "Zoom"
@@ -208,10 +214,29 @@ export function EventDetailPanel({
               <div className="mb-2 flex items-center gap-2">
                 {proj && <div className="h-2 w-2 rounded-full" style={{ background: evColor }} />}
                 {proj && <span className="font-jp text-[10px] text-fg-subtle">{proj.name}</span>}
-                <span className="text-[10px] tabular-nums text-fg-weak">
-                  {formatClock(event.startTime)}–{formatClock(event.endTime)} (
-                  {fmtDuration(duration)})
-                </span>
+                {isAllDay ? (
+                  <span className="text-[10px] tabular-nums text-fg-weak">
+                    <span
+                      aria-label="終日"
+                      className="mr-1.5 rounded-[3px] border border-bg-divider px-1.5 py-px font-jp text-[10px] text-fg-subtle"
+                    >
+                      終日
+                    </span>
+                    {formatAllDayRange(event)}
+                  </span>
+                ) : isDeadline ? (
+                  <span
+                    aria-label={`${formatClock(event.startTime)} 締切`}
+                    className="text-[10px] tabular-nums text-fg-weak"
+                  >
+                    ⏰ {formatClock(event.startTime)}
+                  </span>
+                ) : (
+                  <span className="text-[10px] tabular-nums text-fg-weak">
+                    {formatClock(event.startTime)}–{formatClock(event.endTime)} (
+                    {fmtDuration(duration)})
+                  </span>
+                )}
                 {isGoogleCalendar && <GoogleCalendarBadge size="md" />}
                 <div className="flex-1" />
                 {canDelete ? (

--- a/src/features/event-management/EventManagement.tsx
+++ b/src/features/event-management/EventManagement.tsx
@@ -5,7 +5,14 @@ import { useMemo, useState } from "react";
 import type { CalendarSubscription } from "@/entities/calendar-subscription/types";
 import { GoogleCalendarBadge } from "@/entities/event/GoogleCalendarBadge";
 import { EVENT_SOURCE, type Event, type EventVisibilityOverride } from "@/entities/event/types";
-import { fmtDuration, formatClock, localDateOf } from "@/shared/lib/time";
+import {
+  fmtDuration,
+  formatAllDayRange,
+  formatClock,
+  isAllDayEvent,
+  isDeadlineEvent,
+  localDateOf,
+} from "@/shared/lib/time";
 
 import { computeEventVisibilityState } from "./visibilityState";
 
@@ -221,6 +228,9 @@ function EventRow({
   const overrideActive = overrideValue !== "none";
   const next: EventVisibilityOverride = effectiveShown ? "hidden" : "shown";
   const buttonLabel = effectiveShown ? "予定化解除" : "予定化する";
+  // ADR-0050: 終日 / ゼロ長は専用ラベルで描画する。
+  const isAllDay = isAllDayEvent(event);
+  const isDeadline = !isAllDay && isDeadlineEvent(event);
   const start = formatClock(event.startTime);
   const end = formatClock(event.endTime);
   const minutes = Math.max(
@@ -278,7 +288,23 @@ function EventRow({
           </div>
         )}
         <div className="mt-0.5 text-[10px] tabular-nums text-fg-weak">
-          {start}–{end} ({fmtDuration(minutes)})
+          {isAllDay ? (
+            <>
+              <span
+                aria-label="終日"
+                className="mr-1.5 rounded-[3px] border border-bg-divider px-1 py-px font-jp text-[9px] text-fg-subtle"
+              >
+                終日
+              </span>
+              {formatAllDayRange(event)}
+            </>
+          ) : isDeadline ? (
+            <span aria-label={`${start} 締切`}>⏰ {start}</span>
+          ) : (
+            <>
+              {start}–{end} ({fmtDuration(minutes)})
+            </>
+          )}
         </div>
       </div>
       <div className="flex shrink-0 items-center">

--- a/src/features/settings/SettingsPanel.tsx
+++ b/src/features/settings/SettingsPanel.tsx
@@ -4,7 +4,13 @@ import { useEffect, useMemo, useState } from "react";
 
 import type { CalendarSubscription } from "@/entities/calendar-subscription/types";
 import { EVENT_SOURCE, type Event, type EventVisibilityOverride } from "@/entities/event/types";
-import { formatClock, localDateOf } from "@/shared/lib/time";
+import {
+  formatAllDayRange,
+  formatClock,
+  isAllDayEvent,
+  isDeadlineEvent,
+  localDateOf,
+} from "@/shared/lib/time";
 
 import { useCalendarSubscriptions, type CalendarListItem } from "./useCalendarSubscriptions";
 
@@ -271,8 +277,29 @@ function OverridesSection({
                   {event.title}
                 </div>
                 <div className="mt-0.5 text-[10px] tabular-nums text-fg-weak">
-                  {localDateOf(event.startTime)} {formatClock(event.startTime)}–
-                  {formatClock(event.endTime)}
+                  {isAllDayEvent(event) ? (
+                    <>
+                      <span
+                        aria-label="終日"
+                        className="mr-1.5 rounded-[3px] border border-bg-divider px-1 py-px font-jp text-[9px] text-fg-subtle"
+                      >
+                        終日
+                      </span>
+                      {formatAllDayRange(event)}
+                    </>
+                  ) : isDeadlineEvent(event) ? (
+                    <>
+                      {localDateOf(event.startTime)}{" "}
+                      <span aria-label={`${formatClock(event.startTime)} 締切`}>
+                        ⏰ {formatClock(event.startTime)}
+                      </span>
+                    </>
+                  ) : (
+                    <>
+                      {localDateOf(event.startTime)} {formatClock(event.startTime)}–
+                      {formatClock(event.endTime)}
+                    </>
+                  )}
                 </div>
               </div>
               <div className="flex shrink-0 items-center">

--- a/src/shared/lib/time.test.ts
+++ b/src/shared/lib/time.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, test } from "vitest";
 import {
+  allDayDayCount,
+  formatAllDayRange,
   formatDate,
+  formatJstMonthDay,
   formatRelativeTime,
   fmtDuration,
   fmtMin,
+  isAllDayEvent,
+  isDeadlineEvent,
   localDateOf,
   timeToMin,
   toDateTimeLocalInput,
@@ -93,6 +98,126 @@ describe("localDateOf", () => {
 
   test("月日は 2 桁ゼロ埋めする", () => {
     expect(localDateOf("2026-01-02T03:04:05")).toBe("2026-01-02");
+  });
+});
+
+describe("isAllDayEvent (ADR-0050)", () => {
+  test("JST 00:00 開始 + 24h で終日と判定する", () => {
+    expect(
+      isAllDayEvent({
+        // 2026-05-06 JST 00:00 = 2026-05-05 15:00 UTC
+        startTime: "2026-05-05T15:00:00.000Z",
+        endTime: "2026-05-06T15:00:00.000Z",
+      }),
+    ).toBe(true);
+  });
+
+  test("JST 00:00 開始 + 24h の倍数 (複数日終日) も true", () => {
+    expect(
+      isAllDayEvent({
+        startTime: "2026-05-05T15:00:00.000Z",
+        endTime: "2026-05-08T15:00:00.000Z", // 3 日連続
+      }),
+    ).toBe(true);
+  });
+
+  test("JST 00:00 開始でも duration が 24h 未満なら false", () => {
+    expect(
+      isAllDayEvent({
+        startTime: "2026-05-05T15:00:00.000Z",
+        endTime: "2026-05-06T03:00:00.000Z",
+      }),
+    ).toBe(false);
+  });
+
+  test("JST 00:00 開始でも duration が 0 なら false (ゼロ長は終日ではない)", () => {
+    expect(
+      isAllDayEvent({
+        startTime: "2026-05-05T15:00:00.000Z",
+        endTime: "2026-05-05T15:00:00.000Z",
+      }),
+    ).toBe(false);
+  });
+
+  test("JST 00:00 でない開始は false (通常の timed event)", () => {
+    expect(
+      isAllDayEvent({
+        // 2026-05-06 JST 10:00
+        startTime: "2026-05-06T01:00:00.000Z",
+        endTime: "2026-05-06T02:00:00.000Z",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("isDeadlineEvent (ADR-0050)", () => {
+  test("start === end は true", () => {
+    expect(
+      isDeadlineEvent({
+        startTime: "2026-05-06T09:00:00.000Z",
+        endTime: "2026-05-06T09:00:00.000Z",
+      }),
+    ).toBe(true);
+  });
+
+  test("start !== end は false", () => {
+    expect(
+      isDeadlineEvent({
+        startTime: "2026-05-06T09:00:00.000Z",
+        endTime: "2026-05-06T10:00:00.000Z",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("allDayDayCount", () => {
+  test("単日終日は 1", () => {
+    expect(
+      allDayDayCount({
+        startTime: "2026-05-05T15:00:00.000Z",
+        endTime: "2026-05-06T15:00:00.000Z",
+      }),
+    ).toBe(1);
+  });
+
+  test("3 日連続終日は 3", () => {
+    expect(
+      allDayDayCount({
+        startTime: "2026-05-05T15:00:00.000Z",
+        endTime: "2026-05-08T15:00:00.000Z",
+      }),
+    ).toBe(3);
+  });
+});
+
+describe("formatJstMonthDay", () => {
+  test("UTC ISO を JST の M/D で返す", () => {
+    // 2026-05-05 15:00 UTC = 2026-05-06 JST
+    expect(formatJstMonthDay("2026-05-05T15:00:00.000Z")).toBe("5/6");
+  });
+
+  test("日付境界ケース (UTC 23:30 = JST 翌 8:30) でも JST 日付を返す", () => {
+    expect(formatJstMonthDay("2026-05-05T23:30:00.000Z")).toBe("5/6");
+  });
+});
+
+describe("formatAllDayRange", () => {
+  test("単日終日は M/D だけ返す", () => {
+    expect(
+      formatAllDayRange({
+        startTime: "2026-05-05T15:00:00.000Z",
+        endTime: "2026-05-06T15:00:00.000Z",
+      }),
+    ).toBe("5/6");
+  });
+
+  test("複数日終日は inclusive 末日まで M/D → M/D 形式で返す", () => {
+    expect(
+      formatAllDayRange({
+        startTime: "2026-05-05T15:00:00.000Z",
+        endTime: "2026-05-08T15:00:00.000Z", // exclusive end (= 5/9 JST 00:00 ではなく 5/8 JST 24:00)
+      }),
+    ).toBe("5/6 → 5/8");
   });
 });
 

--- a/src/shared/lib/time.ts
+++ b/src/shared/lib/time.ts
@@ -75,6 +75,76 @@ const MS_PER_MIN = 60 * 1000;
 const MS_PER_HOUR = 60 * MS_PER_MIN;
 const MS_PER_DAY = 24 * MS_PER_HOUR;
 
+// ADR-0050: 終日 / ゼロ長 event を heuristic で扱う。
+// kozutsumi は JST 固定 (ADR-0049 で言及した将来課題) のため、終日判定も JST 基準で行う。
+const JST_OFFSET_MS = 9 * MS_PER_HOUR;
+
+type EventTimes = { startTime: string; endTime: string };
+
+/**
+ * 「終日」event 判定 (ADR-0050)。Google Calendar の `start.date` / `end.date` 表現を
+ * sync mapper が `[JST 00:00, JST 翌 00:00)` の 24h 区間に正規化して保存する前提で、
+ * 「JST 00:00 ぴったり開始」かつ「duration が 24h の正の倍数」を終日とみなす。
+ *
+ * 単一ユーザー / JST 固定なので local TZ に依存しない計算 (JST 固定 offset) を行う。
+ */
+export function isAllDayEvent(event: EventTimes): boolean {
+  const startMs = Date.parse(event.startTime);
+  const endMs = Date.parse(event.endTime);
+  if (Number.isNaN(startMs) || Number.isNaN(endMs)) return false;
+  if ((startMs + JST_OFFSET_MS) % MS_PER_DAY !== 0) return false;
+  const duration = endMs - startMs;
+  return duration > 0 && duration % MS_PER_DAY === 0;
+}
+
+/**
+ * 「ゼロ長 / 締切系」event 判定 (ADR-0050)。`start === end` を「`HH:mm までに ○○`」
+ * のような締切として扱う。
+ */
+export function isDeadlineEvent(event: EventTimes): boolean {
+  const startMs = Date.parse(event.startTime);
+  const endMs = Date.parse(event.endTime);
+  if (Number.isNaN(startMs) || Number.isNaN(endMs)) return false;
+  return startMs === endMs;
+}
+
+/**
+ * 終日 event の含まれる日数。`isAllDayEvent` が true な前提で 1 以上の整数を返す。
+ * 1 → 単日終日、N → N 日連続の終日 (旅行・出張等)。
+ */
+export function allDayDayCount(event: EventTimes): number {
+  const startMs = Date.parse(event.startTime);
+  const endMs = Date.parse(event.endTime);
+  if (Number.isNaN(startMs) || Number.isNaN(endMs)) return 1;
+  return Math.max(1, Math.round((endMs - startMs) / MS_PER_DAY));
+}
+
+/**
+ * UTC ISO 文字列を JST の `M/D` に整形する。終日 event の期間表示で local TZ に
+ * 依存せず日付を取り出すため、JST offset を加えて UTC メソッドで読み出す。
+ */
+export function formatJstMonthDay(iso: string): string {
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return iso;
+  const shifted = new Date(ms + JST_OFFSET_MS);
+  return `${shifted.getUTCMonth() + 1}/${shifted.getUTCDate()}`;
+}
+
+/**
+ * 終日 event の期間ラベル。単日なら `M/D`、複数日なら `M/D → M/D` (inclusive) を返す。
+ * `endTime` は exclusive (= 翌日 JST 00:00) なので 1 日引いて inclusive 末日を出す。
+ */
+export function formatAllDayRange(event: EventTimes): string {
+  const startMs = Date.parse(event.startTime);
+  const endMs = Date.parse(event.endTime);
+  if (Number.isNaN(startMs) || Number.isNaN(endMs)) return formatJstMonthDay(event.startTime);
+  const startLabel = formatJstMonthDay(event.startTime);
+  const days = Math.max(1, Math.round((endMs - startMs) / MS_PER_DAY));
+  if (days <= 1) return startLabel;
+  const lastInclusive = new Date(endMs - MS_PER_DAY).toISOString();
+  return `${startLabel} → ${formatJstMonthDay(lastInclusive)}`;
+}
+
 /** 依存イベントが「直近に迫っている」と判定する閾値 (24h)。タスクカードのハイライト判定に使う。 */
 export const IMMINENT_THRESHOLD_MS = MS_PER_DAY;
 

--- a/supabase/migrations/20260506100000_p3_relax_events_time_order.sql
+++ b/supabase/migrations/20260506100000_p3_relax_events_time_order.sql
@@ -1,0 +1,15 @@
+-- ADR 0050: ゼロ長 / 終日イベントを heuristic で扱う。
+--
+-- ゼロ長 (start === end) の締切系予定 (例: `18:00 までに学童のお迎え`) を取り込めるようにするため、
+-- `events_time_order` 制約を strict (`end > start`) から非 strict (`end >= start`) に緩める。
+-- 逆順 (end < start) は引き続き不正データとして弾く。
+--
+-- References:
+-- * docs/adr/0050-zero-and-full-day-event-handling.md
+-- * Issue #221 / Issue #222
+
+alter table public.events
+  drop constraint if exists events_time_order;
+
+alter table public.events
+  add constraint events_time_order check (end_time >= start_time);


### PR DESCRIPTION
## 概要 (What)

Google Calendar 由来の「特殊な時間幅 event」2 種類を整理して取り込み・表示できるようにした:

- 終日 event (Issue #221) — `00:00 - 00:00` と表示されていたのを「終日」pill に
- ゼロ長 event (Issue #222) — `events_time_order` 違反で取り込めなかった締切系 (`18:00 までに ○○`) を取り込み、⏰ アイコンで表示

## 関連 Issue

Closes #221, Closes #222

## 背景 (Why)

PR #220 (Issue #219 救済) の preview 動作確認中に発覚した 2 件。表面的には別問題だが、内側では「DB 上 `start_time` / `end_time` だけ持っていて event の種類 (timed / 終日 / 締切) を表す軸がない」「UI が `HH:mm-HH:mm` 一辺倒」という同じ構造的問題に起因していたため、1 ADR (ADR-0050) + 1 PR で扱うことにした。

設計判断は [ADR-0050](./docs/adr/0050-zero-and-full-day-event-handling.md):

- DB schema は変えず heuristic で扱う (案 B)。schema 化 (案 A: `is_all_day` カラム) は multi-tz 対応が必要になった時点での supersede trigger として残す
- heuristic は `src/shared/lib/time.ts` の 1 ペア (`isAllDayEvent` / `isDeadlineEvent`) に集約し、UI 側に散らさない

## Before → After (概念・フロー・メンタルモデル)

**Before:**

- 終日 event: 表示が `00:00 - 00:00` で終日であることが分からない
- ゼロ長 event: DB 制約 `events_time_order check (end_time > start_time)` で取り込み拒否 → skipped 扱い
- 「特殊な時間幅 event」を表現する軸が存在しない

**After:**

- 終日: 「終日」pill (複数日は `M/D → M/D` を補足)。DayTimeline では JST 00:00 開始により自然に最上段に並び、past/now/next の時刻判定からは除外して「一日中有効」として常駐
- ゼロ長: ⏰ + `HH:mm` の締切感ある表示で取り込み・表示
- DB 制約は `end_time >= start_time` に緩和し、逆順のみ skip する不変条件に整理

## 追加したテスト (How verified)

- `src/shared/lib/time.test.ts`: `isAllDayEvent` (JST 00:00 開始 + 24h 倍数 / duration 0 / non-aligned)、`isDeadlineEvent`、`allDayDayCount`、`formatJstMonthDay`、`formatAllDayRange` (単日 / 複数日 inclusive 末日)
- `src/entities/event/sync.test.ts`: ゼロ長を「取り込む」方向に書き換え。逆順だけ `invalid_time_range` skipped、`partitionEvents` でゼロ長が upserts に乗るケース
- `npm run typecheck` / `npm run test` (623 passed) / `npm run lint` / `npm run format:check` 全通過
- ⚠️ UI の見た目 (終日 pill のサイズ感、⏰ の意図伝達、複数日終日 `5/6 → 5/8` のリーダブルさ) は preview で目視確認したい

## リリース前チェックリスト (When / Before merge)

- [x] マイグレーション (`20260506100000_p3_relax_events_time_order.sql`) の適用順を確認した — preview DB で apply
- [ ] preview 環境で終日 / ゼロ長 event の見た目を確認 (テキスト切替の余地あり)
- [x] ADR を更新した (`docs/adr/0050-zero-and-full-day-event-handling.md` 新規)

## このPRの範囲外 (Out of scope)

- 終日 / 締切をスタック計画ロジック側でどう扱うか (例: 終日は ToDo に降ろさない、締切は task 依存条件として紐づけ可能にする) — ADR-0050 の Notes に将来検討として記載
- multi-tz 対応 (本 ADR を supersede する trigger)
- ゼロ長 event の表示テキスト案 (`HH:mm 締切` 等) — preview で動作確認後に切替判断

https://claude.ai/code/session_01WomkfFMZibjVuXs1qrZyZ2

---
_Generated by [Claude Code](https://claude.ai/code/session_01WomkfFMZibjVuXs1qrZyZ2)_