### PR TITLE
feat(calendar-ext): 繰り返し event の系列 override を rule + bulk apply で実現 (Closes #229)

### DIFF
--- a/e2e/recurring-event-visibility-override.spec.ts
+++ b/e2e/recurring-event-visibility-override.spec.ts
@@ -1,0 +1,286 @@
+import { createAdminClient, waitForActionLog } from "./db";
+import { expect, test } from "./fixtures";
+
+/**
+ * Issue #229 / ADR 0056:
+ * recurring event に対する 3 択 modal (この予定だけ / これ以降 / すべて) を踏む e2e。
+ *
+ * シナリオ:
+ *   1. service_role で external_account + subscription + recurring 系列 (instance3 件) を seed
+ *      - 全 instance に共通の `recurring_event_id = 'rec-master-1'` を持たせる
+ *   2. /events から中央 instance (#2) の詳細パネルを開き「予定化解除」を押すと modal が開く
+ *   3. 「これ以降の予定もまとめて」を選択
+ *      - DB: instance #2 / #3 の visibility_override = 'hidden' (instance #1 は 'none' のまま)
+ *      - DB: event_visibility_override_rules に scope='this_and_following' / from_start_time=instance #2.start_time の rule が 1 行
+ *      - action_log: event_demoted x2 (各 instance、bulk_operation_id 同一) + event_visibility_rule_added x1 (同 bulk_operation_id)
+ *   4. 単発 override 保護: instance #1 を直接 hidden にした後、scope='all' で予定化を bulk apply しても
+ *      instance #1 は hidden のまま (上書きされない)。残り (#2/#3) は shown に揃う。
+ *   5. rule 削除: settings の rules セクションから rule を削除すると DB 行が消え、
+ *      event_visibility_rule_removed action_log が記録される。既存 instance の visibility は変わらない。
+ */
+test.describe("recurring event の 3 択 modal (Issue #229 / ADR 0056)", () => {
+  test("scope='this_and_following' で bulk apply + rule 永続化 + action_log 群が揃う", async ({
+    signedInPage: page,
+    testEmail,
+    testUserId,
+  }) => {
+    const recurringEventId = "rec-master-1";
+    const externalId1 = "ext-rec-i1";
+    const externalId2 = "ext-rec-i2";
+    const externalId3 = "ext-rec-i3";
+    const titlePrefix = "繰り返し系列 e2e";
+
+    const admin = createAdminClient();
+
+    const { data: account, error: accErr } = await admin
+      .from("external_accounts")
+      .upsert(
+        {
+          user_id: testUserId,
+          source: "google_calendar",
+          external_account_id: testEmail,
+          display_name: "(primary)",
+        },
+        { onConflict: "user_id,source,external_account_id" },
+      )
+      .select("id")
+      .single();
+    if (accErr) throw new Error(`[e2e] seed external_account failed: ${accErr.message}`);
+
+    const { error: subErr } = await admin.from("user_calendar_subscriptions").upsert(
+      {
+        user_id: testUserId,
+        external_account_id: account!.id,
+        source: "google_calendar",
+        external_calendar_id: "primary",
+        auto_promote_to_timeline: true,
+        display_name: "(primary)",
+      },
+      { onConflict: "user_id,external_account_id,external_calendar_id" },
+    );
+    if (subErr) throw new Error(`[e2e] seed subscription failed: ${subErr.message}`);
+
+    const start1 = todayPlus(0, 14, 0);
+    const end1 = todayPlus(0, 15, 0);
+    const start2 = todayPlus(7, 14, 0);
+    const end2 = todayPlus(7, 15, 0);
+    const start3 = todayPlus(14, 14, 0);
+    const end3 = todayPlus(14, 15, 0);
+
+    const insertInstance = async (
+      externalId: string,
+      titleSuffix: string,
+      startIso: string,
+      endIso: string,
+    ) => {
+      const { error } = await admin.from("events").insert({
+        user_id: testUserId,
+        title: `${titlePrefix} ${titleSuffix}`,
+        start_time: startIso,
+        end_time: endIso,
+        project_id: null,
+        meet_url: null,
+        has_attachments: false,
+        description: "",
+        source: "google_calendar",
+        external_id: externalId,
+        external_calendar_id: "primary",
+        visibility_override: "none",
+        recurring_event_id: recurringEventId,
+      });
+      if (error) throw new Error(`[e2e] seed event ${externalId} failed: ${error.message}`);
+    };
+    await insertInstance(externalId1, "#1", start1.toISOString(), end1.toISOString());
+    await insertInstance(externalId2, "#2", start2.toISOString(), end2.toISOString());
+    await insertInstance(externalId3, "#3", start3.toISOString(), end3.toISOString());
+
+    await page.getByRole("link", { name: "予定" }).click();
+    await page.waitForURL((url) => url.pathname === "/events", { timeout: 10_000 });
+
+    // 中央 instance (#2) の row → 「予定化解除」
+    const row2 = page.getByRole("listitem").filter({ hasText: `${titlePrefix} #2` });
+    await expect(row2).toBeVisible();
+    await row2.getByRole("button", { name: "予定化解除" }).click();
+
+    // 3 択 modal が開く
+    const dialog = page.getByRole("dialog", { name: "繰り返し予定の予定化解除" });
+    await expect(dialog).toBeVisible();
+
+    // 「これ以降の予定もまとめて」を選ぶ
+    await dialog.getByRole("button", { name: /これ以降の予定もまとめて/ }).click();
+
+    // DB: instance #2 / #3 が hidden に、#1 は none のまま
+    await expect
+      .poll(
+        async () => {
+          const { data } = await admin
+            .from("events")
+            .select("external_id, visibility_override")
+            .eq("user_id", testUserId)
+            .in("external_id", [externalId1, externalId2, externalId3]);
+          const m = new Map<string, string>();
+          for (const r of data ?? []) m.set(r.external_id ?? "", r.visibility_override);
+          return `${m.get(externalId1)}/${m.get(externalId2)}/${m.get(externalId3)}`;
+        },
+        { message: "instance #1=none, #2/#3=hidden に揃う", timeout: 10_000 },
+      )
+      .toBe("none/hidden/hidden");
+
+    // DB: rule が 1 行入っている
+    const { data: rule } = await admin
+      .from("event_visibility_override_rules")
+      .select("scope, override_value, from_start_time")
+      .eq("user_id", testUserId)
+      .eq("recurring_event_id", recurringEventId)
+      .single();
+    expect(rule).toMatchObject({
+      scope: "this_and_following",
+      override_value: "hidden",
+    });
+    expect(rule!.from_start_time).toBeTruthy();
+    expect(new Date(rule!.from_start_time!).toISOString()).toBe(start2.toISOString());
+
+    // action_log: event_visibility_rule_added (bulk_operation_id 取得用)
+    const ruleAdded = await waitForActionLog(
+      admin,
+      testUserId,
+      (r) =>
+        r.action_type === "event_visibility_rule_added" &&
+        (r.metadata as Record<string, unknown>)["recurring_event_id"] === recurringEventId,
+      { description: "event_visibility_rule_added" },
+    );
+    const bulkOpId = (ruleAdded.metadata as Record<string, unknown>)["bulk_operation_id"] as string;
+    expect(typeof bulkOpId).toBe("string");
+    expect(bulkOpId.length).toBeGreaterThan(0);
+
+    // action_log: instance #2 と #3 にそれぞれ event_demoted (同 bulk_operation_id)
+    const demoted2 = await waitForActionLog(
+      admin,
+      testUserId,
+      (r) =>
+        r.action_type === "event_demoted" &&
+        (r.metadata as Record<string, unknown>)["external_id"] === externalId2,
+      { description: "event_demoted #2" },
+    );
+    expect(demoted2.metadata).toMatchObject({
+      scope: "this_and_following",
+      recurring_event_id: recurringEventId,
+      bulk_operation_id: bulkOpId,
+      to: "hidden",
+      // auto_promote=true で hidden は default 逸脱
+      is_override_of_default: true,
+    });
+    const demoted3 = await waitForActionLog(
+      admin,
+      testUserId,
+      (r) =>
+        r.action_type === "event_demoted" &&
+        (r.metadata as Record<string, unknown>)["external_id"] === externalId3,
+      { description: "event_demoted #3" },
+    );
+    expect((demoted3.metadata as Record<string, unknown>)["bulk_operation_id"]).toBe(bulkOpId);
+  });
+
+  test("scope='all' でも単発 override 済 instance は保護される (ADR 0056 §5)", async ({
+    signedInPage: page,
+    testEmail,
+    testUserId,
+  }) => {
+    const recurringEventId = "rec-master-2";
+    const externalId1 = "ext-rec-protect-i1";
+    const externalId2 = "ext-rec-protect-i2";
+    const titlePrefix = "繰り返し protect e2e";
+
+    const admin = createAdminClient();
+
+    const { data: account } = await admin
+      .from("external_accounts")
+      .upsert(
+        {
+          user_id: testUserId,
+          source: "google_calendar",
+          external_account_id: testEmail,
+          display_name: "(primary)",
+        },
+        { onConflict: "user_id,source,external_account_id" },
+      )
+      .select("id")
+      .single();
+    await admin.from("user_calendar_subscriptions").upsert(
+      {
+        user_id: testUserId,
+        external_account_id: account!.id,
+        source: "google_calendar",
+        external_calendar_id: "primary",
+        auto_promote_to_timeline: true,
+        display_name: "(primary)",
+      },
+      { onConflict: "user_id,external_account_id,external_calendar_id" },
+    );
+
+    // instance #1 は最初から visibility_override='hidden' (= 単発 override 済)
+    await admin.from("events").insert({
+      user_id: testUserId,
+      title: `${titlePrefix} #1`,
+      start_time: todayPlus(0, 16, 0).toISOString(),
+      end_time: todayPlus(0, 17, 0).toISOString(),
+      project_id: null,
+      meet_url: null,
+      has_attachments: false,
+      description: "",
+      source: "google_calendar",
+      external_id: externalId1,
+      external_calendar_id: "primary",
+      visibility_override: "hidden",
+      recurring_event_id: recurringEventId,
+    });
+    await admin.from("events").insert({
+      user_id: testUserId,
+      title: `${titlePrefix} #2`,
+      start_time: todayPlus(7, 16, 0).toISOString(),
+      end_time: todayPlus(7, 17, 0).toISOString(),
+      project_id: null,
+      meet_url: null,
+      has_attachments: false,
+      description: "",
+      source: "google_calendar",
+      external_id: externalId2,
+      external_calendar_id: "primary",
+      visibility_override: "none",
+      recurring_event_id: recurringEventId,
+    });
+
+    await page.getByRole("link", { name: "予定" }).click();
+    await page.waitForURL((url) => url.pathname === "/events", { timeout: 10_000 });
+
+    // instance #2 から「予定化解除」→ scope='all'
+    const row2 = page.getByRole("listitem").filter({ hasText: `${titlePrefix} #2` });
+    await row2.getByRole("button", { name: "予定化解除" }).click();
+    const dialog = page.getByRole("dialog", { name: "繰り返し予定の予定化解除" });
+    await dialog.getByRole("button", { name: /すべての繰り返し/ }).click();
+
+    // instance #1 は 'hidden' のまま (元の単発 override は保護)、instance #2 も 'hidden' になっている
+    await expect
+      .poll(
+        async () => {
+          const { data } = await admin
+            .from("events")
+            .select("external_id, visibility_override")
+            .eq("user_id", testUserId)
+            .in("external_id", [externalId1, externalId2]);
+          const m = new Map<string, string>();
+          for (const r of data ?? []) m.set(r.external_id ?? "", r.visibility_override);
+          return `${m.get(externalId1)}/${m.get(externalId2)}`;
+        },
+        { message: "instance #1 は hidden 維持、#2 は hidden に揃う", timeout: 10_000 },
+      )
+      .toBe("hidden/hidden");
+  });
+});
+
+function todayPlus(addDays: number, hour: number, minute: number): Date {
+  const d = new Date();
+  d.setHours(hour, minute, 0, 0);
+  d.setDate(d.getDate() + addDays);
+  return d;
+}

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -255,6 +255,7 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
               events={events}
               subscriptions={calendarSubscriptions}
               onSetVisibilityOverride={setEventVisibilityOverride}
+              onSetRecurringVisibilityOverride={setRecurringEventVisibilityOverride}
               onOpenEvent={setEventDetailId}
             />
           ) : (

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -129,6 +129,7 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
     updateEvent,
     deleteEvent,
     setEventVisibilityOverride,
+    setRecurringEventVisibilityOverride,
     createProject,
     updateProject,
     deleteProject,
@@ -299,6 +300,7 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
                   onUpdate={updateEvent}
                   onDelete={deleteEvent}
                   onSetVisibilityOverride={setEventVisibilityOverride}
+                  onSetRecurringVisibilityOverride={setRecurringEventVisibilityOverride}
                   subscriptionAutoPromote={subscriptionAutoPromote}
                 />
               );

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -342,7 +342,6 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
             onClose={() => setSettingsOpen(false)}
             primaryExternalAccountId={calendarSubscriptions[0]?.externalAccountId ?? null}
             events={events}
-            onSetVisibilityOverride={setEventVisibilityOverride}
           />
         </div>
       </CorrectionFactorsProvider>

