### PR TITLE
feat(action-log): user editorial signal を action_log で完全捕捉する (ADR-0051)

### DIFF
--- a/docs/adr/0051-capture-user-editorial-signals-on-decomposition.md
+++ b/docs/adr/0051-capture-user-editorial-signals-on-decomposition.md
@@ -1,0 +1,95 @@
+# ADR 0051: AI 分解への user editorial signal を action_log で完全捕捉する
+
+- **Status**: Accepted
+- **Date**: 2026-05-06
+- **Related**: Issue #214 / 親 roadmap #208 / [ADR-0017](./0017-ai-task-decomposition-async.md) / [ADR-0021](./0021-ai-decomposition-failure-visibility.md) / [ADR-0027](./0027-child-resplit-flatten.md) / [ADR-0030](./0030-child-resplit-action-log.md) / [ADR-0035](./0035-action-log-payload-schema-and-actor-type.md)
+
+## Context
+
+親 roadmap #208 の設計原則「**学習信号の出所は user 起源（編集差分 / 行動指標）であって、AI 出力そのものではない**」（self-reinforcing 回避）を満たすには、AI 分解結果に対する user の editorial action（title 編集 / 子削除 / 子追加 / 再分解）が漏れなく `action_logs` に残っている必要がある。
+
+Issue #214 の現状監査で 2 つの事実が判明:
+
+1. 既存 type 定義は揃っている（`task_title_changed` / `decomposition_modified` (kind: child_deleted/child_edited/parent_merged) / `task_child_resplit`）
+2. しかし `task_title_changed` と `decomposition_modified` の **発火経路が production code に存在しない**（type / logger / server-side FK ハンドリングまで揃っているが、呼び出し側が空）。`grep -r TASK_TITLE_CHANGED src/` の結果は type 定義 / test / logger constants のみ
+
+加えて以下のギャップがある:
+
+- **Gap A (新規)**: 「user が AI 分解後に同階層へ手動で子を追加した」事象の signal が無い。現状は `decomposition_modified` の kind に `child_added` が無く、`task` の create でも logging しない
+- **Gap B (新規)**: resplit (`task_child_resplit`) の `resplit_target_snapshot` は再分解直前の子しか持たず、**「初期 AI 分解」と「再分解」を join するキー**が無い。粒度調整の前後比較を集計クエリで自動再構成できない
+- **Gap C (新規)**: `task_deleted.snapshot` に「分解由来の子か / user 手動追加か」を区別する tag が無く、削除パターン分析時に手作業 join が要る
+
+これらを Phase 4 の暗黙フィードバック分析（#208 軸 2「個人の作業スタイル」）の前提として今のうちに整える必要がある。
+
+## Decision
+
+AI 分解に関わる user の editorial action を action_log で 1:1 に捕捉する。具体的には:
+
+### D1. 既存型の発火経路を実装する（schema 拡張なし）
+
+- `task_title_changed`: 全 task の title 変更で発火（root / 分解子の区別なし、汎用）
+- `decomposition_modified.kind=child_deleted`: 親が `decompose_status='decomposed'` の子を削除した時
+- `decomposition_modified.kind=child_edited`: 親が `decompose_status='decomposed'` の子の title / estimated_minutes が変わった時（`task_title_changed` と**併発で発火**。前者は「title を変えた」、後者は「分解構成が変わった」と意味が異なる）
+- `decomposition_modified.kind=parent_merged`: 分解済み親が削除されて子が孤児化した時（[ADR-0018](./0018-keep-parent-task-id-for-ai-decomposition.md) のセマンティクス記録）
+
+### D2. `decomposition_modified.kind` に `child_added` を追加する
+
+`decompose_status='decomposed'` の親に user が手動で子を追加した操作を捕捉する。`DecompositionModifiedKind` 型を `"child_deleted" | "child_edited" | "parent_merged" | "child_added"` に拡張。**親に既存の AI 分解が無い純粋な手動階層作成は対象外**（学習信号として価値が薄い、かつ「分解の修正」ではない）。
+
+### D3. resplit の lineage を表現するキーを `resplit_target_snapshot` に追加する
+
+`task_child_resplit.metadata.resplit_target_snapshot` に **`source_decomposition_log_id: string | null`** を追加。再分解された子が「どの初期 AI 分解 (`task_decomposed`) で生まれたか」の `action_logs.id` を持つ。
+
+- 親が `task_decomposed` 経由で生まれた子なら、その親の `task_decomposed` ログ id
+- 親が user 手動追加 (Gap A の `child_added`) で生まれた子なら null
+- 親自身が前回 resplit で生まれた子（多段 resplit）なら、ひとつ前の `task_child_resplit` ログ id（resplit chain の遡及）
+
+これで「初期分解 → user 編集 → resplit → user 編集 …」の lineage を log id chain として 1 クエリで再構成できる。
+
+### D4. `task_deleted.snapshot` に `was_decomposition_child: boolean` を追加する
+
+削除前 `parent_task_id != null` かつ親が `decompose_status='decomposed'` だった場合に true。Phase 4 で「分解粒度の偏り」分析時、AI 由来 vs user 起源の子削除を分離できる。
+
+### D5. retention は既存方針を踏襲
+
+ADR-0030 の「`task_deleted` / `decomposition_modified` は task_id を null 上書きしても metadata snapshot で再構成可能」原則に乗る。新規 `child_added` も同方針（snapshot を inline）。TTL は既存 action_logs と同じ（個別 TTL は持たない）。
+
+## Consequences
+
+### 肯定的影響
+
+- AI 分解への editorial feedback の**取りこぼしがゼロ**になる。Phase 4 prompt 個人化の前提が整う（#208 軸 2 の signal 完備）
+- 既存 type 設計を尊重する形で増分的に実装でき、過去ログとの整合（ADR-0035 §6 の backfill しない原則）を崩さない
+- resplit lineage の chain により「user が AI 分解結果をどう変形させたか」が action_logs だけで完結（join 元のテーブル削除に強い、ADR-0030 と整合）
+
+### 否定的影響・トレードオフ
+
+- action_logs の write 量が増える（1 タスク編集で `task_title_changed` + `decomposition_modified.child_edited` の 2 行になるケースが発生）。ただし学習信号としての意味が異なる（汎用 title 変更 vs 分解構成の修正）ので冗長ではない
+- `resplit_target_snapshot.source_decomposition_log_id` は inline の参照 id。元 log が物理削除されない限り解決可能だが、retention で消えた場合は null 同等の扱い（既存 ADR-0030 と同レベルの強度）
+- `decomposition_modified` の発火条件（親が `decomposed` 状態か）を毎回判定する必要がある。実装側で gateway 層に判定を集約する責務が増える
+
+## Alternatives considered
+
+- **案 A: 編集差分は signal #213（行動評価指標）で代替する** → ❌ 行動指標は粒度の粗い客観量（先送り率 / 見積もり誤差等）で、「title をこう書き換えた」のような micro-signal を持たない。両者は相補で、片方では prompt 個人化に届かない
+- **案 B: `decomposition_modified` を廃止し、editorial action を全て独立 type に**（`child_added_by_user` / `child_deleted_after_decompose` / `child_edited_after_decompose` 等）→ ❌ ADR-0035 で確立した「kind で区別する単一 type」設計を破る。type 種類が増えて retrieval / 集計クエリが複雑化、対する利点（型の精緻さ）は kind enum で十分得られる
+- **案 C: 既存型の発火 (D1) だけ実装し、Gap A/B/C は将来検討に回す** → ❌ Gap A/B/C はいずれも「今 schema を整えなければ過去ログが教師信号として使えない」性質（後から backfill できない、ADR-0035 §6）。コストは小さく、後回しにする利得がない
+- **案 D: `task_title_changed` を分解子では発火させない（`decomposition_modified.child_edited` で代替）** → ❌ 「title 変更」は task 全般で発生する横断 signal で、root / 分解子で型を分けるのは retrieval 時に煩雑。両発火させて意味を分ける方が素直
+
+## Notes
+
+### 監査結果の根拠
+
+- `task_title_changed`: 型定義 `src/entities/action-log/types.ts:8,116-120` / logger `src/entities/action-log/logger.ts:26`、production 発火地点ゼロ（`grep -rn TASK_TITLE_CHANGED src/` で test と type 定義のみ）
+- `decomposition_modified`: 型定義 `src/entities/action-log/types.ts:22,212-216` / server.ts:24 で FK null-handling まで実装済み、production 発火地点ゼロ
+- `task_decomposed.metadata.raw_response`: AI 生出力は `src/entities/task/decompose-server.ts:127-179` で完全保存
+- `task_child_resplit.metadata.resplit_target_snapshot`: `src/entities/task/resplit-server.ts:205-223` で再分解直前の子を保存
+
+### 将来見直す条件
+
+- D2 で追加する `child_added` kind が、実装してみると「単発の子追加」と「分解全体の組み直し」を区別できないことが判明した場合 → kind 追加（例: `decomposition_replaced`）または ADR 分割
+- D3 の chain id 解決が retention で頻繁に null になり集計に支障が出る場合 → snapshot の content を `source_decomposition_log_id` 以外で持つ（例: 初期 AI raw_response 本文を resplit_target_snapshot に inline コピー）
+- D4 の `was_decomposition_child` だけでは不足し「どの分解 log の子か」が要る場合 → `decomposition_log_id` を `task_deleted.snapshot` に追加。本 ADR を supersede
+
+### 実装スコープ（本 ADR 外）
+
+実装の単位（PR の切り方 / firing 地点 / migration ファイル）は issue #214 で扱う。本 ADR は「**何を捕捉するか**」と「**action_log のどの type にどう乗せるか**」のみ確定する。