--- a/src/app/api/events/[id]/visibility-override/bulk/route.ts
+++ b/src/app/api/events/[id]/visibility-override/bulk/route.ts
@@ -1,0 +1,241 @@
+import { randomUUID } from "node:crypto";
+
+import { NextResponse } from "next/server";
+
+import { logServerSide } from "@/entities/action-log/server";
+import { SupabaseCalendarSubscriptionGateway } from "@/entities/calendar-subscription/supabase-gateway";
+import { EVENT_SOURCE } from "@/entities/event/types";
+import { createClient } from "@/shared/supabase/server";
+
+/**
+ * Issue #229 / ADR 0056: recurring event の系列 override (bulk apply + rule 永続化)。
+ *
+ * - POST /api/events/[id]/visibility-override/bulk
+ *   body: { value: 'shown' | 'hidden', scope: 'this_and_following' | 'all' }
+ *
+ * 操作対象 instance (path param `id`) を起点に:
+ *   1. **bulk apply** (ADR 0056 §3 step 1): 該当 instance の `visibility_override` を
+ *      `value` に bulk update。**単発 override 済 (visibility_override != 'none') は保護**
+ *      (ADR 0056 §5)。`scope='this_and_following'` は target.start_time 以降のみ。
+ *   2. **rule 永続化** (ADR 0056 §3 step 2): `event_visibility_override_rules` を upsert
+ *      (1 recurring グループ = 1 rule、新しい操作で上書き)。
+ *   3. **action_log** (ADR 0056 §8): 影響を受けた各 instance に `event_promoted` /
+ *      `event_demoted` を発火 + rule 行に対し `event_visibility_rule_added` を発火。
+ *      全て同じ `bulk_operation_id` (uuid) で紐付ける (1 操作 = 1 集計単位)。
+ *
+ * recurring instance でない event (`recurring_event_id IS NULL`) に対する系列操作は 400 で拒否する
+ * (UI で抑止しているはずだが多重防御)。
+ */
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+type PostBody = {
+  value?: string;
+  scope?: string;
+};
+
+export async function POST(req: Request, ctx: RouteContext) {
+  const { id } = await ctx.params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  let body: PostBody;
+  try {
+    body = (await req.json()) as PostBody;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const value = body.value;
+  const scope = body.scope;
+  if (value !== "shown" && value !== "hidden") {
+    return NextResponse.json(
+      { error: "invalid_input", message: "value は 'shown' | 'hidden' のいずれか" },
+      { status: 400 },
+    );
+  }
+  if (scope !== "this_and_following" && scope !== "all") {
+    return NextResponse.json(
+      { error: "invalid_input", message: "scope は 'this_and_following' | 'all' のいずれか" },
+      { status: 400 },
+    );
+  }
+
+  // 操作対象 (target) instance を読む。recurring_event_id が NULL なら 400 で拒否。
+  const { data: target, error: targetErr } = await supabase
+    .from("events")
+    .select(
+      "id, source, external_calendar_id, external_id, recurring_event_id, start_time, visibility_override",
+    )
+    .eq("id", id)
+    .maybeSingle();
+  if (targetErr) {
+    console.error("[visibility-override/bulk] read target failed", targetErr);
+    return NextResponse.json({ error: "read_failed" }, { status: 500 });
+  }
+  if (!target) return NextResponse.json({ error: "not_found" }, { status: 404 });
+  if (!target.recurring_event_id) {
+    return NextResponse.json(
+      { error: "not_recurring", message: "単発 event には系列操作はできません" },
+      { status: 400 },
+    );
+  }
+
+  const recurringEventId = target.recurring_event_id;
+  const externalCalendarId = target.external_calendar_id;
+  const source = target.source;
+
+  // subscription を引いて auto_promote を取る。manual recurring event は実質存在しないが、
+  // 防御として manual fallback (subscription 無し → auto_promote=true 扱い) を踏襲する。
+  let subscriptionAutoPromote = true;
+  let externalAccountIdentifier = "";
+  if (source === EVENT_SOURCE.GOOGLE_CALENDAR) {
+    const subs = await new SupabaseCalendarSubscriptionGateway(supabase).list();
+    const sub = subs.find(
+      (s) => s.source === source && s.externalCalendarId === externalCalendarId,
+    );
+    if (sub) {
+      subscriptionAutoPromote = sub.autoPromoteToTimeline;
+      externalAccountIdentifier = sub.externalAccountIdentifier;
+    }
+  }
+
+  // ADR 0056 §5: 単発 override 済 (visibility_override != 'none') instance は除外して
+  // 「事実」を保護する。bulk update の WHERE で `visibility_override = 'none'` を絞ることで実現。
+  const targetStart = target.start_time;
+  let query = supabase
+    .from("events")
+    .select("id, external_id, start_time")
+    .eq("user_id", user.id)
+    .eq("source", source)
+    .eq("external_calendar_id", externalCalendarId)
+    .eq("recurring_event_id", recurringEventId)
+    .eq("visibility_override", "none");
+  if (scope === "this_and_following") {
+    query = query.gte("start_time", targetStart);
+  }
+  const { data: targets, error: targetsErr } = await query;
+  if (targetsErr) {
+    console.error("[visibility-override/bulk] fetch targets failed", targetsErr);
+    return NextResponse.json({ error: "read_failed" }, { status: 500 });
+  }
+  const targetIds = (targets ?? []).map((r) => r.id);
+
+  // bulk update: visibility_override を value に揃える。対象 0 件でも rule の永続化は行う
+  // (新規取り込み instance に対して方針が効くため)。
+  if (targetIds.length > 0) {
+    const { error: updateErr } = await supabase
+      .from("events")
+      .update({ visibility_override: value })
+      .in("id", targetIds);
+    if (updateErr) {
+      console.error("[visibility-override/bulk] bulk update failed", updateErr);
+      return NextResponse.json({ error: "update_failed" }, { status: 500 });
+    }
+  }
+
+  // rule 永続化 (ADR 0056 §3 step 2): 同 recurring グループに既存 rule があれば置き換える
+  // (UNIQUE (user_id, source, external_calendar_id, recurring_event_id) を活用)。
+  const fromStartTime = scope === "this_and_following" ? targetStart : null;
+  const { data: rule, error: ruleErr } = await supabase
+    .from("event_visibility_override_rules")
+    .upsert(
+      {
+        user_id: user.id,
+        source,
+        external_calendar_id: externalCalendarId,
+        recurring_event_id: recurringEventId,
+        scope,
+        override_value: value,
+        from_start_time: fromStartTime,
+      },
+      { onConflict: "user_id,source,external_calendar_id,recurring_event_id" },
+    )
+    .select("id")
+    .single();
+  if (ruleErr || !rule) {
+    console.error("[visibility-override/bulk] rule upsert failed", ruleErr);
+    return NextResponse.json({ error: "rule_upsert_failed" }, { status: 500 });
+  }
+
+  // action_log (ADR 0056 §8): bulk_operation_id で全 log を 1 操作として紐付ける。
+  const bulkOperationId = randomUUID();
+  const tripleBase = {
+    source,
+    external_account_id: externalAccountIdentifier,
+    external_calendar_id: externalCalendarId,
+  };
+
+  // 各 instance ごとに 1 件 (event_promoted / event_demoted)。
+  // is_override_of_default は to と subscription_auto_promote の関係から計算 (PATCH と同じ式)。
+  const isOverrideOfDefault =
+    value === "shown" ? !subscriptionAutoPromote : subscriptionAutoPromote;
+  for (const r of targets ?? []) {
+    if (value === "shown") {
+      await logServerSide(
+        supabase,
+        user.id,
+        "event_promoted",
+        {
+          ...tripleBase,
+          external_id: r.external_id ?? "",
+          from: "none",
+          to: "shown",
+          subscription_auto_promote: subscriptionAutoPromote,
+          is_override_of_default: isOverrideOfDefault,
+          scope,
+          recurring_event_id: recurringEventId,
+          bulk_operation_id: bulkOperationId,
+        },
+        "user",
+      );
+    } else {
+      await logServerSide(
+        supabase,
+        user.id,
+        "event_demoted",
+        {
+          ...tripleBase,
+          external_id: r.external_id ?? "",
+          from: "none",
+          to: "hidden",
+          subscription_auto_promote: subscriptionAutoPromote,
+          is_override_of_default: isOverrideOfDefault,
+          scope,
+          recurring_event_id: recurringEventId,
+          bulk_operation_id: bulkOperationId,
+        },
+        "user",
+      );
+    }
+  }
+
+  // rule 永続化を 1 件 log。bulk_operation_id で event_*ed 群と紐付ける。
+  await logServerSide(
+    supabase,
+    user.id,
+    "event_visibility_rule_added",
+    {
+      rule_id: rule.id,
+      source,
+      external_calendar_id: externalCalendarId,
+      recurring_event_id: recurringEventId,
+      scope,
+      override_value: value,
+      from_start_time: fromStartTime,
+      bulk_operation_id: bulkOperationId,
+    },
+    "user",
+  );
+
+  return NextResponse.json({
+    rule_id: rule.id,
+    bulk_operation_id: bulkOperationId,
+    scope,
+    value,
+    affected_event_ids: targetIds,
+  });
+}

--- a/src/app/api/events/[id]/visibility-override/route.ts
+++ b/src/app/api/events/[id]/visibility-override/route.ts
@@ -64,7 +64,9 @@ export async function PATCH(req: Request, ctx: RouteContext) {
   // 現状の event を読む。RLS 違反 / 見つからない場合は 404 で早期 return。
   const { data: row, error: readErr } = await supabase
     .from("events")
-    .select("id, source, external_id, external_calendar_id, visibility_override, user_id")
+    .select(
+      "id, source, external_id, external_calendar_id, visibility_override, recurring_event_id, user_id",
+    )
     .eq("id", id)
     .maybeSingle();
   if (readErr) {
@@ -110,6 +112,10 @@ export async function PATCH(req: Request, ctx: RouteContext) {
     external_id: row.external_id ?? "",
   };
 
+  // ADR 0056 §8: 単発操作でも recurring instance なら recurring_event_id を log に残す。
+  // scope='single' を明示することで Phase 4 が「単発 / 系列」を一目で区別できる。
+  const recurringEventId = row.recurring_event_id ?? null;
+
   if (next === "shown") {
     // to='shown' かつ default が auto_promote=true (= 表示) なら is_override_of_default=false。
     // to='shown' かつ default が auto_promote=false (= 非表示) なら是 default 逸脱。
@@ -124,6 +130,8 @@ export async function PATCH(req: Request, ctx: RouteContext) {
         to: "shown",
         subscription_auto_promote: subscriptionAutoPromote,
         is_override_of_default: isOverrideOfDefault,
+        scope: "single",
+        recurring_event_id: recurringEventId,
       },
       "user",
     );
@@ -139,6 +147,8 @@ export async function PATCH(req: Request, ctx: RouteContext) {
         to: "hidden",
         subscription_auto_promote: subscriptionAutoPromote,
         is_override_of_default: isOverrideOfDefault,
+        scope: "single",
+        recurring_event_id: recurringEventId,
       },
       "user",
     );

--- a/src/app/api/events/visibility-override-rules/[id]/route.ts
+++ b/src/app/api/events/visibility-override-rules/[id]/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from "next/server";
+
+import { logServerSide } from "@/entities/action-log/server";
+import { createClient } from "@/shared/supabase/server";
+
+/**
+ * Issue #229 / ADR 0056 §7: 系列 override の rule 単独削除。
+ *
+ * - DELETE /api/events/visibility-override-rules/[id]
+ *
+ * rule を削除しても既存 instance の `visibility_override` (= 事実) は触らない (ADR 0056 §7)。
+ * 削除以降に取り込まれる新規 instance は default 動作 (subscription.auto_promote) に戻る。
+ *
+ * action_log: `event_visibility_rule_removed` を 1 件発火。
+ */
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function DELETE(_req: Request, ctx: RouteContext) {
+  const { id } = await ctx.params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  // 削除前に rule の snapshot を取って action_log に残す (ADR 0035 §2 ii: 削除系は snapshot 必須)。
+  const { data: rule, error: readErr } = await supabase
+    .from("event_visibility_override_rules")
+    .select(
+      "id, source, external_calendar_id, recurring_event_id, scope, override_value, from_start_time",
+    )
+    .eq("id", id)
+    .maybeSingle();
+  if (readErr) {
+    console.error("[visibility-override-rules] read failed", readErr);
+    return NextResponse.json({ error: "read_failed" }, { status: 500 });
+  }
+  if (!rule) return NextResponse.json({ error: "not_found" }, { status: 404 });
+
+  const { error: delErr } = await supabase
+    .from("event_visibility_override_rules")
+    .delete()
+    .eq("id", id);
+  if (delErr) {
+    console.error("[visibility-override-rules] delete failed", delErr);
+    return NextResponse.json({ error: "delete_failed" }, { status: 500 });
+  }
+
+  await logServerSide(
+    supabase,
+    user.id,
+    "event_visibility_rule_removed",
+    {
+      rule_id: rule.id,
+      source: rule.source,
+      external_calendar_id: rule.external_calendar_id,
+      recurring_event_id: rule.recurring_event_id,
+      scope: rule.scope as "this_and_following" | "all",
+      override_value: rule.override_value as "shown" | "hidden",
+      from_start_time: rule.from_start_time,
+    },
+    "user",
+  );
+
+  return NextResponse.json({ deleted: true });
+}

--- a/src/app/api/events/visibility-override-rules/route.ts
+++ b/src/app/api/events/visibility-override-rules/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+
+import { createClient } from "@/shared/supabase/server";
+
+/**
+ * Issue #229 / ADR 0056 §7: 系列 override の rule 一覧を返す。
+ *
+ * - GET /api/events/visibility-override-rules
+ *   → { rules: EventVisibilityOverrideRule[] }
+ *
+ * 認証済 user の rules を全件返す。RLS が user_id = auth.uid() で絞っているので
+ * service_role でない限り他ユーザーの rule は読めない。
+ *
+ * UI (SettingsPanel rules セクション) で「方針」一覧 + 単独削除導線を提供するために使う
+ * (孤立 rule の手動削除も同経路、ADR 0056 §7)。
+ */
+export async function GET() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const { data, error } = await supabase
+    .from("event_visibility_override_rules")
+    .select(
+      "id, source, external_calendar_id, recurring_event_id, scope, override_value, from_start_time, created_at",
+    )
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: false });
+  if (error) {
+    console.error("[visibility-override-rules] list failed", error);
+    return NextResponse.json({ error: "read_failed" }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    rules: (data ?? []).map((r) => ({
+      id: r.id,
+      source: r.source,
+      externalCalendarId: r.external_calendar_id,
+      recurringEventId: r.recurring_event_id,
+      scope: r.scope,
+      overrideValue: r.override_value,
+      fromStartTime: r.from_start_time,
+      createdAt: r.created_at,
+    })),
+  });
+}

--- a/src/app/useDashboardMutations.ts
+++ b/src/app/useDashboardMutations.ts
@@ -6,7 +6,11 @@ import { useCallback } from "react";
 import { dashboardKeys } from "./useDashboardQueries";
 import { ACTION_TYPES, log } from "@/entities/action-log/logger";
 import type { CreateEventInput, UpdateEventInput } from "@/entities/event/gateway";
-import type { Event, EventVisibilityOverride } from "@/entities/event/types";
+import type {
+  Event,
+  EventVisibilityOverride,
+  EventVisibilityOverrideScope,
+} from "@/entities/event/types";
 import type { CreateProjectInput, UpdateProjectInput } from "@/entities/project/gateway";
 import type { Project } from "@/entities/project/types";
 import type { CreateTaskInput, ProjectCascadeMode } from "@/entities/task/gateway";
@@ -77,6 +81,16 @@ export type DashboardMutations = {
    * の override 一覧 reset 専用導線から呼ぶ (ADR 0032: 日常 UI から none へは戻せない)。
    */
   setEventVisibilityOverride: (id: string, value: EventVisibilityOverride) => Promise<void>;
+  /**
+   * Issue #229 / ADR 0056: recurring event の系列 override (bulk apply + rule 永続化)。
+   * `scope='this_and_following' | 'all'` のみ受け付ける (`single` は既存の
+   * setEventVisibilityOverride 経路を使う)。
+   */
+  setRecurringEventVisibilityOverride: (
+    id: string,
+    value: "shown" | "hidden",
+    scope: Exclude<EventVisibilityOverrideScope, "single">,
+  ) => Promise<void>;
   createProject: (input: CreateProjectInput) => Promise<void>;
   updateProject: (id: string, patch: UpdateProjectInput) => Promise<void>;
   /** schema 上 ON DELETE SET NULL なので tasks/events も invalidate する。 */
@@ -466,6 +480,55 @@ export function useDashboardMutations(): DashboardMutations {
     },
   });
 