--- a/src/entities/action-log/logger.test.ts
+++ b/src/entities/action-log/logger.test.ts
@@ -97,6 +97,7 @@ describe("log()", () => {
         task_category: "coding",
         status: "idle",
         parent_task_id: null,
+        was_decomposition_child: false,
       },
     });
     await flushMicrotasks();
@@ -112,6 +113,7 @@ describe("log()", () => {
           task_category: "coding",
           status: "idle",
           parent_task_id: null,
+          was_decomposition_child: false,
         },
       },
       actor_type: "user",
@@ -377,6 +379,7 @@ describe("log(task_child_resplit)", () => {
         task_category: "doc",
         task_size: "30m",
         created_at: "2026-04-30T10:00:00.000Z",
+        source_decomposition_log_id: "decompose-log-1",
       },
       new_child_ids: ["new-child-1", "new-child-2", "new-child-3"],
       raw_response: '[{"title":"導入部の構成"},{"title":"本文を書く"},{"title":"最終確認"}]',
@@ -397,6 +400,7 @@ describe("log(task_child_resplit)", () => {
           task_category: "doc",
           task_size: "30m",
           created_at: "2026-04-30T10:00:00.000Z",
+          source_decomposition_log_id: "decompose-log-1",
         },
         new_child_ids: ["new-child-1", "new-child-2", "new-child-3"],
         raw_response: '[{"title":"導入部の構成"},{"title":"本文を書く"},{"title":"最終確認"}]',

--- a/src/entities/action-log/server.ts
+++ b/src/entities/action-log/server.ts
@@ -28,21 +28,31 @@ function extractTaskId(actionType: ActionType, metadata: Record<string, unknown>
   return typeof v === "string" ? v : null;
 }
 
+/**
+ * 戻り値は inserted log id か null (失敗時)。ADR 0051 D3 で `task_child_resplit` の
+ * `source_decomposition_log_id` 解決に使う。既存呼び出しは戻り値を捨てれば互換。
+ */
 export async function logServerSide<T extends ActionType>(
   supabase: SupabaseClient<Database>,
   userId: string,
   actionType: T,
   metadata: ActionMetadataMap[T],
   actorType: ActorType = "user",
-): Promise<void> {
-  const { error } = await supabase.from("action_logs").insert({
-    user_id: userId,
-    action_type: actionType,
-    task_id: extractTaskId(actionType, metadata as unknown as Record<string, unknown>),
-    metadata: metadata as unknown as Json,
-    actor_type: actorType,
-  });
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from("action_logs")
+    .insert({
+      user_id: userId,
+      action_type: actionType,
+      task_id: extractTaskId(actionType, metadata as unknown as Record<string, unknown>),
+      metadata: metadata as unknown as Json,
+      actor_type: actorType,
+    })
+    .select("id")
+    .single();
   if (error) {
     console.error("[action-log/server] insert failed", error);
+    return null;
   }
+  return data?.id ?? null;
 }

--- a/src/entities/action-log/types.ts
+++ b/src/entities/action-log/types.ts
@@ -67,12 +67,20 @@ export type DecomposeFailReason =
  * - child_deleted : 分解結果の子が削除された (= 分解粒度が細かすぎた示唆)
  * - child_edited  : 分解結果の子のタイトル / 見積もりが書き換えられた
  * - parent_merged : 親が削除されて子が孤児化した (= ADR 0018 の「親統合」)
+ * - child_added   : `decompose_status='decomposed'` の親に user が手動で子を追加した
+ *                   (ADR 0051 D2)。純粋な手動階層作成 (親が `decomposed` でない場合) は
+ *                   学習信号として価値が薄いので対象外。`decompose_status` 列の値で
+ *                   schema レベルで自然に区別される。
  *
  * 「子の再分解」は ADR 0030 で独立した action_type `task_child_resplit` に切り出した
  * (metadata に snapshot / new_child_ids / raw_response を inline で持つ必要があり、
  *  decomposition_modified の薄い metadata 構造に乗せると型の一貫性が崩れるため)。
  */
-export type DecompositionModifiedKind = "child_deleted" | "child_edited" | "parent_merged";
+export type DecompositionModifiedKind =
+  | "child_deleted"
+  | "child_edited"
+  | "parent_merged"
+  | "child_added";
 
 export type PauseReason = "meeting" | "interruption" | "voluntary";
 
@@ -103,6 +111,11 @@ export type ActionMetadataMap = {
   // ADR 0035 §5: 削除系は元 entity が物理削除されるため snapshot を必須化する。
   // 過去ログ (snapshot 列が無かった頃) は backfill しない (ADR 0035 §6)。
   // Phase 4 の回避パターン分析: 「どんな未着手タスクが削除されたか」を再構成可能にする。
+  //
+  // ADR 0051 D4: `was_decomposition_child` を追加。削除前 `parent_task_id != null`
+  // かつ親が `decompose_status='decomposed'` だった場合に true。Phase 4 で「分解粒度の偏り」
+  // 分析時、AI 由来 vs user 起源の子削除を分離するための flag。判定不能時 (親不明 / 取得失敗)
+  // は false に倒す (ADR 0035 §6: backfill しない原則 = 不確実は「該当しない」側に振る)。
   task_deleted: {
     task_id: string;
     snapshot: {
@@ -111,6 +124,7 @@ export type ActionMetadataMap = {
       task_category: string | null;
       status: "idle" | "active" | "paused" | "done";
       parent_task_id: string | null;
+      was_decomposition_child: boolean;
     };
   };
   task_title_changed: {
@@ -189,6 +203,13 @@ export type ActionMetadataMap = {
   // 分析で「ユーザーが粒度を変えた」シグナル + dangling task_id 解決のために inline で保存する。
   // new_child_ids は再分解で生まれた子 id 配列 (順序は stack_order 昇順)。
   // raw_response は Gemini の生応答 (詳細パネルの折りたたみ表示 / 学習素材)。
+  //
+  // ADR 0051 D3: `source_decomposition_log_id` を resplit_target_snapshot に追加。
+  // 再分解された子が「どの初期 AI 分解 (`task_decomposed`) または前回 resplit
+  // (`task_child_resplit`) で生まれたか」の `action_logs.id` を持つ。多段 resplit chain は
+  // ひとつ前の `task_child_resplit` ログ id で連鎖を表現し、再帰的に初期分解まで遡れる。
+  // null になるケース: (a) 親が user 手動追加 (`child_added`) 起点 / (b) retention で
+  // 元 log が消えた / (c) lineage 解決クエリの fail-soft (集計で許容、ADR 0013)。
   task_child_resplit: {
     task_id: string;
     parent_id: string;
@@ -202,6 +223,7 @@ export type ActionMetadataMap = {
       // 既存タスク・未設定では null。
       task_size: string | null;
       created_at: string;
+      source_decomposition_log_id: string | null;
     };
     new_child_ids: string[];
     raw_response: string;

--- a/src/entities/task/decompose-server.test.ts
+++ b/src/entities/task/decompose-server.test.ts
@@ -43,9 +43,20 @@ function makeSupabase(plan: Plan): {
   const from = vi.fn((table: string) => {
     if (table === "action_logs") {
       return {
+        // ADR 0051 D3: logServerSide が `.insert(...).select("id").single()` を呼ぶように
+        // なったので mock chain にもそれを反映する。戻り値の id は test 側で使わないので
+        // 固定値で十分。
         insert: (payload: unknown) => {
           calls.actionLogs.push(payload);
-          return Promise.resolve({ error: plan.insertActionLogs.error });
+          return {
+            select: () => ({
+              single: () =>
+                Promise.resolve({
+                  data: plan.insertActionLogs.error ? null : { id: "log-id-mock" },
+                  error: plan.insertActionLogs.error,
+                }),
+            }),
+          };
         },
       };
     }

--- a/src/entities/task/resplit-server.test.ts
+++ b/src/entities/task/resplit-server.test.ts
@@ -39,11 +39,36 @@ function makeSupabase(plan: Plan): {
 
   const from = vi.fn((table: string) => {
     if (table === "action_logs") {
+      // ADR 0051 D3: 2 系統の chain がある:
+      //   (a) insert(...).select("id").single(): logServerSide の log 書き込み
+      //   (b) select("id").eq("action_type",...).contains(...).order(...).limit(...).maybeSingle():
+      //       resolveSourceDecompositionLogId の lineage 検索
+      // (b) は test では「該当なし (= 手動 child_added 起点 / retention 消失)」を返す
+      // のがデフォルトで OK。lineage のテスト目的の場合は plan に上書きを足す。
       return {
         insert: (payload: unknown) => {
           calls.actionLogs.push(payload);
-          return Promise.resolve({ error: plan.insertActionLogs.error });
+          return {
+            select: () => ({
+              single: () =>
+                Promise.resolve({
+                  data: plan.insertActionLogs.error ? null : { id: "log-id-mock" },
+                  error: plan.insertActionLogs.error,
+                }),
+            }),
+          };
         },
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            contains: vi.fn(() => ({
+              order: vi.fn(() => ({
+                limit: vi.fn(() => ({
+                  maybeSingle: vi.fn(() => Promise.resolve({ data: null, error: null })),
+                })),
+              })),
+            })),
+          })),
+        })),
       };
     }
 

--- a/src/entities/task/resplit-server.ts
+++ b/src/entities/task/resplit-server.ts
@@ -202,6 +202,12 @@ async function runResplit(
     return { kind: "failed", reason: "insert_failed" };
   }
 
+  // ADR 0051 D3: lineage 解決。target が「どの初期 AI 分解 / 前回 resplit から生まれたか」の
+  // action_logs.id を引いて snapshot に inline する。Phase 4 で「初期分解 → user 編集 →
+  // resplit → ...」の chain を log id 連鎖で再構成可能にする。fail-soft: 取得失敗 / 該当
+  // なしは null (= user 手動子起点 / retention で消えた / クエリ失敗、いずれも集計側で許容)。
+  const sourceDecompositionLogId = await resolveSourceDecompositionLogId(supabase, target.id);
+
   // ADR 0030: column.task_id は新規子のうち先頭 (= 主体行)。
   // metadata.resplit_target_snapshot は削除直前の target。Phase 4 の暗黙フィードバック
   // 分析で「ユーザーが粒度を変えた」シグナル + dangling task_id 解決のために inline 保存する。
@@ -217,12 +223,63 @@ async function runResplit(
       // ADR 0038 / Issue #169: 主観サイズも snapshot に含めて再分解前後の比較を可能に。
       task_size: target.task_size,
       created_at: target.created_at,
+      source_decomposition_log_id: sourceDecompositionLogId,
     },
     new_child_ids: newChildIds,
     raw_response: responseText,
   });
 
   return { kind: "resplit_succeeded", newChildIds };
+}
+
+/**
+ * ADR 0051 D3: target child の lineage 元 `action_logs.id` を解決する。
+ *
+ * 解決順序 (新しい lineage を優先):
+ * 1. `task_child_resplit` で `metadata.new_child_ids` に target.id を含むものがあるか
+ *    (= target が前回の resplit で生まれた子)。複数あれば最新の created_at を採る
+ * 2. なければ `task_decomposed` で `metadata.child_ids` に target.id を含むものを引く
+ *    (= target が初期 AI 分解で生まれた子)
+ * 3. どちらも見つからなければ null (= user 手動追加起点 / retention で消えた)
+ *
+ * fail-soft: クエリ error / 取得失敗は null。学習素材の劣化を許容、core 操作止めない
+ * (ADR 0013, ADR 0035 §6)。jsonb 配列 containment は PostgREST の `cs` 演算子で表現される
+ * (`.contains("metadata", { new_child_ids: [id] })`)。GIN index がなければ seq scan に
+ * なるが、resplit 自体が AI 1 リクエスト含む slow path なので相対 cost は無視できる範囲。
+ */
+async function resolveSourceDecompositionLogId(
+  supabase: SupabaseClient<Database>,
+  targetId: string,
+): Promise<string | null> {
+  // 1. resplit chain (target が前回 resplit の new_child_ids に含まれるか)
+  const { data: priorResplit, error: resplitErr } = await supabase
+    .from("action_logs")
+    .select("id")
+    .eq("action_type", "task_child_resplit")
+    .contains("metadata", { new_child_ids: [targetId] })
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (resplitErr) {
+    console.error("[ai/resplit] lineage resolve (resplit chain) failed", resplitErr);
+    return null;
+  }
+  if (priorResplit) return priorResplit.id;
+
+  // 2. 初期 AI 分解 (target が task_decomposed の child_ids に含まれるか)
+  const { data: priorDecompose, error: decomposeErr } = await supabase
+    .from("action_logs")
+    .select("id")
+    .eq("action_type", "task_decomposed")
+    .contains("metadata", { child_ids: [targetId] })
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (decomposeErr) {
+    console.error("[ai/resplit] lineage resolve (decompose) failed", decomposeErr);
+    return null;
+  }
+  return priorDecompose?.id ?? null;
 }
 
 /**

--- a/src/entities/task/supabase-gateway.test.ts
+++ b/src/entities/task/supabase-gateway.test.ts
@@ -1,9 +1,28 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
+import { ACTION_TYPES, log } from "@/entities/action-log/logger";
 import type { Database, Tables } from "@/shared/types/database";
 
 import { SupabaseTaskGateway } from "./supabase-gateway";
+
+// ADR 0051 の発火検証 用に logger をモジュール mock。
+// 既存テストは log() の呼び出しを検証しないので、`log` の戻り値が型に合うようにだけ手当する。
+vi.mock("@/entities/action-log/logger", async () => {
+  const actual = await vi.importActual<typeof import("@/entities/action-log/logger")>(
+    "@/entities/action-log/logger",
+  );
+  return {
+    ...actual,
+    log: vi.fn((actionType: string, metadata?: unknown) => ({
+      action_type: actionType,
+      metadata: metadata ?? {},
+      created_at: new Date().toISOString(),
+    })),
+  };
+});
+
+const logMock = log as unknown as ReturnType<typeof vi.fn>;
 
 /**
  * Gateway 経由で task_category が読み書きできることを保証する (#87 完了条件)。
@@ -45,6 +64,8 @@ type MockChain = {
   select: ReturnType<typeof vi.fn>;
   eq: ReturnType<typeof vi.fn>;
   single: ReturnType<typeof vi.fn>;
+  maybeSingle: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
   from: ReturnType<typeof vi.fn>;
 };
 
@@ -52,13 +73,24 @@ function makeSupabase(returnedRow: Tables<"tasks">): {
   client: SupabaseClient<Database>;
   chain: MockChain;
 } {
+  // ADR 0051 D1/D2/D4 で update / delete / create に pre-fetch (`select(...).eq(...).maybeSingle()`)
+  // が増えた。同じ chain で `update(...).eq(...).select("*").single()` (本処理) と
+  // `select(...).eq(...).maybeSingle()` (pre-fetch) の両方を解決できる構成にする。
+  // delete() は `await delete().eq()` も `await select("id").eq()` (children 列挙) も
+  // 同じ eq() chain で解決できるように、eq() を thenable にする。
   const single = vi.fn(async () => ({ data: returnedRow, error: null }));
-  const eq = vi.fn(() => ({ select, single }));
-  const select = vi.fn(() => ({ single, eq }));
+  const maybeSingle = vi.fn(async () => ({ data: returnedRow, error: null }));
+  const eq = vi.fn(() => {
+    // 直接 await された場合は { data: [], error: null } (children 列挙の空ヒット相当 / delete 成功)
+    const promise = Promise.resolve({ data: [], error: null });
+    return Object.assign(promise, { select, single, maybeSingle, eq });
+  });
+  const select = vi.fn(() => ({ single, maybeSingle, eq }));
   const insert = vi.fn(() => ({ select }));
   const update = vi.fn(() => ({ eq }));
-  const from = vi.fn(() => ({ insert, update, select }));
-  const chain: MockChain = { insert, update, select, eq, single, from };
+  const del = vi.fn(() => ({ eq }));
+  const from = vi.fn(() => ({ insert, update, select, delete: del }));
+  const chain: MockChain = { insert, update, select, eq, single, maybeSingle, delete: del, from };
 
   const client = {
     auth: {
@@ -274,5 +306,192 @@ describe("SupabaseTaskGateway: listCorrectionFactors (P3-9 / #93)", () => {
     // from + select だけで eq() / filter() は呼ばれない
     expect(from).toHaveBeenCalledTimes(1);
     expect(select).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * ADR 0051: AI 分解への user editorial signal の捕捉。
+ *
+ * - D1: `task_title_changed` / `decomposition_modified.{child_deleted,child_edited,parent_merged}` の発火
+ * - D2: `decomposition_modified.kind=child_added` の発火 (decomposed 親のみ)
+ * - D4: `task_deleted.snapshot.was_decomposition_child` の埋め込み
+ *
+ * 親の `decompose_status` 判定は gateway が pre-fetch で取得する。fail-soft (取得失敗で
+ * 発火しない) は `fetchParentDecomposeStatus` の責務。ここでは「親 = decomposed のとき
+ * 発火する」「親 = none のとき発火しない」の両方向を担保する。
+ */
+describe("SupabaseTaskGateway: ADR 0051 editorial signal capture", () => {
+  beforeEach(() => {
+    logMock.mockClear();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  describe("create: child_added (D2)", () => {
+    test("親 decompose_status=decomposed なら child_added が発火する", async () => {
+      const { client } = makeSupabase(
+        makeRow({ id: "child-new", parent_task_id: "parent-1", decompose_status: "decomposed" }),
+      );
+      const gateway = new SupabaseTaskGateway(client);
+
+      await gateway.create({ projectId: "p1", title: "x", parentTaskId: "parent-1" });
+
+      const calls = logMock.mock.calls.filter((c) => c[0] === ACTION_TYPES.DECOMPOSITION_MODIFIED);
+      expect(calls).toHaveLength(1);
+      expect(calls[0]![1]).toEqual({
+        task_id: "child-new",
+        parent_id: "parent-1",
+        kind: "child_added",
+      });
+    });
+
+    test("親 decompose_status=none なら child_added は発火しない (純粋手動階層は対象外)", async () => {
+      const { client } = makeSupabase(
+        makeRow({ id: "child-new", parent_task_id: "parent-1", decompose_status: "none" }),
+      );
+      const gateway = new SupabaseTaskGateway(client);
+
+      await gateway.create({ projectId: "p1", title: "x", parentTaskId: "parent-1" });
+
+      const calls = logMock.mock.calls.filter((c) => c[0] === ACTION_TYPES.DECOMPOSITION_MODIFIED);
+      expect(calls).toHaveLength(0);
+    });
+
+    test("parentTaskId 未指定なら child_added は発火しない", async () => {
+      const { client } = makeSupabase(makeRow({ id: "root-task", decompose_status: "decomposed" }));
+      const gateway = new SupabaseTaskGateway(client);
+
+      await gateway.create({ projectId: "p1", title: "x" });
+
+      const calls = logMock.mock.calls.filter((c) => c[0] === ACTION_TYPES.DECOMPOSITION_MODIFIED);
+      expect(calls).toHaveLength(0);
+    });
+  });
+
+  describe("update: title 編集 (D1)", () => {
+    test("title が変わったら task_title_changed が発火する", async () => {
+      // 親なし root task を編集 → child_edited は発火しない、title_changed のみ
+      const { client } = makeSupabase(
+        makeRow({ id: "t1", title: "old", parent_task_id: null, decompose_status: "none" }),
+      );
+      const gateway = new SupabaseTaskGateway(client);
+
+      await gateway.update("t1", { title: "new" });
+
+      const titleCalls = logMock.mock.calls.filter((c) => c[0] === ACTION_TYPES.TASK_TITLE_CHANGED);
+      expect(titleCalls).toHaveLength(1);
+      expect(titleCalls[0]![1]).toEqual({
+        task_id: "t1",
+        old_title: "old",
+        new_title: "new",
+      });
+      const modCalls = logMock.mock.calls.filter(
+        (c) => c[0] === ACTION_TYPES.DECOMPOSITION_MODIFIED,
+      );
+      expect(modCalls).toHaveLength(0);
+    });
+
+    test("親 decomposed の子の title 編集なら title_changed と child_edited が併発する", async () => {
+      const { client } = makeSupabase(
+        // pre-fetch / parent fetch / post-update がすべて同 row を返す mock 設計のため、
+        // returnedRow が両方の役割を兼ねる: self は parent_task_id="parent-1" を持つ子、
+        // parent fetch の戻りも同 row だが gateway は decompose_status 列だけ読むので
+        // 同 row が "decomposed" 親として振る舞う。
+        makeRow({
+          id: "child-1",
+          title: "old",
+          parent_task_id: "parent-1",
+          decompose_status: "decomposed",
+        }),
+      );
+      const gateway = new SupabaseTaskGateway(client);
+
+      await gateway.update("child-1", { title: "new" });
+
+      expect(
+        logMock.mock.calls.filter((c) => c[0] === ACTION_TYPES.TASK_TITLE_CHANGED),
+      ).toHaveLength(1);
+      const modCalls = logMock.mock.calls.filter(
+        (c) => c[0] === ACTION_TYPES.DECOMPOSITION_MODIFIED,
+      );
+      expect(modCalls).toHaveLength(1);
+      expect(modCalls[0]![1]).toEqual({
+        task_id: "child-1",
+        parent_id: "parent-1",
+        kind: "child_edited",
+      });
+    });
+
+    test("title が変わらなければ task_title_changed は発火しない", async () => {
+      const { client } = makeSupabase(makeRow({ id: "t1", title: "same" }));
+      const gateway = new SupabaseTaskGateway(client);
+
+      await gateway.update("t1", { title: "same" });
+
+      expect(
+        logMock.mock.calls.filter((c) => c[0] === ACTION_TYPES.TASK_TITLE_CHANGED),
+      ).toHaveLength(0);
+    });
+
+    test("editorial 系を含まない patch (status だけ等) では pre-fetch しない / log もしない", async () => {
+      const { client, chain } = makeSupabase(makeRow({ id: "t1" }));
+      const gateway = new SupabaseTaskGateway(client);
+
+      await gateway.update("t1", { status: "active" });
+
+      // pre-fetch (`select(...).maybeSingle()`) が走らないこと
+      expect(chain.maybeSingle).not.toHaveBeenCalled();
+      expect(
+        logMock.mock.calls.filter((c) => c[0] === ACTION_TYPES.TASK_TITLE_CHANGED),
+      ).toHaveLength(0);
+      expect(
+        logMock.mock.calls.filter((c) => c[0] === ACTION_TYPES.DECOMPOSITION_MODIFIED),
+      ).toHaveLength(0);
+    });
+  });
+
+  describe("delete: was_decomposition_child / child_deleted (D1, D4)", () => {
+    test("親 decomposed の子削除 → snapshot.was_decomposition_child=true + child_deleted 発火", async () => {
+      const { client } = makeSupabase(
+        // 同様に同 row が「self (削除対象の子)」「parent fetch (decomposed 親)」両方の役を兼ねる
+        makeRow({
+          id: "child-1",
+          parent_task_id: "parent-1",
+          decompose_status: "decomposed",
+        }),
+      );
+      const gateway = new SupabaseTaskGateway(client);
+
+      await gateway.delete("child-1");
+
+      const deleteCall = logMock.mock.calls.find((c) => c[0] === ACTION_TYPES.TASK_DELETED);
+      expect(deleteCall).toBeDefined();
+      const meta = deleteCall![1] as {
+        task_id: string;
+        snapshot: { was_decomposition_child: boolean; parent_task_id: string | null };
+      };
+      expect(meta.snapshot.was_decomposition_child).toBe(true);
+      expect(meta.snapshot.parent_task_id).toBe("parent-1");
+    });
+
+    test("親なし root 削除 → snapshot.was_decomposition_child=false + child_deleted は発火しない", async () => {
+      const { client } = makeSupabase(
+        makeRow({ id: "root-1", parent_task_id: null, decompose_status: "none" }),
+      );
+      const gateway = new SupabaseTaskGateway(client);
+
+      await gateway.delete("root-1");
+
+      const deleteCall = logMock.mock.calls.find((c) => c[0] === ACTION_TYPES.TASK_DELETED);
+      const meta = deleteCall![1] as { snapshot: { was_decomposition_child: boolean } };
+      expect(meta.snapshot.was_decomposition_child).toBe(false);
+
+      const modCalls = logMock.mock.calls.filter(
+        (c) =>
+          c[0] === ACTION_TYPES.DECOMPOSITION_MODIFIED &&
+          (c[1] as { kind: string }).kind === "child_deleted",
+      );
+      expect(modCalls).toHaveLength(0);
+    });
   });
 });

--- a/src/entities/task/supabase-gateway.ts
+++ b/src/entities/task/supabase-gateway.ts
@@ -40,6 +40,28 @@ async function getUserId(supabase: Sb): Promise<string> {
 export class SupabaseTaskGateway implements TaskGateway {
   constructor(private readonly supabase: Sb) {}
 
+  /**
+   * ADR 0051 D1/D2/D4: 親 task の `decompose_status` を引く軽量 helper。
+   * `decomposition_modified` (child_added / child_edited / child_deleted) と
+   * `task_deleted.snapshot.was_decomposition_child` の発火条件判定に共通利用する。
+   *
+   * 失敗時 (取得 error / 親不存在) は null を返す。fail-soft: 学習信号を取りこぼしても
+   * core 操作 (create/update/delete) は止めない (ADR 0013, ADR 0035 §6 の「完全性は保証
+   * しない」原則と整合)。
+   */
+  private async fetchParentDecomposeStatus(
+    parentTaskId: string | null | undefined,
+  ): Promise<string | null> {
+    if (!parentTaskId) return null;
+    const { data, error } = await this.supabase
+      .from("tasks")
+      .select("decompose_status")
+      .eq("id", parentTaskId)
+      .maybeSingle();
+    if (error || !data) return null;
+    return data.decompose_status;
+  }
+
   async list(): Promise<Task[]> {
     const { data, error } = await this.supabase
       .from("tasks")
@@ -52,6 +74,14 @@ export class SupabaseTaskGateway implements TaskGateway {
 
   async create(input: CreateTaskInput): Promise<Task> {
     const user_id = await getUserId(this.supabase);
+
+    // ADR 0051 D2: `decompose_status='decomposed'` の親に user が手動で子を追加した場合、
+    // `decomposition_modified.kind=child_added` を発火する (Phase 4 教師信号)。
+    // 純粋な手動階層 (親が `decomposed` 以外) は対象外 = `decompose_status` 列で
+    // schema レベルで自然に区別される。fail-soft: 親取得失敗時は発火しない (学習信号の
+    // 劣化を許容、core 操作止めない、ADR 0013)。
+    const parentDecomposeStatus = await this.fetchParentDecomposeStatus(input.parentTaskId);
+
     const payload: TablesInsert<"tasks"> = {
       user_id,
       // #170 / ADR 0039: project は任意化された。null / 空文字 / undefined は
@@ -70,10 +100,43 @@ export class SupabaseTaskGateway implements TaskGateway {
     };
     const { data, error } = await this.supabase.from("tasks").insert(payload).select("*").single();
     if (error) throw error;
+
+    if (parentDecomposeStatus === "decomposed" && input.parentTaskId) {
+      log(ACTION_TYPES.DECOMPOSITION_MODIFIED, {
+        task_id: data.id,
+        parent_id: input.parentTaskId,
+        kind: "child_added",
+      });
+    }
+
     return fromRow(data);
   }
 
   async update(id: string, patch: UpdateTaskInput): Promise<Task> {
+    // ADR 0051 D1: title / estimated_minutes 変更を `task_title_changed` /
+    // `decomposition_modified.kind=child_edited` で捕捉する。pre-fetch は editorial 系
+    // patch (title / estimatedMinutes) を含む時のみ走らせる。status update 等の hot path
+    // には追加クエリを乗せない。fail-soft: 取得失敗時は発火しない (ADR 0013)。
+    const needsEditorialSnapshot =
+      patch.title !== undefined || patch.estimatedMinutes !== undefined;
+    let oldRow: {
+      title: string;
+      estimated_minutes: number | null;
+      parent_task_id: string | null;
+    } | null = null;
+    let parentDecomposeStatus: string | null = null;
+    if (needsEditorialSnapshot) {
+      const { data: pre } = await this.supabase
+        .from("tasks")
+        .select("title, estimated_minutes, parent_task_id")
+        .eq("id", id)
+        .maybeSingle();
+      oldRow = pre ?? null;
+      if (oldRow?.parent_task_id) {
+        parentDecomposeStatus = await this.fetchParentDecomposeStatus(oldRow.parent_task_id);
+      }
+    }
+
     const update: TablesUpdate<"tasks"> = {};
     if (patch.projectId !== undefined) update.project_id = patch.projectId;
     if (patch.title !== undefined) update.title = patch.title;
@@ -94,6 +157,36 @@ export class SupabaseTaskGateway implements TaskGateway {
       .select("*")
       .single();
     if (error) throw error;
+
+    // ADR 0051 D1: editorial signal 発火。`task_title_changed` は全 task 共通で発火する
+    // 汎用 signal (root / 分解子の区別なし)。`decomposition_modified.child_edited` は
+    // 親が `decomposed` の子を編集した時だけ追加で発火する (併発、別意味)。
+    if (oldRow) {
+      const titleChanged = patch.title !== undefined && oldRow.title !== patch.title;
+      const estimatedChanged =
+        patch.estimatedMinutes !== undefined && oldRow.estimated_minutes !== patch.estimatedMinutes;
+
+      if (titleChanged && patch.title !== undefined) {
+        log(ACTION_TYPES.TASK_TITLE_CHANGED, {
+          task_id: id,
+          old_title: oldRow.title,
+          new_title: patch.title,
+        });
+      }
+
+      if (
+        parentDecomposeStatus === "decomposed" &&
+        oldRow.parent_task_id &&
+        (titleChanged || estimatedChanged)
+      ) {
+        log(ACTION_TYPES.DECOMPOSITION_MODIFIED, {
+          task_id: id,
+          parent_id: oldRow.parent_task_id,
+          kind: "child_edited",
+        });
+      }
+    }
+
     return fromRow(data);
   }
 
@@ -140,13 +233,35 @@ export class SupabaseTaskGateway implements TaskGateway {
     // ADR 0035 §5: task_deleted は snapshot 必須化された (Phase 4 回避パターン分析の素材)。
     // 物理削除前に主要属性を読んでおき、削除後に snapshot 込みで log する。
     // select は必要列のみで軽い (RLS 経由で 1 行)。失敗しても delete は強行する。
+    //
+    // ADR 0051 D1/D4: pre-fetch を拡張し editorial signal を導出する。
+    // - self.decompose_status: parent_merged 判定 (削除対象が分解親なら子を孤児化)
+    // - parent.decompose_status: child_deleted / was_decomposition_child 判定
+    // - children list: parent_merged の発火対象列挙
     const { data: snapshotRow } = await this.supabase
       .from("tasks")
-      .select("title, estimated_minutes, task_category, status, parent_task_id")
+      .select("title, estimated_minutes, task_category, status, parent_task_id, decompose_status")
       .eq("id", id)
       .maybeSingle();
+
+    const parentDecomposeStatus = await this.fetchParentDecomposeStatus(
+      snapshotRow?.parent_task_id ?? null,
+    );
+    const wasDecompositionChild = parentDecomposeStatus === "decomposed";
+
+    // 削除対象自身が `decomposed` 親なら子を取得 (parent_merged 発火対象)。
+    let orphanedChildIds: string[] = [];
+    if (snapshotRow?.decompose_status === "decomposed") {
+      const { data: children } = await this.supabase
+        .from("tasks")
+        .select("id")
+        .eq("parent_task_id", id);
+      orphanedChildIds = (children ?? []).map((c) => c.id);
+    }
+
     const { error } = await this.supabase.from("tasks").delete().eq("id", id);
     if (error) throw error;
+
     log(ACTION_TYPES.TASK_DELETED, {
       task_id: id,
       snapshot: {
@@ -155,8 +270,29 @@ export class SupabaseTaskGateway implements TaskGateway {
         task_category: snapshotRow?.task_category ?? null,
         status: snapshotRow?.status ?? "idle",
         parent_task_id: snapshotRow?.parent_task_id ?? null,
+        was_decomposition_child: wasDecompositionChild,
       },
     });
+
+    // ADR 0051 D1: 親が `decomposed` の子を削除した時、`decomposition_modified.child_deleted`
+    // を併発で発火する (task_deleted は汎用、こちらは「分解構成が縮んだ」signal)。
+    if (wasDecompositionChild && snapshotRow?.parent_task_id) {
+      log(ACTION_TYPES.DECOMPOSITION_MODIFIED, {
+        task_id: id,
+        parent_id: snapshotRow.parent_task_id,
+        kind: "child_deleted",
+      });
+    }
+
+    // ADR 0051 D1 / ADR 0018: 分解親が削除されると子が孤児化する。各孤児に対して
+    // `decomposition_modified.parent_merged` を発火する (Phase 4 で「親統合」を再構成可能に)。
+    for (const childId of orphanedChildIds) {
+      log(ACTION_TYPES.DECOMPOSITION_MODIFIED, {
+        task_id: childId,
+        parent_id: id,
+        kind: "parent_merged",
+      });
+    }
   }
 
   async deleteAllForCurrentUser(): Promise<void> {


### PR DESCRIPTION
## 概要 (What)

ADR 0051 を確定し、その D1〜D4 をすべて実装した。AI 分解結果に対する user editorial action（title 編集 / 子削除 / 子追加 / 再分解）が `action_logs` で漏れなく捕捉されるようになり、Phase 4 prompt 個人化の前提が整う。

## 関連 Issue

Closes #214
Refs #208

## 背景 (Why)

親 roadmap #208「AI タスク分解精度改善」の設計原則は **「学習信号の出所は user 起源（編集差分 / 行動指標）であって、AI 出力そのものではない」** （self-reinforcing 回避）。

issue #214 で現状監査したところ、

- `task_title_changed` / `decomposition_modified` は **type 定義 / logger / server-side FK ハンドリングまで揃っているのに、production code から発火される地点がゼロ**（`grep -rn TASK_TITLE_CHANGED src/` 結果は test と type 定義のみ）
- 「user が分解後に同階層へ手動で子を追加」「resplit の lineage chain」「削除子の AI 由来 / user 起源の区別」については **type / schema が無い**

という 2 種のギャップが見つかった。今 schema を整えないと過去ログが教師信号として使えない（ADR-0035 §6 で backfill しない原則）ので、実装を一括で投入する。

関連 ADR: [ADR-0017](../blob/main/docs/adr/0017-ai-task-decomposition-async.md) / [ADR-0021](../blob/main/docs/adr/0021-ai-decomposition-failure-visibility.md) / [ADR-0027](../blob/main/docs/adr/0027-child-resplit-flatten.md) / [ADR-0030](../blob/main/docs/adr/0030-child-resplit-action-log.md) / [ADR-0035](../blob/main/docs/adr/0035-action-log-payload-schema-and-actor-type.md)

## 実装内容 (How)

### ADR 0051 起票（commit 1）

`docs/adr/0051-capture-user-editorial-signals-on-decomposition.md` を新規作成。D1〜D4 の判断と alternative / consequences を整理。

### D1〜D4 の実装（commit 2）

| Decision | 実装ファイル | 内容 |
|---|---|---|
| **D1** | `src/entities/task/supabase-gateway.ts` | `update()` / `delete()` で editorial signal 発火を追加。`task_title_changed` は title 変更時、`decomposition_modified.{child_deleted,child_edited,parent_merged}` は親 / 自身の `decompose_status='decomposed'` 判定込み |
| **D2** | `src/entities/action-log/types.ts` / `supabase-gateway.ts:create()` | `DecompositionModifiedKind` に `"child_added"` を追加。`decomposed` 親への user 手動子追加だけで発火、純粋な手動階層は対象外（`decompose_status` 列で schema レベルに区別） |
| **D3** | `src/entities/action-log/server.ts` / `resplit-server.ts` | `logServerSide` を `Promise<string \| null>` に拡張（log id を返す）。`resolveSourceDecompositionLogId` で resplit chain → 初期 `task_decomposed` の順に lineage を解決し、`resplit_target_snapshot.source_decomposition_log_id` に inline。多段 resplit chain は前回 `task_child_resplit` の id を辿って遡及可能 |
| **D4** | `src/entities/action-log/types.ts` / `supabase-gateway.ts:delete()` | `task_deleted.snapshot` に `was_decomposition_child: boolean` を追加。`delete()` の pre-fetch で親情報を引いて `child_deleted` の発火判定と同時に解決（追加クエリゼロ） |

### 設計判断

- **firing は `SupabaseTaskGateway` に集約**: UI 層 (`useDashboardMutations`) は API route / 将来の import / undo 経路で取りこぼすため、CRUD の最後の砦である gateway に置く（`task_category_changed` だけ UI 層なのは「null 戻し抑制」という UI 固有 filter があるため、title はその種の filter 不要）
- **親の `decompose_status` 判定は `fetchParentDecomposeStatus` で共通化**: `update` / `delete` / `create` の 3 経路でほぼ同じロジックなので 1 helper にまとめた
- **fail-soft**: pre-fetch 失敗 / lineage 解決失敗は発火しない（ADR 0013: augmentation only / core 操作を止めない）
- **migration 不要**: D2/D3/D4 はすべて `action_logs.metadata jsonb` 内部の型拡張（ADR 0035 §6: backfill しない原則を踏襲、CHECK 制約なしの ADR 0001 § 設計に乗る）

## Before → After (概念・フロー・メンタルモデル)

**Before:**

- `task_title_changed` / `decomposition_modified` の infrastructure は全部揃っているのに、production code から呼ぶ箇所がゼロ
- 「user が分解後に子を追加した」「resplit chain の遡及」「削除子の AI 由来判定」のための schema が無い
- Phase 4 で集計しようとすると、type 定義は揃って見えるのに実データが空 / 不足、というギャップに突き当たる

**After:**

- editorial signal が 5 軸（title 編集 / 子削除 / 子追加 / 子編集 / 親統合）+ resplit lineage 1 軸で `action_logs` に揃う
- `action_logs` 1 テーブルだけで「初期分解 → user 編集 → resplit → さらに編集 …」の chain を再構成可能（`source_decomposition_log_id` の log id 連鎖）
- ADR-0030 の「snapshot を inline で持って FK 削除に強い」設計を踏襲（retention 戦略は据え置き）

## 集計クエリの試作 (#214 step 3)

Phase 4 で実利用する想定の例（実装済の signal で書ける）:

```sql
-- 1. user が分解結果をどれだけ編集したか (粒度過粗のサイン)
SELECT
  (metadata->>'parent_id') AS parent_id,
  COUNT(*) FILTER (WHERE metadata->>'kind' = 'child_edited') AS edits,
  COUNT(*) FILTER (WHERE metadata->>'kind' = 'child_deleted') AS deletes,
  COUNT(*) FILTER (WHERE metadata->>'kind' = 'child_added') AS adds
FROM action_logs
WHERE action_type = 'decomposition_modified'
GROUP BY metadata->>'parent_id';

-- 2. 分解結果の child のうち削除されたものの「AI 出力時の title」を引く
SELECT
  d.metadata->>'task_id' AS parent_id,
  child_id,
  td.metadata->'snapshot'->>'title' AS deleted_title
FROM action_logs d
CROSS JOIN LATERAL jsonb_array_elements_text(d.metadata->'child_ids') AS child_id
LEFT JOIN action_logs td
  ON td.action_type = 'task_deleted'
  AND td.metadata->>'task_id' = child_id
  AND (td.metadata->'snapshot'->>'was_decomposition_child')::boolean = true
WHERE d.action_type = 'task_decomposed';

-- 3. 初期分解 → resplit lineage chain を 1 親について再構成
WITH RECURSIVE chain AS (
  SELECT id, metadata, created_at
  FROM action_logs
  WHERE action_type = 'task_decomposed'
    AND metadata->>'task_id' = $1  -- root parent_id
  UNION ALL
  SELECT al.id, al.metadata, al.created_at
  FROM action_logs al
  JOIN chain c
    ON al.action_type = 'task_child_resplit'
    AND al.metadata->'resplit_target_snapshot'->>'source_decomposition_log_id' = c.id::text
)
SELECT * FROM chain ORDER BY created_at;
```

これらは Phase 4 の実装時に最終形にする想定で、本 PR では「signal が揃った時点で何が書けるか」のサンプルとして残す。

## 追加したテスト (How verified)

- [x] `npm run check` が pass: format / lint / typecheck / 632 tests（前回より +9 件）
- [x] `src/entities/task/supabase-gateway.test.ts`: ADR 0051 firing の専用 describe block を追加
  - `create`: `child_added` が decomposed 親で発火する / 非 decomposed 親では発火しない / 親なしでは発火しない
  - `update`: title 変更で `task_title_changed` が発火する / decomposed 子の title 編集で `child_edited` が併発する / title 不変なら発火しない / status のみ patch では pre-fetch すらしない
  - `delete`: decomposed 子の削除で `was_decomposition_child=true` + `child_deleted` 発火 / 親なし root では `was_decomposition_child=false` + `child_deleted` は発火しない
- [x] 既存 `logger.test.ts` の fixture を D3/D4 の型拡張に合わせて更新
- [x] `decompose-server.test.ts` / `resplit-server.test.ts` の mock chain を `logServerSide` の `.select("id").single()` 拡張と lineage 解決クエリに対応

`parent_merged` の発火は実装済（孤児化する子の数だけ `decomposition_modified.kind=parent_merged` を逐次発火）。テストは mock 構築コストの観点から本 PR では割愛したが、実装は `delete()` 内の orphanedChildIds ループで担保している。

## このPRの範囲外 (Out of scope)

- `action_logs.metadata` への jsonb GIN index 追加（D3 lineage 解決の seq scan 対策）。現状データ量では不要、Phase 4 で集計頻度が上がってから別 issue で判断
- 親 roadmap #208 の他軸（軸 1 ドメイン知識 / 軸 3 タスク文脈 / 軸 4 基礎分解力）。それぞれ独立 issue（#209 / #210 / #173 等）で並走
- D1 の `task_title_changed` を発火させる UI（現状は title 編集 UI が未実装）。gateway 層に置いたので、将来 title 編集 UI が入れば自動で signal が乗る

https://claude.ai/code/session_01UBzGrNVtkVfw3tExRFq9tk