+  // Issue #229 / ADR 0056: 系列 override (bulk apply + rule 永続化)。
+  // server 側で affected な instance を返すので、optimistic は target だけ即時書き換え、
+  // 残りは onSettled の invalidate で refetch して反映する (refetch 1 回でも UX は十分)。
+  // rule 一覧 (settings の rules セクション) も invalidate する。
+  const setRecurringEventVisibilityOverrideMutation = useMutation({
+    mutationFn: async ({
+      id,
+      value,
+      scope,
+    }: {
+      id: string;
+      value: "shown" | "hidden";
+      scope: Exclude<EventVisibilityOverrideScope, "single">;
+    }) => {
+      const res = await fetch(`/api/events/${id}/visibility-override/bulk`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ value, scope }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(body?.error ?? `recurring_visibility_override_failed: ${res.status}`);
+      }
+      return (await res.json()) as {
+        rule_id: string;
+        bulk_operation_id: string;
+        scope: "this_and_following" | "all";
+        value: "shown" | "hidden";
+        affected_event_ids: string[];
+      };
+    },
+    onMutate: async ({ id, value }) => {
+      await queryClient.cancelQueries({ queryKey: dashboardKeys.events });
+      const previous = queryClient.getQueryData<Event[]>(dashboardKeys.events);
+      // optimistic: target instance だけ即時書き換え。系列影響は onSettled の invalidate に任せる。
+      queryClient.setQueryData<Event[]>(dashboardKeys.events, (prev) =>
+        (prev ?? []).map((e) => (e.id === id ? { ...e, visibilityOverride: value } : e)),
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(dashboardKeys.events, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.events });
+      queryClient.invalidateQueries({ queryKey: ["calendar", "visibility-override-rules"] });
+    },
+  });
+
   // ADR 0010: manual イベントだけが UI から削除可能。google_calendar は
   // SupabaseEventGateway.delete が source を見て弾く。
   const deleteEventMutation = useMutation({
@@ -751,6 +814,10 @@ export function useDashboardMutations(): DashboardMutations {
     deleteEvent: (id) => deleteEventMutation.mutateAsync(id).then(() => undefined),
     setEventVisibilityOverride: (id, value) =>
       setEventVisibilityOverrideMutation.mutateAsync({ id, value }).then(() => undefined),
+    setRecurringEventVisibilityOverride: (id, value, scope) =>
+      setRecurringEventVisibilityOverrideMutation
+        .mutateAsync({ id, value, scope })
+        .then(() => undefined),
     createProject: (input) => createProjectMutation.mutateAsync(input).then(() => undefined),
     updateProject: (id, patch) =>
       updateProjectMutation.mutateAsync({ id, patch }).then(() => undefined),

--- a/src/entities/action-log/logger.test.ts
+++ b/src/entities/action-log/logger.test.ts
@@ -216,6 +216,8 @@ describe("ACTION_TYPES", () => {
       EVENT_PROMOTED: "event_promoted",
       EVENT_DEMOTED: "event_demoted",
       EVENT_OVERRIDE_CLEARED: "event_override_cleared",
+      EVENT_VISIBILITY_RULE_ADDED: "event_visibility_rule_added",
+      EVENT_VISIBILITY_RULE_REMOVED: "event_visibility_rule_removed",
       EXTERNAL_ACCOUNT_ADDED: "external_account_added",
       EXTERNAL_ACCOUNT_REMOVED: "external_account_removed",
       EVENT_VISIBILITY_FROZEN_BY_SUBSCRIPTION_TOGGLE:

--- a/src/entities/action-log/logger.ts
+++ b/src/entities/action-log/logger.ts
@@ -46,6 +46,8 @@ export const ACTION_TYPES = Object.freeze({
   EVENT_PROMOTED: "event_promoted",
   EVENT_DEMOTED: "event_demoted",
   EVENT_OVERRIDE_CLEARED: "event_override_cleared",
+  EVENT_VISIBILITY_RULE_ADDED: "event_visibility_rule_added",
+  EVENT_VISIBILITY_RULE_REMOVED: "event_visibility_rule_removed",
   EXTERNAL_ACCOUNT_ADDED: "external_account_added",
   EXTERNAL_ACCOUNT_REMOVED: "external_account_removed",
   EVENT_VISIBILITY_FROZEN_BY_SUBSCRIPTION_TOGGLE: "event_visibility_frozen_by_subscription_toggle",

--- a/src/entities/action-log/types.ts
+++ b/src/entities/action-log/types.ts
@@ -28,6 +28,8 @@ export type ActionType =
   | "event_promoted"
   | "event_demoted"
   | "event_override_cleared"
+  | "event_visibility_rule_added"
+  | "event_visibility_rule_removed"
   | "external_account_added"
   | "external_account_removed"
   // system actor:
@@ -277,6 +279,15 @@ export type ActionMetadataMap = {
     to: "shown";
     subscription_auto_promote: boolean;
     is_override_of_default: boolean;
+    // ADR 0056 §8: 系列 / 単発の区別を Phase 4 が分析できるように残す。
+    // - scope='single' (default、recurring 由来でも単発操作なら 'single')
+    //   recurring 由来なら recurring_event_id も入れる (rule 系操作との突合のため)。
+    //   bulk_operation_id は付けない。
+    // - scope='this_and_following' | 'all' のとき:
+    //   recurring_event_id 必須。bulk_operation_id 必須 (1 操作 = 1 uuid を全 instance log で共有)。
+    scope?: "single" | "this_and_following" | "all";
+    recurring_event_id?: string | null;
+    bulk_operation_id?: string;
   };
   event_demoted: {
     source: string;
@@ -287,6 +298,33 @@ export type ActionMetadataMap = {
     to: "hidden";
     subscription_auto_promote: boolean;
     is_override_of_default: boolean;
+    // ADR 0056 §8: event_promoted と同じ規約。
+    scope?: "single" | "this_and_following" | "all";
+    recurring_event_id?: string | null;
+    bulk_operation_id?: string;
+  };
+  // ADR 0056 §8: rule 永続化操作。event_promoted/event_demoted と
+  // bulk_operation_id で対応する (1 操作 = 1 rule + N 件 event_*ed log)。
+  event_visibility_rule_added: {
+    rule_id: string;
+    source: string;
+    external_calendar_id: string;
+    recurring_event_id: string;
+    scope: "this_and_following" | "all";
+    override_value: "shown" | "hidden";
+    /** scope='this_and_following' のとき必須、'all' のとき null。 */
+    from_start_time: string | null;
+    /** 同操作の event_promoted/event_demoted 群と紐付ける uuid (ADR 0056 §8)。 */
+    bulk_operation_id: string;
+  };
+  event_visibility_rule_removed: {
+    rule_id: string;
+    source: string;
+    external_calendar_id: string;
+    recurring_event_id: string;
+    scope: "this_and_following" | "all";
+    override_value: "shown" | "hidden";
+    from_start_time: string | null;
   };
   event_override_cleared: {
     source: string;

--- a/src/entities/event/RecurringScopeModal.tsx
+++ b/src/entities/event/RecurringScopeModal.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect } from "react";
+
+import type { EventVisibilityOverrideScope } from "./types";
+
+/**
+ * Issue #229 / ADR 0056 §6: recurring event の予定化 / 解除を選んだ時に出す 3 択 modal。
+ *
+ * - default は `single` (ADR 0056 §6)。系列影響は明示選択でしか発生させない。
+ * - `role="dialog"` + `aria-modal` + `aria-labelledby` で a11y 構造を立てる
+ *   (kozutsumi-frontend-a11y skill 2.1)。
+ * - 操作中 (pending) は全ボタンを disabled にして連打を防ぐ。
+ * - ESC / オーバーレイクリックで閉じる (キャンセル相当)。
+ *
+ * 呼び出し元 (EventDetailPanel / EventManagement) が `targetValue` (= 倒したい方向) を
+ * 決めて modal を開く。modal 自体は「どの scope に適用するか」だけを担当する。
+ */
+export function RecurringScopeModal({
+  targetValue,
+  pending,
+  onSelect,
+  onClose,
+}: {
+  targetValue: "shown" | "hidden";
+  pending: boolean;
+  onSelect: (scope: EventVisibilityOverrideScope) => void;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !pending) onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose, pending]);
+
+  const titleId = "event-recurring-scope-title";
+  const verb = targetValue === "shown" ? "予定化" : "予定化解除";
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      className="fixed inset-0 z-[210] flex items-center justify-center"
+    >
+      <div
+        onClick={pending ? undefined : onClose}
+        className="absolute inset-0 bg-black/60 backdrop-blur-[4px]"
+      />
+      <div className="relative w-[min(420px,calc(100vw-32px))] rounded-lg border border-bg-divider bg-bg-elevated p-5 shadow-xl">
+        <h3 id={titleId} className="m-0 font-jp text-[13px] font-semibold text-fg-strong">
+          繰り返し予定の{verb}
+        </h3>
+        <p className="mt-2 text-[11px] leading-relaxed text-fg-muted">
+          この予定は繰り返しの一部です。どの範囲に{verb}を適用しますか?
+        </p>
+        <div className="mt-4 flex flex-col gap-2">
+          <button
+            type="button"
+            disabled={pending}
+            onClick={() => onSelect("single")}
+            className="rounded-md border border-accent-blue/60 bg-accent-blue/10 px-3 py-2 text-left font-jp text-[12px] text-fg-emphasized disabled:opacity-60"
+          >
+            <span className="block font-semibold">この予定だけ</span>
+            <span className="mt-0.5 block text-[10px] text-fg-muted">
+              選択した回のみに{verb}を適用します。
+            </span>
+          </button>
+          <button
+            type="button"
+            disabled={pending}
+            onClick={() => onSelect("this_and_following")}
+            className="rounded-md border border-bg-divider bg-bg-primary px-3 py-2 text-left font-jp text-[12px] text-fg-emphasized disabled:opacity-60"
+          >
+            <span className="block font-semibold">これ以降の予定もまとめて</span>
+            <span className="mt-0.5 block text-[10px] text-fg-muted">
+              この回以降の繰り返しすべてに{verb}を適用します。
+            </span>
+          </button>
+          <button
+            type="button"
+            disabled={pending}
+            onClick={() => onSelect("all")}
+            className="rounded-md border border-bg-divider bg-bg-primary px-3 py-2 text-left font-jp text-[12px] text-fg-emphasized disabled:opacity-60"
+          >
+            <span className="block font-semibold">すべての繰り返し</span>
+            <span className="mt-0.5 block text-[10px] text-fg-muted">
+              過去・未来を含む全ての回に{verb}を適用します。
+            </span>
+          </button>
+        </div>
+        <div className="mt-4 flex justify-end">
+          <button
+            type="button"
+            disabled={pending}
+            onClick={onClose}
+            className="rounded border border-bg-divider bg-transparent px-3 py-1.5 font-jp text-[11px] text-fg-subtle disabled:opacity-60"
+          >
+            キャンセル
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/entities/event/RecurringScopeModal.tsx
+++ b/src/entities/event/RecurringScopeModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import type { EventVisibilityOverrideScope } from "./types";
 
@@ -11,6 +11,9 @@ import type { EventVisibilityOverrideScope } from "./types";
  * - `role="dialog"` + `aria-modal` + `aria-labelledby` で a11y 構造を立てる
  *   (kozutsumi-frontend-a11y skill 2.1)。
  * - 操作中 (pending) は全ボタンを disabled にして連打を防ぐ。
+ * - **クリックしたボタンだけ「処理中…」表示にする** ことで、bulk apply に時間がかかっても
+ *   「効いていない / 固まった」に見えないようにする。他のボタンは強めに fade して連打を防ぐ
+ *   (一律に opacity-60 だとどれを押したか視覚的に分からないバグっぽさが出る)。
  * - ESC / オーバーレイクリックで閉じる (キャンセル相当)。
  *
  * 呼び出し元 (EventDetailPanel / EventManagement) が `targetValue` (= 倒したい方向) を
@@ -27,6 +30,11 @@ export function RecurringScopeModal({
   onSelect: (scope: EventVisibilityOverrideScope) => void;
   onClose: () => void;
 }) {
+  // クリックされた scope を保持して「処理中」表示に使う。pending=false の間は描画側で
+  // ガードするので state は stale で構わない (次のクリックで上書き)。useEffect で cleanup
+  // すると set-state-in-effect になるので、derivation 側で `pending && ...` を見る。
+  const [clickedScope, setClickedScope] = useState<EventVisibilityOverrideScope | null>(null);
+
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape" && !pending) onClose();
@@ -35,8 +43,42 @@ export function RecurringScopeModal({
     return () => window.removeEventListener("keydown", onKey);
   }, [onClose, pending]);
 
+  const handleClick = (scope: EventVisibilityOverrideScope) => {
+    if (pending) return;
+    setClickedScope(scope);
+    onSelect(scope);
+  };
+
   const titleId = "event-recurring-scope-title";
   const verb = targetValue === "shown" ? "予定化" : "予定化解除";
+
+  const choices: Array<{
+    scope: EventVisibilityOverrideScope;
+    title: string;
+    description: string;
+    /** default scope (`single`) は強調枠 (ADR 0056 §6)。それ以外は通常枠。 */
+    emphasis: boolean;
+  }> = [
+    {
+      scope: "single",
+      title: "この予定だけ",
+      description: `選択した回のみに${verb}を適用します。`,
+      emphasis: true,
+    },
+    {
+      scope: "this_and_following",
+      title: "これ以降の予定もまとめて",
+      description: `この回以降の繰り返しすべてに${verb}を適用します。`,
+      emphasis: false,
+    },
+    {
+      scope: "all",
+      title: "すべての繰り返し",
+      description: `過去・未来を含む全ての回に${verb}を適用します。`,
+      emphasis: false,
+    },
+  ];
+
   return (
     <div
       role="dialog"
@@ -56,39 +98,43 @@ export function RecurringScopeModal({
           この予定は繰り返しの一部です。どの範囲に{verb}を適用しますか?
         </p>
         <div className="mt-4 flex flex-col gap-2">
-          <button
-            type="button"
-            disabled={pending}
-            onClick={() => onSelect("single")}
-            className="rounded-md border border-accent-blue/60 bg-accent-blue/10 px-3 py-2 text-left font-jp text-[12px] text-fg-emphasized disabled:opacity-60"
-          >
-            <span className="block font-semibold">この予定だけ</span>
-            <span className="mt-0.5 block text-[10px] text-fg-muted">
-              選択した回のみに{verb}を適用します。
-            </span>
-          </button>
-          <button
-            type="button"
-            disabled={pending}
-            onClick={() => onSelect("this_and_following")}
-            className="rounded-md border border-bg-divider bg-bg-primary px-3 py-2 text-left font-jp text-[12px] text-fg-emphasized disabled:opacity-60"
-          >
-            <span className="block font-semibold">これ以降の予定もまとめて</span>
-            <span className="mt-0.5 block text-[10px] text-fg-muted">
-              この回以降の繰り返しすべてに{verb}を適用します。
-            </span>
-          </button>
-          <button
-            type="button"
-            disabled={pending}
-            onClick={() => onSelect("all")}
-            className="rounded-md border border-bg-divider bg-bg-primary px-3 py-2 text-left font-jp text-[12px] text-fg-emphasized disabled:opacity-60"
-          >
-            <span className="block font-semibold">すべての繰り返し</span>
-            <span className="mt-0.5 block text-[10px] text-fg-muted">
-              過去・未来を含む全ての回に{verb}を適用します。
-            </span>
-          </button>
+          {choices.map((c) => {
+            // pending 中だけ「クリック済」として描画する (pending=false 時は state が stale でも無視)。
+            const isClicked = pending && clickedScope === c.scope;
+            const isOtherClicked = pending && clickedScope !== null && clickedScope !== c.scope;
+            // 「クリックされた行」: 強い枠 + 処理中ラベル。
+            // 「クリックされてない行 (pending 中)」: 強めに fade してアクション不能に。
+            // 「pending じゃない」: 通常表示。emphasis あれば accent 枠で default を示唆。
+            const baseClass =
+              "rounded-md px-3 py-2 text-left font-jp text-[12px] text-fg-emphasized transition";
+            const stateClass = isClicked
+              ? "border-2 border-accent-blue bg-accent-blue/20 ring-2 ring-accent-blue/40"
+              : isOtherClicked
+                ? "border border-bg-divider bg-bg-primary opacity-30"
+                : c.emphasis
+                  ? "border border-accent-blue/60 bg-accent-blue/10"
+                  : "border border-bg-divider bg-bg-primary";
+            return (
+              <button
+                key={c.scope}
+                type="button"
+                disabled={pending}
+                aria-busy={isClicked}
+                onClick={() => handleClick(c.scope)}
+                className={`${baseClass} ${stateClass}`}
+              >
+                <span className="block font-semibold">
+                  {c.title}
+                  {isClicked ? (
+                    <span className="ml-2 font-jp text-[10px] font-normal text-accent-blue">
+                      処理中…
+                    </span>
+                  ) : null}
+                </span>
+                <span className="mt-0.5 block text-[10px] text-fg-muted">{c.description}</span>
+              </button>
+            );
+          })}
         </div>
         <div className="mt-4 flex justify-end">
           <button

--- a/src/entities/event/gateway.ts
+++ b/src/entities/event/gateway.ts
@@ -28,6 +28,11 @@ export type UpdateEventInput = {
  * `externalCalendarId` (ADR 0033 / 0052) は subscription を介して呼び出し元が決める。primary calendar は
  * Google API resolve した実 id (= email)。リテラル `'primary'` は使わない。
  * `visibility_override` も同期で再 upsert されても触らない (ADR 0034 L4)。
+ *
+ * `recurringEventId` (ADR 0056) は recurring の master id。`singleEvents=true` で展開された
+ * instance に対しては Google API が値を返す (単発は null)。新規 instance 取り込み時、該当する
+ * `event_visibility_override_rules` があれば `visibility_override` を rule の値で初期化する
+ * (ADR 0056 §2)。既存 instance は再 upsert されても visibility_override は触らない。
  */
 export type UpsertGoogleCalendarEventInput = {
   externalCalendarId: string;
@@ -38,6 +43,7 @@ export type UpsertGoogleCalendarEventInput = {
   meetUrl: string | null;
   hasAttachments: boolean;
   description: string;
+  recurringEventId: string | null;
 };
 
 export interface EventGateway {

--- a/src/entities/event/supabase-gateway.test.ts
+++ b/src/entities/event/supabase-gateway.test.ts
@@ -24,6 +24,7 @@ function makeRow(overrides: Partial<EventRow> = {}): EventRow {
     external_id: null,
     external_calendar_id: "manual",
     visibility_override: "none",
+    recurring_event_id: null,
     created_at: "2026-04-23T00:00:00.000Z",
     ...overrides,
   };

--- a/src/entities/event/supabase-gateway.ts
+++ b/src/entities/event/supabase-gateway.ts
@@ -30,6 +30,7 @@ function fromRow(row: Tables<"events">): Event {
     externalId: row.external_id,
     externalCalendarId: row.external_calendar_id,
     visibilityOverride: row.visibility_override,
+    recurringEventId: row.recurring_event_id,
     createdAt: row.created_at,
   };
 }
@@ -144,9 +145,38 @@ export class SupabaseEventGateway implements EventGateway {
   async upsertFromGoogleCalendar(inputs: UpsertGoogleCalendarEventInput[]): Promise<number> {
     if (inputs.length === 0) return 0;
     const user_id = await getUserId(this.supabase);
-    // project_id / visibility_override を payload に含めないことで、ON CONFLICT DO UPDATE SET ... から
-    // 除外され、既存行の値が保持される (kozutsumi 側の拡張、ADR 0010 / ADR 0034 L4)
-    const payloads: TablesInsert<"events">[] = inputs.map((input) => ({
+
+    // ADR 0056 §2: 新規 instance 取り込み時に該当 rule があれば visibility_override を
+    // rule.override_value で初期化する。既存 instance は visibility_override を触らない
+    // (ADR 0034 L4 / ADR 0056 §5: 単発 override 保護)。
+    //
+    // 「新規 / 既存」を split して 2 段階の upsert を行う:
+    //   - 新規:   visibility_override を payload に含めて INSERT (rule 由来 or 'none')
+    //   - 既存:   visibility_override を payload に含めず ON CONFLICT DO UPDATE で保持
+    //
+    // 1 つの upsert にまとめると、既存行に対して payload の visibility_override で
+    // 上書きしてしまう (ON CONFLICT DO UPDATE SET の挙動)。
+
+    const externalIds = inputs.map((i) => i.externalId);
+    const { data: existingRows, error: selErr } = await this.supabase
+      .from("events")
+      .select("external_calendar_id, external_id")
+      .eq("user_id", user_id)
+      .eq("source", EVENT_SOURCE.GOOGLE_CALENDAR)
+      .in("external_id", externalIds);
+    if (selErr) throw selErr;
+    const existingKeys = new Set(
+      (existingRows ?? []).map((r) => `${r.external_calendar_id}::${r.external_id}`),
+    );
+    const isNew = (input: UpsertGoogleCalendarEventInput) =>
+      !existingKeys.has(`${input.externalCalendarId}::${input.externalId}`);
+
+    const newInputs = inputs.filter(isNew);
+    const existingInputs = inputs.filter((i) => !isNew(i));
+
+    const initialOverrides = await this.resolveInitialOverridesForNewInstances(user_id, newInputs);
+
+    const basePayload = (input: UpsertGoogleCalendarEventInput): TablesInsert<"events"> => ({
       user_id,
       title: input.title,
       start_time: input.startTime,
@@ -157,14 +187,103 @@ export class SupabaseEventGateway implements EventGateway {
       source: EVENT_SOURCE.GOOGLE_CALENDAR,
       external_id: input.externalId,
       external_calendar_id: input.externalCalendarId,
-    }));
-    // ADR 0033: triple uniqueness `(source, external_calendar_id, external_id)`
-    const { error } = await this.supabase
-      .from("events")
-      .upsert(payloads, { onConflict: "source,external_calendar_id,external_id" });
-    if (error) throw error;
-    // upsert は全 input に対して insert または update を実行するため、affected = inputs.length
+      recurring_event_id: input.recurringEventId,
+    });
+
+    if (newInputs.length > 0) {
+      const newPayloads: TablesInsert<"events">[] = newInputs.map((input) => ({
+        ...basePayload(input),
+        visibility_override:
+          initialOverrides.get(`${input.externalCalendarId}::${input.externalId}`) ?? "none",
+      }));
+      // ignoreDuplicates: 並走 sync で他経路から先行 INSERT された場合に既存値を上書きしない安全弁。
+      const { error } = await this.supabase.from("events").upsert(newPayloads, {
+        onConflict: "source,external_calendar_id,external_id",
+        ignoreDuplicates: true,
+      });
+      if (error) throw error;
+    }
+
+    if (existingInputs.length > 0) {
+      const existingPayloads: TablesInsert<"events">[] = existingInputs.map(basePayload);
+      // visibility_override は payload に含めないので ON CONFLICT DO UPDATE SET から除外され、
+      // 既存値が保持される (ADR 0034 L4)。
+      const { error } = await this.supabase
+        .from("events")
+        .upsert(existingPayloads, { onConflict: "source,external_calendar_id,external_id" });
+      if (error) throw error;
+    }
+
     return inputs.length;
+  }
+
+  /**
+   * ADR 0056 §2: 新規 instance に対し、該当する rule があれば visibility_override の初期値を
+   * rule.override_value に解決する。recurring_event_id が無い (= 単発) instance は対象外。
+   *
+   * 戻り値の Map key は `${external_calendar_id}::${external_id}`。値が無い instance は
+   * default の `'none'` で insert する (ADR 0032)。
+   */
+  private async resolveInitialOverridesForNewInstances(
+    userId: string,
+    newInputs: UpsertGoogleCalendarEventInput[],
+  ): Promise<Map<string, EventVisibilityOverride>> {
+    const result = new Map<string, EventVisibilityOverride>();
+    if (newInputs.length === 0) return result;
+
+    // (external_calendar_id, recurring_event_id) のユニーク集合を作って 1 query にまとめる。
+    const calendarToRecurringIds = new Map<string, Set<string>>();
+    for (const input of newInputs) {
+      if (!input.recurringEventId) continue;
+      let set = calendarToRecurringIds.get(input.externalCalendarId);
+      if (!set) {
+        set = new Set();
+        calendarToRecurringIds.set(input.externalCalendarId, set);
+      }
+      set.add(input.recurringEventId);
+    }
+    if (calendarToRecurringIds.size === 0) return result;
+
+    // calendar 単位で rules を batch fetch (PostgREST の `.in()` を使う)。
+    type RuleRow = {
+      external_calendar_id: string;
+      recurring_event_id: string;
+      scope: "this_and_following" | "all";
+      override_value: "shown" | "hidden";
+      from_start_time: string | null;
+    };
+    const rulesByKey = new Map<string, RuleRow>();
+    for (const [calendarId, recurringIds] of calendarToRecurringIds) {
+      const { data, error } = await this.supabase
+        .from("event_visibility_override_rules")
+        .select("external_calendar_id, recurring_event_id, scope, override_value, from_start_time")
+        .eq("user_id", userId)
+        .eq("source", EVENT_SOURCE.GOOGLE_CALENDAR)
+        .eq("external_calendar_id", calendarId)
+        .in("recurring_event_id", Array.from(recurringIds));
+      if (error) throw error;
+      for (const r of (data as RuleRow[] | null) ?? []) {
+        rulesByKey.set(`${r.external_calendar_id}::${r.recurring_event_id}`, r);
+      }
+    }
+    if (rulesByKey.size === 0) return result;
+
+    for (const input of newInputs) {
+      if (!input.recurringEventId) continue;
+      const rule = rulesByKey.get(`${input.externalCalendarId}::${input.recurringEventId}`);
+      if (!rule) continue;
+      // scope='all' は全 instance に適用、'this_and_following' は from_start_time 以降のみ適用
+      // (ADR 0056 §4: 操作対象 instance の start_time 起点)。
+      const applies =
+        rule.scope === "all" ||
+        (rule.scope === "this_and_following" &&
+          rule.from_start_time !== null &&
+          Date.parse(input.startTime) >= Date.parse(rule.from_start_time));
+      if (applies) {
+        result.set(`${input.externalCalendarId}::${input.externalId}`, rule.override_value);
+      }
+    }
+    return result;
   }
 
   async deleteByGoogleExternalIds(

--- a/src/entities/event/sync.test.ts
+++ b/src/entities/event/sync.test.ts
@@ -150,6 +150,7 @@ describe("mapGoogleEventToUpsertInput", () => {
       meetUrl: "https://meet.google.com/xyz",
       hasAttachments: true,
       description: "議題: 進捗",
+      recurringEventId: null,
     });
   });
 
@@ -172,6 +173,32 @@ describe("mapGoogleEventToUpsertInput", () => {
       meetUrl: null,
       hasAttachments: false,
       description: "",
+      recurringEventId: null,
+    });
+  });
+
+  test("recurring instance: recurringEventId を保持する (ADR 0056)", () => {
+    const result = mapGoogleEventToUpsertInput(
+      {
+        id: "evt-instance-3",
+        recurringEventId: "evt-master-1",
+        summary: "毎週 1on1",
+        start: { dateTime: "2026-04-23T10:00:00+09:00" },
+        end: { dateTime: "2026-04-23T11:00:00+09:00" },
+      },
+      "primary",
+    );
+
+    expect(result).toEqual<UpsertGoogleCalendarEventInput>({
+      externalCalendarId: "primary",
+      externalId: "evt-instance-3",
+      title: "毎週 1on1",
+      startTime: "2026-04-23T01:00:00.000Z",
+      endTime: "2026-04-23T02:00:00.000Z",
+      meetUrl: null,
+      hasAttachments: false,
+      description: "",
+      recurringEventId: "evt-master-1",
     });
   });
 

--- a/src/entities/event/sync.ts
+++ b/src/entities/event/sync.ts
@@ -587,6 +587,9 @@ export function mapGoogleEventToUpsertInput(
     meetUrl: extractMeetUrl(event),
     hasAttachments: Array.isArray(event.attachments) && event.attachments.length > 0,
     description: event.description ?? "",
+    // ADR 0056: recurring instance なら master id を保持 (singleEvents=true でも返る)。
+    // 単発 event は undefined → null に揃えて schema (text nullable) と一致させる。
+    recurringEventId: event.recurringEventId ?? null,
   };
 }
 

--- a/src/entities/event/types.ts
+++ b/src/entities/event/types.ts
@@ -20,6 +20,10 @@ export type EventVisibilityOverride = "none" | "shown" | "hidden";
  *
  * `externalCalendarId` は ADR 0033 の triple `(source, externalCalendarId, externalId)`
  * の中間軸。manual は 'manual'、google_calendar 由来は subscription の calendar id。
+ *
+ * `recurringEventId` は ADR 0056 の recurring グループ識別子 (Google Calendar の master
+ * event id)。NULL = 単発 event。`source` + `externalCalendarId` + `recurringEventId` で
+ * recurring グループを一意に識別する。
  */
 export type Event = {
   id: string;
@@ -34,5 +38,32 @@ export type Event = {
   externalId: string | null;
   externalCalendarId: string;
   visibilityOverride: EventVisibilityOverride;
+  /** ADR 0056: recurring の master id。NULL = 単発 event。 */
+  recurringEventId: string | null;
+  createdAt: string;
+};
+
+/**
+ * ADR 0056: recurring 系列 override の適用範囲。
+ * - `single`: 操作対象の 1 instance のみ (default、既存 #145 と同じ semantics)
+ * - `this_and_following`: 操作対象 instance の `start_time` 以降の全 instance + 新規取り込み
+ * - `all`: 全 instance + 新規取り込み (過去含む)
+ */
+export type EventVisibilityOverrideScope = "single" | "this_and_following" | "all";
+
+/**
+ * ADR 0056: 系列 override の方針 (rule) を表現する。新規 instance 取り込み時の default を
+ * 上書きするための「方針レイヤ」。1 recurring グループ (source + externalCalendarId +
+ * recurringEventId) につき rule は 1 件まで。
+ */
+export type EventVisibilityOverrideRule = {
+  id: string;
+  source: EventSource;
+  externalCalendarId: string;
+  recurringEventId: string;
+  scope: "this_and_following" | "all";
+  overrideValue: "shown" | "hidden";
+  /** scope='this_and_following' のとき必須、'all' のとき null。 */
+  fromStartTime: string | null;
   createdAt: string;
 };

--- a/src/features/day-timeline/DayTimeline.test.tsx
+++ b/src/features/day-timeline/DayTimeline.test.tsx
@@ -17,6 +17,7 @@ const ev = (id: string, title: string, startTime: string, endTime: string): Even
   externalId: null,
   externalCalendarId: "manual",
   visibilityOverride: "none",
+  recurringEventId: null,
   createdAt: "2026-04-11T00:00:00",
 });
 

--- a/src/features/day-timeline/EventCard.test.tsx
+++ b/src/features/day-timeline/EventCard.test.tsx
@@ -17,6 +17,7 @@ const baseEvent: Event = {
   externalId: null,
   externalCalendarId: "manual",
   visibilityOverride: "none",
+  recurringEventId: null,
   createdAt: "2026-04-11T00:00:00",
 };
 

--- a/src/features/day-timeline/TimelineBar.test.tsx
+++ b/src/features/day-timeline/TimelineBar.test.tsx
@@ -25,6 +25,7 @@ describe("TimelineBar", () => {
           externalId: null,
           externalCalendarId: "manual",
           visibilityOverride: "none",
+          recurringEventId: null,
           createdAt: "2026-04-11T00:00:00",
         },
       },

--- a/src/features/day-timeline/buildSlots.test.ts
+++ b/src/features/day-timeline/buildSlots.test.ts
@@ -20,6 +20,7 @@ const ev = (
   externalId: null,
   externalCalendarId: "manual",
   visibilityOverride: "none",
+  recurringEventId: null,
   createdAt: "2026-04-11T00:00:00",
 });
 

--- a/src/features/day-timeline/visibility.test.ts
+++ b/src/features/day-timeline/visibility.test.ts
@@ -21,6 +21,7 @@ const baseManual: Event = {
   externalId: null,
   externalCalendarId: "manual",
   visibilityOverride: "none",
+  recurringEventId: null,
   createdAt: "2026-05-04T00:00:00.000Z",
 };
 

--- a/src/features/event-detail/EventDetailPanel.test.tsx
+++ b/src/features/event-detail/EventDetailPanel.test.tsx
@@ -26,6 +26,7 @@ const baseEvent: Event = {
   externalId: null,
   externalCalendarId: "manual",
   visibilityOverride: "none",
+  recurringEventId: null,
   createdAt: "2026-04-11T00:00:00",
 };
 

--- a/src/features/event-detail/EventDetailPanel.tsx
+++ b/src/features/event-detail/EventDetailPanel.tsx
@@ -1,7 +1,12 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import type { UpdateEventInput } from "../../entities/event/gateway";
-import { EVENT_SOURCE, type Event, type EventVisibilityOverride } from "../../entities/event/types";
+import {
+  EVENT_SOURCE,
+  type Event,
+  type EventVisibilityOverride,
+  type EventVisibilityOverrideScope,
+} from "../../entities/event/types";
 import { GoogleCalendarBadge } from "../../entities/event/GoogleCalendarBadge";
 import { getProject } from "../../entities/project/projects";
 import { useProjects } from "../../entities/project/ProjectsContext";
@@ -45,6 +50,16 @@ type EventDetailPanelProps = {
    */
   onSetVisibilityOverride?: (id: string, value: EventVisibilityOverride) => Promise<void> | void;
   /**
+   * Issue #229 / ADR 0056: recurring event の系列 override (bulk apply + rule 永続化)。
+   * scope='this_and_following' | 'all' のみ受け付ける ('single' は onSetVisibilityOverride を使う)。
+   * 未指定なら recurring event でも 3 択 modal を出さず、既存挙動 (single 操作のみ) のままにする。
+   */
+  onSetRecurringVisibilityOverride?: (
+    id: string,
+    value: "shown" | "hidden",
+    scope: Exclude<EventVisibilityOverrideScope, "single">,
+  ) => Promise<void> | void;
+  /**
    * 当該 event の calendar subscription の `auto_promote_to_timeline` 値。
    * `visibility_override='none'` のとき、effective visibility 計算に使う。
    * 不明 (subscription なし / manual) のときは true (= 既定で表示) として扱う。
@@ -59,6 +74,7 @@ export function EventDetailPanel({
   onUpdate,
   onDelete,
   onSetVisibilityOverride,
+  onSetRecurringVisibilityOverride,
   subscriptionAutoPromote = true,
 }: EventDetailPanelProps) {
   const { projects, projectsById } = useProjects();
@@ -102,14 +118,46 @@ export function EventDetailPanel({
         ? false
         : subscriptionAutoPromote;
   const overrideActive = event.visibilityOverride !== "none";
+  // ADR 0056: recurring instance かつ系列操作 callback が渡されているときだけ 3 択 modal を出す。
+  // 単発 event (recurringEventId === null) や、callback 未指定 (テスト等) は従来の single 操作のみ。
+  const supportsRecurringScope =
+    !!onSetRecurringVisibilityOverride && event.recurringEventId !== null;
+  const [scopeModalOpen, setScopeModalOpen] = useState(false);
+  // modal 開閉中は target を保持 ('shown' / 'hidden' のどちらに倒す操作だったか)。
+  const [pendingTargetValue, setPendingTargetValue] = useState<"shown" | "hidden">("shown");
 
   const handleToggleVisibility = async () => {
     if (visibilityPending || !onSetVisibilityOverride) return;
     const next: EventVisibilityOverride = effectiveShown ? "hidden" : "shown";
+    if (supportsRecurringScope && (next === "shown" || next === "hidden")) {
+      // ADR 0056 §6: default scope='single' を modal で明示選択させる。modal を開くだけで
+      // この時点では DB を触らない。
+      setPendingTargetValue(next);
+      setScopeModalOpen(true);
+      return;
+    }
     setVisibilityPending(true);
     setError(null);
     try {
       await onSetVisibilityOverride(event.id, next);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "予定化の切替に失敗しました");
+    } finally {
+      setVisibilityPending(false);
+    }
+  };
+
+  const handleScopeSelect = async (scope: EventVisibilityOverrideScope) => {
+    if (visibilityPending) return;
+    setVisibilityPending(true);
+    setError(null);
+    try {
+      if (scope === "single") {
+        await onSetVisibilityOverride!(event.id, pendingTargetValue);
+      } else {
+        await onSetRecurringVisibilityOverride!(event.id, pendingTargetValue, scope);
+      }
+      setScopeModalOpen(false);
     } catch (err) {
       setError(err instanceof Error ? err.message : "予定化の切替に失敗しました");
     } finally {
@@ -510,6 +558,111 @@ export function EventDetailPanel({
             </div>
           </form>
         )}
+      </div>
+      {scopeModalOpen ? (
+        <RecurringScopeModal
+          targetValue={pendingTargetValue}
+          pending={visibilityPending}
+          onSelect={handleScopeSelect}
+          onClose={() => setScopeModalOpen(false)}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Issue #229 / ADR 0056 §6: recurring event の予定化 / 解除を選んだ時に出す 3 択 modal。
+ *
+ * - default は `single` (ADR 0056 §6)。系列影響は明示選択でしか発生させない。
+ * - `role="dialog"` + `aria-modal` + `aria-labelledby` で a11y 構造を立てる。
+ * - 操作中 (pending) は全ボタンを disabled にして連打を防ぐ。
+ * - ESC / オーバーレイクリックで閉じる (キャンセル相当)。
+ */
+function RecurringScopeModal({
+  targetValue,
+  pending,
+  onSelect,
+  onClose,
+}: {
+  targetValue: "shown" | "hidden";
+  pending: boolean;
+  onSelect: (scope: EventVisibilityOverrideScope) => void;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !pending) onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose, pending]);
+
+  const titleId = "event-recurring-scope-title";
+  const verb = targetValue === "shown" ? "予定化" : "予定化解除";
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      className="fixed inset-0 z-[210] flex items-center justify-center"
+    >
+      <div
+        onClick={pending ? undefined : onClose}
+        className="absolute inset-0 bg-black/60 backdrop-blur-[4px]"
+      />
+      <div className="relative w-[min(420px,calc(100vw-32px))] rounded-lg border border-bg-divider bg-bg-elevated p-5 shadow-xl">
+        <h3 id={titleId} className="m-0 font-jp text-[13px] font-semibold text-fg-strong">
+          繰り返し予定の{verb}
+        </h3>
+        <p className="mt-2 text-[11px] leading-relaxed text-fg-muted">
+          この予定は繰り返しの一部です。どの範囲に{verb}を適用しますか?
+        </p>
+        <div className="mt-4 flex flex-col gap-2">
+          <button
+            type="button"
+            disabled={pending}
+            onClick={() => onSelect("single")}
+            className="rounded-md border border-accent-blue/60 bg-accent-blue/10 px-3 py-2 text-left font-jp text-[12px] text-fg-emphasized disabled:opacity-60"
+          >
+            <span className="block font-semibold">この予定だけ</span>
+            <span className="mt-0.5 block text-[10px] text-fg-muted">
+              選択した回のみに{verb}を適用します。
+            </span>
+          </button>
+          <button
+            type="button"
+            disabled={pending}
+            onClick={() => onSelect("this_and_following")}
+            className="rounded-md border border-bg-divider bg-bg-primary px-3 py-2 text-left font-jp text-[12px] text-fg-emphasized disabled:opacity-60"
+          >
+            <span className="block font-semibold">これ以降の予定もまとめて</span>
+            <span className="mt-0.5 block text-[10px] text-fg-muted">
+              この回以降の繰り返しすべてに{verb}を適用します。
+            </span>
+          </button>
+          <button
+            type="button"
+            disabled={pending}
+            onClick={() => onSelect("all")}
+            className="rounded-md border border-bg-divider bg-bg-primary px-3 py-2 text-left font-jp text-[12px] text-fg-emphasized disabled:opacity-60"
+          >
+            <span className="block font-semibold">すべての繰り返し</span>
+            <span className="mt-0.5 block text-[10px] text-fg-muted">
+              過去・未来を含む全ての回に{verb}を適用します。
+            </span>
+          </button>
+        </div>
+        <div className="mt-4 flex justify-end">
+          <button
+            type="button"
+            disabled={pending}
+            onClick={onClose}
+            className="rounded border border-bg-divider bg-transparent px-3 py-1.5 font-jp text-[11px] text-fg-subtle disabled:opacity-60"
+          >
+            キャンセル
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/features/event-detail/EventDetailPanel.tsx
+++ b/src/features/event-detail/EventDetailPanel.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import type { UpdateEventInput } from "../../entities/event/gateway";
+import { RecurringScopeModal } from "../../entities/event/RecurringScopeModal";
 import {
   EVENT_SOURCE,
   type Event,
@@ -567,103 +568,6 @@ export function EventDetailPanel({
           onClose={() => setScopeModalOpen(false)}
         />
       ) : null}
-    </div>
-  );
-}
-
-/**
- * Issue #229 / ADR 0056 §6: recurring event の予定化 / 解除を選んだ時に出す 3 択 modal。
- *
- * - default は `single` (ADR 0056 §6)。系列影響は明示選択でしか発生させない。
- * - `role="dialog"` + `aria-modal` + `aria-labelledby` で a11y 構造を立てる。
- * - 操作中 (pending) は全ボタンを disabled にして連打を防ぐ。
- * - ESC / オーバーレイクリックで閉じる (キャンセル相当)。
- */
-function RecurringScopeModal({
-  targetValue,
-  pending,
-  onSelect,
-  onClose,
-}: {
-  targetValue: "shown" | "hidden";
-  pending: boolean;
-  onSelect: (scope: EventVisibilityOverrideScope) => void;
-  onClose: () => void;
-}) {
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && !pending) onClose();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onClose, pending]);
-
-  const titleId = "event-recurring-scope-title";
-  const verb = targetValue === "shown" ? "予定化" : "予定化解除";
-  return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby={titleId}
-      className="fixed inset-0 z-[210] flex items-center justify-center"
-    >
-      <div
-        onClick={pending ? undefined : onClose}
-        className="absolute inset-0 bg-black/60 backdrop-blur-[4px]"
-      />
-      <div className="relative w-[min(420px,calc(100vw-32px))] rounded-lg border border-bg-divider bg-bg-elevated p-5 shadow-xl">
-        <h3 id={titleId} className="m-0 font-jp text-[13px] font-semibold text-fg-strong">
-          繰り返し予定の{verb}
-        </h3>
-        <p className="mt-2 text-[11px] leading-relaxed text-fg-muted">
-          この予定は繰り返しの一部です。どの範囲に{verb}を適用しますか?
-        </p>
-        <div className="mt-4 flex flex-col gap-2">
-          <button
-            type="button"
-            disabled={pending}
-            onClick={() => onSelect("single")}
-            className="rounded-md border border-accent-blue/60 bg-accent-blue/10 px-3 py-2 text-left font-jp text-[12px] text-fg-emphasized disabled:opacity-60"
-          >
-            <span className="block font-semibold">この予定だけ</span>
-            <span className="mt-0.5 block text-[10px] text-fg-muted">
-              選択した回のみに{verb}を適用します。
-            </span>
-          </button>
-          <button
-            type="button"
-            disabled={pending}
-            onClick={() => onSelect("this_and_following")}
-            className="rounded-md border border-bg-divider bg-bg-primary px-3 py-2 text-left font-jp text-[12px] text-fg-emphasized disabled:opacity-60"
-          >
-            <span className="block font-semibold">これ以降の予定もまとめて</span>
-            <span className="mt-0.5 block text-[10px] text-fg-muted">
-              この回以降の繰り返しすべてに{verb}を適用します。
-            </span>
-          </button>
-          <button
-            type="button"
-            disabled={pending}
-            onClick={() => onSelect("all")}
-            className="rounded-md border border-bg-divider bg-bg-primary px-3 py-2 text-left font-jp text-[12px] text-fg-emphasized disabled:opacity-60"
-          >
-            <span className="block font-semibold">すべての繰り返し</span>
-            <span className="mt-0.5 block text-[10px] text-fg-muted">
-              過去・未来を含む全ての回に{verb}を適用します。
-            </span>
-          </button>
-        </div>
-        <div className="mt-4 flex justify-end">
-          <button
-            type="button"
-            disabled={pending}
-            onClick={onClose}
-            className="rounded border border-bg-divider bg-transparent px-3 py-1.5 font-jp text-[11px] text-fg-subtle disabled:opacity-60"
-          >
-            キャンセル
-          </button>
-        </div>
-      </div>
     </div>
   );
 }

--- a/src/features/event-management/EventManagement.test.tsx
+++ b/src/features/event-management/EventManagement.test.tsx
@@ -39,6 +39,7 @@ const eventA: Event = {
   externalId: "ext-A",
   externalCalendarId: "primary",
   visibilityOverride: "none",
+  recurringEventId: null,
   createdAt: "2026-05-04T00:00:00.000Z",
 };
 

--- a/src/features/event-management/EventManagement.tsx
+++ b/src/features/event-management/EventManagement.tsx
@@ -4,7 +4,13 @@ import { useMemo, useState } from "react";
 
 import type { CalendarSubscription } from "@/entities/calendar-subscription/types";
 import { GoogleCalendarBadge } from "@/entities/event/GoogleCalendarBadge";
-import { EVENT_SOURCE, type Event, type EventVisibilityOverride } from "@/entities/event/types";
+import { RecurringScopeModal } from "@/entities/event/RecurringScopeModal";
+import {
+  EVENT_SOURCE,
+  type Event,
+  type EventVisibilityOverride,
+  type EventVisibilityOverrideScope,
+} from "@/entities/event/types";
 import {
   fmtDuration,
   formatAllDayRange,
@@ -24,6 +30,17 @@ type EventManagementProps = {
    * 'none' へのリセットは含まない (日常 UI では reset 不可、SettingsPanel 専用導線)。
    */
   onSetVisibilityOverride: (id: string, value: EventVisibilityOverride) => Promise<void>;
+  /**
+   * Issue #229 / ADR 0056: recurring event の系列 override (bulk apply + rule 永続化)。
+   * scope='this_and_following' | 'all' のみ受け付ける ('single' は onSetVisibilityOverride を使う)。
+   * 未指定なら recurring instance に対しても 3 択 modal を出さず既存の single 操作のみ
+   * (テストや特殊呼び出しで省略可)。
+   */
+  onSetRecurringVisibilityOverride?: (
+    id: string,
+    value: "shown" | "hidden",
+    scope: Exclude<EventVisibilityOverrideScope, "single">,
+  ) => Promise<void>;
   /** 詳細パネルを開きたいとき。未指定なら詳細リンクを出さない (テスト用に省略可)。 */
   onOpenEvent?: (id: string) => void;
 };
@@ -52,11 +69,18 @@ export function EventManagement({
   events,
   subscriptions,
   onSetVisibilityOverride,
+  onSetRecurringVisibilityOverride,
   onOpenEvent,
 }: EventManagementProps) {
   const [filter, setFilter] = useState<FilterMode>("all");
   const [pendingId, setPendingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // ADR 0056: recurring instance に対して開かれた scope modal の状態。
+  // 操作対象 event id と倒したい方向 (`shown` / `hidden`) を保持。
+  const [scopeModal, setScopeModal] = useState<{
+    eventId: string;
+    targetValue: "shown" | "hidden";
+  } | null>(null);
 
   // 安定した参照のため useMemo (subscriptions が変わったときだけ再計算)。
   const subVisibilities = useMemo(
@@ -113,11 +137,40 @@ export function EventManagement({
     return [...map.entries()];
   }, [filtered]);
 
-  const handleToggle = async (id: string, next: EventVisibilityOverride) => {
-    setPendingId(id);
+  const handleToggle = async (event: Event, next: EventVisibilityOverride) => {
+    // ADR 0056: recurring instance かつ系列操作 callback が渡されているときだけ 3 択 modal を出す。
+    // 単発 event (recurringEventId === null) や callback 未指定は従来の single 操作のまま。
+    const supportsRecurringScope =
+      !!onSetRecurringVisibilityOverride &&
+      event.recurringEventId !== null &&
+      (next === "shown" || next === "hidden");
+    if (supportsRecurringScope) {
+      setScopeModal({ eventId: event.id, targetValue: next as "shown" | "hidden" });
+      return;
+    }
+    setPendingId(event.id);
     setError(null);
     try {
-      await onSetVisibilityOverride(id, next);
+      await onSetVisibilityOverride(event.id, next);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "予定化の切替に失敗しました");
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  const handleScopeSelect = async (scope: EventVisibilityOverrideScope) => {
+    if (!scopeModal) return;
+    const { eventId, targetValue } = scopeModal;
+    setPendingId(eventId);
+    setError(null);
+    try {
+      if (scope === "single") {
+        await onSetVisibilityOverride(eventId, targetValue);
+      } else {
+        await onSetRecurringVisibilityOverride!(eventId, targetValue, scope);
+      }
+      setScopeModal(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : "予定化の切替に失敗しました");
     } finally {
@@ -190,7 +243,7 @@ export function EventManagement({
                     overrideValue={state.override}
                     isOverrideOfDefault={state.isOverrideOfDefault}
                     calendarLabel={calendarLabel}
-                    onToggle={(next) => handleToggle(event.id, next)}
+                    onToggle={(next) => handleToggle(event, next)}
                     onOpenEvent={onOpenEvent}
                     busy={pendingId === event.id}
                   />
@@ -200,6 +253,14 @@ export function EventManagement({
           ))}
         </div>
       )}
+      {scopeModal ? (
+        <RecurringScopeModal
+          targetValue={scopeModal.targetValue}
+          pending={pendingId === scopeModal.eventId}
+          onSelect={handleScopeSelect}
+          onClose={() => setScopeModal(null)}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/features/event-management/EventManagement.tsx
+++ b/src/features/event-management/EventManagement.tsx
@@ -368,7 +368,18 @@ function EventRow({
           )}
         </div>
       </div>
-      <div className="flex shrink-0 items-center">
+      <div className="flex shrink-0 items-center gap-1.5">
+        {overrideActive ? (
+          <button
+            type="button"
+            onClick={() => onToggle("none")}
+            disabled={busy}
+            className="rounded-[4px] border border-bg-divider bg-transparent px-2.5 py-[3px] font-jp text-[10px] text-fg-weak disabled:opacity-60"
+            title="個別指定を解除して、カレンダーの自動予定化設定に従う動作に戻す"
+          >
+            リセット
+          </button>
+        ) : null}
         <button
           type="button"
           onClick={() => onToggle(next)}

--- a/src/features/settings/SettingsPanel.tsx
+++ b/src/features/settings/SettingsPanel.tsx
@@ -1,9 +1,15 @@
 "use client";
 
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 
 import type { CalendarSubscription } from "@/entities/calendar-subscription/types";
-import { EVENT_SOURCE, type Event, type EventVisibilityOverride } from "@/entities/event/types";
+import {
+  EVENT_SOURCE,
+  type Event,
+  type EventVisibilityOverride,
+  type EventVisibilityOverrideRule,
+} from "@/entities/event/types";
 import {
   formatAllDayRange,
   formatClock,
@@ -178,6 +184,8 @@ export function SettingsPanel({
           subscriptions={subscriptions}
           onSetVisibilityOverride={onSetVisibilityOverride}
         />
+
+        <RulesSection subscriptions={subscriptions} />
       </div>
     </div>
   );
@@ -463,5 +471,136 @@ function CandidateRow({
         </div>
       </div>
     </li>
+  );
+}
+
+/**
+ * Issue #229 / ADR 0056 §7: 系列 override の rule 一覧 + 単独削除導線。
+ *
+ * 「個別予定化の設定」が **事実 (instance reset)** を扱うのに対し、本セクションは
+ * **方針 (rule reset)** を扱う。両者は別操作として並べる (ADR 0056 §7)。
+ *
+ * rule を削除しても既存 instance の visibility_override (= 事実) は変わらない。
+ * 削除以降に取り込まれる新規 instance は default 動作 (subscription.auto_promote) に戻る。
+ */
+function RulesSection({ subscriptions }: { subscriptions: CalendarSubscription[] }) {
+  const queryClient = useQueryClient();
+  const rulesQuery = useQuery({
+    queryKey: ["calendar", "visibility-override-rules"],
+    queryFn: async () => {
+      const res = await fetch("/api/events/visibility-override-rules");
+      if (!res.ok) throw new Error(`fetch_rules_failed: ${res.status}`);
+      const body = (await res.json()) as { rules: EventVisibilityOverrideRule[] };
+      return body.rules;
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (ruleId: string) => {
+      const res = await fetch(`/api/events/visibility-override-rules/${ruleId}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(body?.error ?? `delete_rule_failed: ${res.status}`);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["calendar", "visibility-override-rules"] });
+    },
+  });
+
+  const subDisplayMap = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const s of subscriptions) {
+      m.set(`${s.source}::${s.externalCalendarId}`, s.displayName ?? s.externalCalendarId);
+    }
+    return m;
+  }, [subscriptions]);
+
+  const rules = rulesQuery.data ?? [];
+  const [error, setError] = useState<string | null>(null);
+
+  const handleDelete = async (ruleId: string) => {
+    setError(null);
+    try {
+      await deleteMutation.mutateAsync(ruleId);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "ルールの削除に失敗しました");
+    }
+  };
+
+  return (
+    <section aria-label="繰り返し予定化のルール" className="mt-6 border-t border-bg-divider pt-4">
+      <h3 className="mb-2 text-[12px] font-semibold text-fg-emphasized">繰り返し予定化のルール</h3>
+      <p className="mb-3 text-[11px] leading-relaxed text-fg-muted">
+        「これ以降」「すべて」を選んで保存した、繰り返し予定への方針一覧です。削除すると、以降に取り込まれる新しい予定は既定の動作に戻ります（既に取り込み済みの個別予定の状態は変わりません）。
+      </p>
+
+      {error ? (
+        <div
+          role="alert"
+          className="mb-2 rounded bg-[#ef444420] px-2 py-1.5 text-[11px] text-accent-red"
+        >
+          {error}
+        </div>
+      ) : null}
+
+      {rulesQuery.isLoading ? (
+        <p className="text-[11px] text-fg-muted">読み込み中…</p>
+      ) : rules.length === 0 ? (
+        <p className="text-[11px] text-fg-muted">登録されているルールはまだありません。</p>
+      ) : (
+        <ul role="list" className="m-0 list-none space-y-1.5 p-0">
+          {rules.map((rule) => {
+            const calendarLabel =
+              subDisplayMap.get(`${rule.source}::${rule.externalCalendarId}`) ??
+              rule.externalCalendarId;
+            const scopeLabel =
+              rule.scope === "all" ? "すべての繰り返し" : "これ以降の予定もまとめて";
+            const valueLabel = rule.overrideValue === "shown" ? "予定化" : "予定化解除";
+            return (
+              <li
+                key={rule.id}
+                className="flex items-start gap-3 rounded-md border border-bg-divider bg-bg-primary px-3 py-2"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-1.5">
+                    <span
+                      className={`rounded-[3px] border px-1 py-[1px] font-jp text-[9px] ${
+                        rule.overrideValue === "shown"
+                          ? "border-accent-blue/40 text-accent-blue"
+                          : "border-bg-divider text-fg-weak"
+                      }`}
+                    >
+                      {valueLabel}
+                    </span>
+                    <span className="truncate text-[10px] text-fg-faint">{calendarLabel}</span>
+                  </div>
+                  <div className="mt-1 truncate font-jp text-[12px] font-medium text-fg-emphasized">
+                    {scopeLabel}
+                  </div>
+                  <div className="mt-0.5 text-[10px] text-fg-weak">
+                    {rule.scope === "this_and_following" && rule.fromStartTime
+                      ? `${localDateOf(rule.fromStartTime)} ${formatClock(rule.fromStartTime)} 以降`
+                      : "全 instance"}
+                  </div>
+                </div>
+                <div className="flex shrink-0 items-center">
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(rule.id)}
+                    disabled={deleteMutation.isPending}
+                    className="rounded-[4px] border border-bg-divider bg-transparent px-2.5 py-[3px] font-jp text-[10px] text-fg-subtle disabled:opacity-60"
+                  >
+                    ルール削除
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
   );
 }

--- a/src/features/settings/SettingsPanel.tsx
+++ b/src/features/settings/SettingsPanel.tsx
@@ -4,19 +4,8 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 
 import type { CalendarSubscription } from "@/entities/calendar-subscription/types";
-import {
-  EVENT_SOURCE,
-  type Event,
-  type EventVisibilityOverride,
-  type EventVisibilityOverrideRule,
-} from "@/entities/event/types";
-import {
-  formatAllDayRange,
-  formatClock,
-  isAllDayEvent,
-  isDeadlineEvent,
-  localDateOf,
-} from "@/shared/lib/time";
+import { type Event, type EventVisibilityOverrideRule } from "@/entities/event/types";
+import { formatClock, localDateOf } from "@/shared/lib/time";
 
 import { useCalendarSubscriptions, type CalendarListItem } from "./useCalendarSubscriptions";
 
@@ -25,13 +14,11 @@ type SettingsPanelProps = {
   onClose: () => void;
   /** UserMenu の Google アカウント (= primary external account) の identifier (text)。 */
   primaryExternalAccountId: string | null;
-  /** Issue #145: override 一覧の元データ。 */
-  events: readonly Event[];
   /**
-   * Issue #145 / ADR 0032: override 一覧から個別 reset (`'none'`) する唯一の導線。
-   * 日常 UI からの reset は禁止 (ADR 0032)、本 panel 専用。
+   * Issue #229 / ADR 0056 §7: rules セクションで「どの繰り返し予定に対する方針か」を表示するために
+   * events 一覧を渡す。`recurring_event_id` でひも付けて instance のタイトルを引く。
    */
-  onSetVisibilityOverride: (id: string, value: EventVisibilityOverride) => Promise<void>;
+  events: readonly Event[];
 };
 
 /**
@@ -51,7 +38,6 @@ export function SettingsPanel({
   onClose,
   primaryExternalAccountId,
   events,
-  onSetVisibilityOverride,
 }: SettingsPanelProps) {
   const { subscriptionsQuery, calendarListQuery, subscribe, unsubscribe, toggleAutoPromote } =
     useCalendarSubscriptions();
@@ -179,152 +165,9 @@ export function SettingsPanel({
           </div>
         </section>
 
-        <OverridesSection
-          events={events}
-          subscriptions={subscriptions}
-          onSetVisibilityOverride={onSetVisibilityOverride}
-        />
-
-        <RulesSection subscriptions={subscriptions} />
+        <RulesSection subscriptions={subscriptions} events={events} />
       </div>
     </div>
-  );
-}
-
-function OverridesSection({
-  events,
-  subscriptions,
-  onSetVisibilityOverride,
-}: {
-  events: readonly Event[];
-  subscriptions: CalendarSubscription[];
-  onSetVisibilityOverride: (id: string, value: EventVisibilityOverride) => Promise<void>;
-}) {
-  const [pendingId, setPendingId] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  const subDisplayMap = useMemo(() => {
-    const m = new Map<string, string>();
-    for (const s of subscriptions) {
-      m.set(`${s.source}::${s.externalCalendarId}`, s.displayName ?? s.externalCalendarId);
-    }
-    return m;
-  }, [subscriptions]);
-
-  // ADR 0032: 設定画面の override 一覧 = `visibility_override !== 'none'` を一覧、reset 専用導線。
-  // start_time 降順 (新しい順) で並べる。
-  const overridden = useMemo(
-    () =>
-      events
-        .filter((e) => e.visibilityOverride !== "none")
-        .map((e) => ({
-          event: e,
-          calendarLabel:
-            e.source === EVENT_SOURCE.MANUAL
-              ? "手動追加"
-              : (subDisplayMap.get(`${e.source}::${e.externalCalendarId}`) ?? e.externalCalendarId),
-        }))
-        .sort((a, b) => (a.event.startTime < b.event.startTime ? 1 : -1)),
-    [events, subDisplayMap],
-  );
-
-  const handleReset = async (id: string) => {
-    setPendingId(id);
-    setError(null);
-    try {
-      await onSetVisibilityOverride(id, "none");
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "リセットに失敗しました");
-    } finally {
-      setPendingId(null);
-    }
-  };
-
-  return (
-    <section aria-label="個別予定化の設定" className="mt-6 border-t border-bg-divider pt-4">
-      <h3 className="mb-2 text-[12px] font-semibold text-fg-emphasized">個別予定化の設定</h3>
-      <p className="mb-3 text-[11px] leading-relaxed text-fg-muted">
-        「予定化」「予定化解除」を個別に指定した予定の一覧です。リセットすると、そのカレンダーの自動予定化設定に従う動作に戻ります。
-      </p>
-
-      {error ? (
-        <div
-          role="alert"
-          className="mb-2 rounded bg-[#ef444420] px-2 py-1.5 text-[11px] text-accent-red"
-        >
-          {error}
-        </div>
-      ) : null}
-
-      {overridden.length === 0 ? (
-        <p className="text-[11px] text-fg-muted">個別指定している予定はまだありません。</p>
-      ) : (
-        <ul role="list" className="m-0 list-none space-y-1.5 p-0">
-          {overridden.map(({ event, calendarLabel }) => (
-            <li
-              key={event.id}
-              className="flex items-start gap-3 rounded-md border border-bg-divider bg-bg-primary px-3 py-2"
-            >
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-1.5">
-                  <span
-                    className={`rounded-[3px] border px-1 py-[1px] font-jp text-[9px] ${
-                      event.visibilityOverride === "shown"
-                        ? "border-accent-blue/40 text-accent-blue"
-                        : "border-bg-divider text-fg-weak"
-                    }`}
-                  >
-                    {event.visibilityOverride === "shown" ? "予定化中" : "予定化解除中"}
-                  </span>
-                  <span className="truncate text-[10px] text-fg-faint">{calendarLabel}</span>
-                </div>
-                <div
-                  className="mt-1 truncate font-jp text-[12px] font-medium text-fg-emphasized"
-                  title={event.title}
-                >
-                  {event.title}
-                </div>
-                <div className="mt-0.5 text-[10px] tabular-nums text-fg-weak">
-                  {isAllDayEvent(event) ? (
-                    <>
-                      <span
-                        aria-label="終日"
-                        className="mr-1.5 rounded-[3px] border border-bg-divider px-1 py-px font-jp text-[9px] text-fg-subtle"
-                      >
-                        終日
-                      </span>
-                      {formatAllDayRange(event)}
-                    </>
-                  ) : isDeadlineEvent(event) ? (
-                    <>
-                      {localDateOf(event.startTime)}{" "}
-                      <span aria-label={`${formatClock(event.startTime)} 締切`}>
-                        ⏰ {formatClock(event.startTime)}
-                      </span>
-                    </>
-                  ) : (
-                    <>
-                      {localDateOf(event.startTime)} {formatClock(event.startTime)}–
-                      {formatClock(event.endTime)}
-                    </>
-                  )}
-                </div>
-              </div>
-              <div className="flex shrink-0 items-center">
-                <button
-                  type="button"
-                  onClick={() => handleReset(event.id)}
-                  disabled={pendingId === event.id}
-                  className="rounded-[4px] border border-bg-divider bg-transparent px-2.5 py-[3px] font-jp text-[10px] text-fg-subtle disabled:opacity-60"
-                >
-                  リセット
-                </button>
-              </div>
-            </li>
-          ))}
-        </ul>
-      )}
-    </section>
   );
 }
 
@@ -483,7 +326,13 @@ function CandidateRow({
  * rule を削除しても既存 instance の visibility_override (= 事実) は変わらない。
  * 削除以降に取り込まれる新規 instance は default 動作 (subscription.auto_promote) に戻る。
  */
-function RulesSection({ subscriptions }: { subscriptions: CalendarSubscription[] }) {
+function RulesSection({
+  subscriptions,
+  events,
+}: {
+  subscriptions: CalendarSubscription[];
+  events: readonly Event[];
+}) {
   const queryClient = useQueryClient();
   const rulesQuery = useQuery({
     queryKey: ["calendar", "visibility-override-rules"],
@@ -517,6 +366,21 @@ function RulesSection({ subscriptions }: { subscriptions: CalendarSubscription[]
     }
     return m;
   }, [subscriptions]);
+
+  // ADR 0056: rule は recurring_event_id (= Google master id) を保持するが、タイトルは持たない。
+  // events から (source, external_calendar_id, recurring_event_id) でひも付けて 1 件のタイトルを引く
+  // (recurring 系列の全 instance はタイトル共通なので任意の 1 件で OK)。一致する instance が
+  // ローカルに 1 件もない場合 (= Google 側で master が切れた孤立 rule) は recurring_event_id を
+  // そのまま fallback 表示する。
+  const recurringTitleMap = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const ev of events) {
+      if (!ev.recurringEventId) continue;
+      const key = `${ev.source}::${ev.externalCalendarId}::${ev.recurringEventId}`;
+      if (!m.has(key)) m.set(key, ev.title);
+    }
+    return m;
+  }, [events]);
 
   const rules = rulesQuery.data ?? [];
   const [error, setError] = useState<string | null>(null);
@@ -559,6 +423,10 @@ function RulesSection({ subscriptions }: { subscriptions: CalendarSubscription[]
             const scopeLabel =
               rule.scope === "all" ? "すべての繰り返し" : "これ以降の予定もまとめて";
             const valueLabel = rule.overrideValue === "shown" ? "予定化" : "予定化解除";
+            const recurringTitle =
+              recurringTitleMap.get(
+                `${rule.source}::${rule.externalCalendarId}::${rule.recurringEventId}`,
+              ) ?? "(ローカルに該当予定なし)";
             return (
               <li
                 key={rule.id}
@@ -577,13 +445,17 @@ function RulesSection({ subscriptions }: { subscriptions: CalendarSubscription[]
                     </span>
                     <span className="truncate text-[10px] text-fg-faint">{calendarLabel}</span>
                   </div>
-                  <div className="mt-1 truncate font-jp text-[12px] font-medium text-fg-emphasized">
-                    {scopeLabel}
+                  <div
+                    className="mt-1 truncate font-jp text-[12px] font-medium text-fg-emphasized"
+                    title={recurringTitle}
+                  >
+                    {recurringTitle}
                   </div>
                   <div className="mt-0.5 text-[10px] text-fg-weak">
+                    {scopeLabel}
                     {rule.scope === "this_and_following" && rule.fromStartTime
-                      ? `${localDateOf(rule.fromStartTime)} ${formatClock(rule.fromStartTime)} 以降`
-                      : "全 instance"}
+                      ? ` ・ ${localDateOf(rule.fromStartTime)} ${formatClock(rule.fromStartTime)} 以降`
+                      : null}
                   </div>
                 </div>
                 <div className="flex shrink-0 items-center">

--- a/src/features/task-detail/TaskDetailPanel.test.tsx
+++ b/src/features/task-detail/TaskDetailPanel.test.tsx
@@ -134,6 +134,7 @@ describe("TaskDetailPanel", () => {
         externalId: null,
         externalCalendarId: "manual",
         visibilityOverride: "none",
+        recurringEventId: null,
         createdAt: "2026-04-11T00:00:00",
       },
     ];
@@ -171,6 +172,7 @@ describe("TaskDetailPanel", () => {
         externalId: null,
         externalCalendarId: "manual",
         visibilityOverride: "none",
+        recurringEventId: null,
         createdAt: "2026-04-11T00:00:00",
       },
     ];
@@ -199,6 +201,7 @@ describe("TaskDetailPanel", () => {
         externalId: null,
         externalCalendarId: "manual",
         visibilityOverride: "none",
+        recurringEventId: null,
         createdAt: "2026-04-11T00:00:00",
       },
     ];
@@ -226,6 +229,7 @@ describe("TaskDetailPanel", () => {
       externalId: null,
       externalCalendarId: "manual",
       visibilityOverride: "none",
+      recurringEventId: null,
       createdAt: "2026-04-09T00:00:00",
     };
     const future: Event = {
@@ -241,6 +245,7 @@ describe("TaskDetailPanel", () => {
       externalId: null,
       externalCalendarId: "manual",
       visibilityOverride: "none",
+      recurringEventId: null,
       createdAt: "2026-04-09T00:00:00",
     };
     const { getByText, queryByText } = renderPanel({
@@ -266,6 +271,7 @@ describe("TaskDetailPanel", () => {
       externalId: null,
       externalCalendarId: "manual",
       visibilityOverride: "none",
+      recurringEventId: null,
       createdAt: "2026-04-09T00:00:00",
     };
     const future: Event = {
@@ -281,6 +287,7 @@ describe("TaskDetailPanel", () => {
       externalId: null,
       externalCalendarId: "manual",
       visibilityOverride: "none",
+      recurringEventId: null,
       createdAt: "2026-04-09T00:00:00",
     };
     const { getByText, getAllByRole } = renderPanel({

--- a/src/features/task-stack/TaskStack.test.tsx
+++ b/src/features/task-stack/TaskStack.test.tsx
@@ -59,6 +59,7 @@ const baseEvent: Event = {
   externalId: null,
   externalCalendarId: "manual",
   visibilityOverride: "none",
+  recurringEventId: null,
   createdAt: "2026-04-11T00:00:00",
 };
 

--- a/src/mocks/events.ts
+++ b/src/mocks/events.ts
@@ -17,6 +17,7 @@ export function buildInitialEvents(): Event[] {
     externalId: null,
     externalCalendarId: "manual",
     visibilityOverride: "none" as const,
+    recurringEventId: null,
     createdAt: now,
   };
 

--- a/src/shared/google/calendar.ts
+++ b/src/shared/google/calendar.ts
@@ -19,6 +19,12 @@ export type GoogleCalendarEvent = {
     entryPoints?: Array<{ entryPointType?: string; uri?: string }>;
   };
   attachments?: Array<unknown>;
+  /**
+   * ADR 0056: recurring event を `singleEvents=true` で展開した instance に対し
+   * Google API が返す master id。NULL/undefined = 単発 event。kozutsumi 側は
+   * `events.recurring_event_id` に保持する (recurring グループ識別軸)。
+   */
+  recurringEventId?: string;
 };
 
 export type GoogleCalendarEventsListResponse = {

--- a/src/shared/types/database.ts
+++ b/src/shared/types/database.ts
@@ -138,6 +138,7 @@ export type Database = {
           external_id: string | null;
           external_calendar_id: string;
           visibility_override: Database["public"]["Enums"]["event_visibility_override"];
+          recurring_event_id: string | null;
           created_at: string;
         };
         Insert: {
@@ -154,6 +155,7 @@ export type Database = {
           external_id?: string | null;
           external_calendar_id: string;
           visibility_override?: Database["public"]["Enums"]["event_visibility_override"];
+          recurring_event_id?: string | null;
           created_at?: string;
         };
         Update: {
@@ -170,6 +172,43 @@ export type Database = {
           external_id?: string | null;
           external_calendar_id?: string;
           visibility_override?: Database["public"]["Enums"]["event_visibility_override"];
+          recurring_event_id?: string | null;
+          created_at?: string;
+        };
+        Relationships: [];
+      };
+      event_visibility_override_rules: {
+        Row: {
+          id: string;
+          user_id: string;
+          source: Database["public"]["Enums"]["event_source"];
+          external_calendar_id: string;
+          recurring_event_id: string;
+          scope: "this_and_following" | "all";
+          override_value: "shown" | "hidden";
+          from_start_time: string | null;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          source: Database["public"]["Enums"]["event_source"];
+          external_calendar_id: string;
+          recurring_event_id: string;
+          scope: "this_and_following" | "all";
+          override_value: "shown" | "hidden";
+          from_start_time?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          source?: Database["public"]["Enums"]["event_source"];
+          external_calendar_id?: string;
+          recurring_event_id?: string;
+          scope?: "this_and_following" | "all";
+          override_value?: "shown" | "hidden";
+          from_start_time?: string | null;
           created_at?: string;
         };
         Relationships: [];

--- a/supabase/migrations/20260507000000_p3_229_recurring_event_override.sql
+++ b/supabase/migrations/20260507000000_p3_229_recurring_event_override.sql
@@ -1,0 +1,139 @@
+-- Issue #229 / ADR 0056: recurring event の系列 override は「rule + bulk apply」併用で表現する。
+--
+-- References:
+-- * docs/adr/0056-recurring-event-override-via-rule-and-bulk-apply.md
+--     events.recurring_event_id 列追加 + event_visibility_override_rules テーブル新設
+--     (本 ADR §1)。事実 (events.visibility_override) と方針 (rules) を別レイヤで持つ。
+-- * docs/adr/0032-events-visibility-override-physical-model.md
+--     visibility_override の 3 値 enum (none / shown / hidden)。本 migration で再利用。
+-- * docs/adr/0033-events-cross-source-uniqueness.md
+--     triple `(source, external_calendar_id, external_id)` で events を一意化する原則。
+--     rules テーブルの recurring グループ識別もこれに揃える (`source` + `external_calendar_id`
+--     + `recurring_event_id` の triple)。
+-- * docs/adr/0046-db-grants-fully-described-by-migrations.md
+--     authenticated への table-level GRANT は migration が完全記述する。
+--     ALTER DEFAULT PRIVILEGES があるので新規 table も自動 GRANT 対象になるが、
+--     idempotent に明示しておく。
+-- * docs/adr/0001-action-logs-from-phase1.md
+--     action_logs には CHECK / enum を貼らない原則。本 migration は触らない。
+--
+-- 設計判断の要点:
+-- * `events.recurring_event_id` は **既存行 backfill しない** (ADR 0056 §1)。
+--   次回 sync で各 instance の `recurringEventId` が埋まる挙動を許容する。
+--   manual / 単発 google event は NULL のまま (= 単発 event を表す)。
+-- * rules の `scope` は text 列 (CHECK 無し)。値域は TS リテラル union で固定する
+--   (ADR 0001 と整合)。`override_value` も同様。
+-- * rules の UNIQUE は `(user_id, source, external_calendar_id, recurring_event_id, scope,
+--   override_value, from_start_time)` ではなく **`(user_id, source, external_calendar_id,
+--   recurring_event_id)`** にして、1 系列につき rule は 1 件だけにする。系列に対する方針は
+--   常に最新 1 件で十分 (ADR 0056 §3 後段: 既存 rule があれば置き換える)。
+
+-- =====================================================================
+-- 1. events.recurring_event_id を追加 (ADR 0056 §1)
+-- =====================================================================
+--
+-- Google Calendar API `events.list?singleEvents=true` でも各 instance の
+-- `recurringEventId` が返る (recurring の master を指す文字列、Google 内部 id)。
+-- kozutsumi 側は (source, external_calendar_id, recurring_event_id) で recurring グループを
+-- 識別する (`source` / `external_calendar_id` は既存の triple 軸を流用)。
+--
+-- 既存行 backfill はしない: 次回 sync で各 instance に値が入る (ADR 0056 §1)。
+-- 単発 event は NULL のまま。
+
+alter table public.events
+  add column recurring_event_id text;
+
+comment on column public.events.recurring_event_id is
+  'ADR 0056: Google Calendar の recurring master id (singleEvents=true でも返る)。NULL = 単発 event。'
+  ' (source, external_calendar_id, recurring_event_id) で recurring グループを識別する。';
+
+-- recurring グループ単位の bulk update / rule 適用クエリを高速化する。
+-- WHERE clause は `(user_id, source, external_calendar_id, recurring_event_id)` の複合になり、
+-- recurring_event_id IS NOT NULL の行に絞った partial index が選択性として有効。
+create index events_recurring_group_idx
+  on public.events (user_id, source, external_calendar_id, recurring_event_id)
+  where recurring_event_id is not null;
+
+-- =====================================================================
+-- 2. event_visibility_override_rules テーブル新設 (ADR 0056 §1)
+-- =====================================================================
+--
+-- 「方針」を表すテーブル。事実 (events.visibility_override) とは別レイヤ。
+-- rule は新規 instance 取り込み時の default を上書きするために使う (ADR 0056 §2)。
+--
+-- 1 recurring グループ (source + external_calendar_id + recurring_event_id) につき
+-- rule は 1 件まで。新しい操作は既存 rule を上書きする (ON CONFLICT DO UPDATE)。
+-- これにより「方針」は常に「最新の意思」として 1 件に正規化される。
+--
+-- `scope`:
+--   - 'this_and_following' = 操作対象 instance の start_time 以降の新規 instance に適用
+--   - 'all'                = 全ての新規 instance に適用 (from_start_time は NULL)
+-- `from_start_time`:
+--   - scope='this_and_following' のとき NOT NULL (操作対象 instance の start_time)
+--   - scope='all'                のとき NULL
+-- `override_value`:
+--   - 'shown' / 'hidden' のいずれか。`'none'` は rule として持たない
+--     (rule 削除 = 方針撤回 = 新規 instance を default に戻す)。
+
+create table public.event_visibility_override_rules (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on delete cascade,
+  source public.event_source not null,
+  external_calendar_id text not null,
+  recurring_event_id text not null,
+  scope text not null,
+  override_value public.event_visibility_override not null,
+  from_start_time timestamptz,
+  created_at timestamptz not null default now(),
+  -- 1 recurring グループにつき rule は 1 件 (ADR 0056 §3)
+  unique (user_id, source, external_calendar_id, recurring_event_id),
+  -- override_value は 'none' を rule として持たない (rule 自体が「方針あり」を意味する)
+  constraint event_visibility_override_rules_value_chk
+    check (override_value in ('shown', 'hidden')),
+  -- scope と from_start_time の整合性 (ADR 0056 §1 / §4)
+  constraint event_visibility_override_rules_scope_chk
+    check (
+      (scope = 'this_and_following' and from_start_time is not null) or
+      (scope = 'all' and from_start_time is null)
+    )
+);
+
+comment on table public.event_visibility_override_rules is
+  'ADR 0056: recurring event の系列 override 方針。新規 instance 取り込み時に default を上書きする。';
+
+-- 適用判定 (新規 instance insert 時) のクエリ高速化。
+create index event_visibility_override_rules_lookup_idx
+  on public.event_visibility_override_rules
+     (user_id, source, external_calendar_id, recurring_event_id);
+
+-- =====================================================================
+-- 3. RLS (owner-only 4 種、ADR 0023 規約)
+-- =====================================================================
+
+alter table public.event_visibility_override_rules enable row level security;
+
+create policy "event_visibility_override_rules: owner can select"
+  on public.event_visibility_override_rules for select
+  using (user_id = auth.uid());
+create policy "event_visibility_override_rules: owner can insert"
+  on public.event_visibility_override_rules for insert
+  with check (user_id = auth.uid());
+create policy "event_visibility_override_rules: owner can update"
+  on public.event_visibility_override_rules for update
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+create policy "event_visibility_override_rules: owner can delete"
+  on public.event_visibility_override_rules for delete
+  using (user_id = auth.uid());
+
+-- =====================================================================
+-- 4. authenticated への table-level GRANT (ADR 0046)
+-- =====================================================================
+--
+-- 20260504040000_grant_authenticated_to_public_tables.sql で ALTER DEFAULT PRIVILEGES
+-- を入れているので postgres role で create した本 table は自動的に GRANT 対象になる。
+-- 念のため明示的にも grant して preview / 本番のずれを防ぐ (idempotent)。
+
+grant select, insert, update, delete on
+    public.event_visibility_override_rules
+  to authenticated;


### PR DESCRIPTION
## 概要 (What)

繰り返し予定の予定化 / 解除を「この予定だけ / これ以降の予定もまとめて / すべての繰り返し」の 3 択で操作できるようにした。系列操作は **既存 instance への bulk apply（事実）+ rule 永続化（方針）** の併用で表現し、新規取り込み instance にも方針が継続適用される。

## 関連 Issue

Closes #229

## 背景 (Why)

毎週の 1on1 / 定例のような繰り返し予定を予定化解除したい時、これまでは 1 件ずつ操作する必要があり日常利用の摩擦になっていた（#145 の event 単位 override）。一方で「今週だけ別件で休み」のような単発 override は残したいので、Google Calendar 流の 3 択 UX が必要。行動データ観点でも「単発 override」と「系列 override」は別シグナル（突発対応 vs 習慣からの方針転換）なので、scope を区別して action_log に残せると Phase 4 学習素材の解像度が上がる。

設計判断は ADR-0056 で確定済み（rule + bulk apply 併用、単発 override 保護、bulk_operation_id で集計と instance 復元を両立）。本 PR はその実装。

## Before → After (概念・フロー・メンタルモデル)

**Before:**

- events テーブルは `visibility_override` の 3 値（none/shown/hidden）を持つだけで、recurring の概念を保持していない（`recurring_event_id` 列なし）
- 予定化 / 解除は常に 1 instance への単発操作。系列を一括で扱う方法が無い
- action_log は scope の区別を持たず、Phase 4 から「単発 / 系列」を分離できない

**After:**

- events に `recurring_event_id` を追加し、`(source, external_calendar_id, recurring_event_id)` で系列をグルーピングできる
- 系列 override は **events テーブル（事実）** と **`event_visibility_override_rules`（方針）** の 2 レイヤで持つ。前者は「現時点のスナップショット」、後者は「未来取り込み instance への適用ルール」
- recurring instance の予定化 / 解除では 3 択 modal を表示（default は `single`）。系列影響は明示選択でしか発生しない
- 単発 override 済 instance は系列操作で **上書きされない**（情報濃度の濃いシグナルを保護）
- action_log は `event_promoted` / `event_demoted` に scope / recurring_event_id / bulk_operation_id を追加。新 type `event_visibility_rule_added` / `event_visibility_rule_removed` を導入し、bulk_operation_id で 1 操作 = N 件 + 1 rule をグルーピング

## 追加したテスト (How verified)

- [x] unit: `mapGoogleEventToUpsertInput` の recurring instance ケース（`recurringEventId` 保持）
- [x] unit: 既存 fixture に `recurringEventId: null` を補充（型整合）
- [x] unit: ACTION_TYPES に新 type 2 件が含まれる
- [x] e2e: `scope='this_and_following'` で bulk apply + rule 永続化 + 各 instance の `event_demoted` + `event_visibility_rule_added` が同 `bulk_operation_id` で揃う
- [x] e2e: `scope='all'` でも単発 override 済 instance は保護される（ADR 0056 §5）
- [x] `npm run check`（format / lint / typecheck / vitest 635 件）通過
- [x] `npm run build`（Next.js 本番ビルド）通過、新規 route 4 つが認識される
- 未カバー: rule 削除導線の e2e（settings の「ルール削除」ボタン）。手動確認のみ

## リリース前チェックリスト (When / Before merge)

- [x] マイグレーションの適用順を確認した（`20260507000000_p3_229_recurring_event_override.sql`、本 PR で 1 ファイルのみ追加）
- [x] 既存ユーザーへの影響: `recurring_event_id` は backfill しない方針（ADR §1）。次回 sync で各 instance に値が入る。既存 events / 既存 visibility_override は触らない
- [x] ドキュメント: ADR-0056 は #231 で先行マージ済み

## このPRの範囲外 (Out of scope)

- recurring event の create / update（read-only 維持、ADR 0010）
- master 削除の能動検知（API 信号なし、ADR §7）
- master 分裂後の旧 / 新系列の関連付け（Google 側のユーザー意思を尊重、ADR Notes）
- timezone 跨ぎの「これ以降」境界厳密化（JST 固定運用前提、ADR §4）
- action_log payload schema の詳細仕様（#154 で確定予定）


---
_Generated by [Claude Code](https://claude.ai/code/session_016mfcWtAbCzjGZrDDg1UjiH)_