### PR TITLE
test(task-stack): stack top と timer の auto-bind 不変条件を回帰防止する (Closes #238)

### DIFF
--- a/src/app/useTopTaskTimer.test.tsx
+++ b/src/app/useTopTaskTimer.test.tsx
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+// logger は useTaskTimer.test.tsx と同じ作法で差し替える。
+const mocks = vi.hoisted(() => ({
+  log: vi.fn(),
+}));
+
+vi.mock("@/entities/action-log/logger", () => ({
+  ACTION_TYPES: Object.freeze({
+    TASK_STARTED: "task_started",
+    TASK_PAUSED: "task_paused",
+    TASK_RESUMED: "task_resumed",
+    TASK_COMPLETED: "task_completed",
+    TASK_REORDERED: "task_reordered",
+    TASK_DELETED: "task_deleted",
+    TASK_TITLE_CHANGED: "task_title_changed",
+    INTERRUPTION_PUSHED: "interruption_pushed",
+    INTERRUPTION_COMPLETED: "interruption_completed",
+    STACK_PROPOSED: "stack_proposed",
+    STACK_PROPOSAL_ACCEPTED: "stack_proposal_accepted",
+  }),
+  log: mocks.log,
+}));
+
+const { log: logMock } = mocks;
+
+import { act, renderHook } from "@testing-library/react";
+
+import type { TaskGateway } from "@/entities/task/gateway";
+import type { TaskTimeEntryGateway } from "@/entities/task/time-entry-gateway";
+import type { Task } from "@/entities/task/types";
+import { withGateways } from "@/shared/gateway/test-helpers";
+
+import { useTopTaskTimer } from "./useTopTaskTimer";
+
+const baseTask: Task = {
+  id: "t1",
+  projectId: "p1",
+  title: "タスクA",
+  body: "",
+  estimatedMinutes: 30,
+  status: "idle",
+  stackOrder: 0,
+  dependsOnEventId: null,
+  isInterruption: false,
+  parentTaskId: null,
+  decomposeStatus: "none",
+  taskCategory: null,
+  taskSize: null,
+  createdAt: "2026-04-19T09:00:00.000Z",
+  completedAt: null,
+};
+
+type TimerMocks = {
+  update: ReturnType<typeof vi.fn>;
+  list: ReturnType<typeof vi.fn>;
+  getOpen: ReturnType<typeof vi.fn>;
+  start: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+};
+
+function makeTimerMocks(): TimerMocks {
+  return {
+    update: vi.fn().mockResolvedValue({}),
+    list: vi.fn().mockResolvedValue([]),
+    getOpen: vi.fn().mockResolvedValue(null),
+    start: vi.fn().mockResolvedValue({
+      id: "te-new",
+      taskId: "t1",
+      startedAt: "2026-04-19T10:00:00.000Z",
+      pausedAt: null,
+      pauseReason: null,
+      durationSeconds: null,
+    }),
+    close: vi.fn().mockImplementation(async (entry, reason) => ({
+      ...(entry as Record<string, unknown>),
+      pausedAt: "2026-04-19T10:01:00.000Z",
+      pauseReason: reason ?? null,
+      durationSeconds: 60,
+    })),
+  };
+}
+
+function wrapTimer(m: TimerMocks) {
+  const taskGateway: Partial<TaskGateway> = {
+    update: m.update as unknown as TaskGateway["update"],
+  };
+  const taskTimeEntryGateway: Partial<TaskTimeEntryGateway> = {
+    list: m.list as unknown as TaskTimeEntryGateway["list"],
+    getOpen: m.getOpen as unknown as TaskTimeEntryGateway["getOpen"],
+    start: m.start as unknown as TaskTimeEntryGateway["start"],
+    close: m.close as unknown as TaskTimeEntryGateway["close"],
+  };
+  return withGateways({ taskGateway, taskTimeEntryGateway });
+}
+
+/**
+ * ADR-0058 Decision 2「stack top が timer の current task として自動 bind される」
+ * の不変条件を hook 境界で守る。AppShell.tsx は `useTopTaskTimer(pendingTasks[0] ?? null)`
+ * の形で常に stack top を渡す前提。
+ */
+describe("useTopTaskTimer (stack top auto-bind / ADR-0058 Decision 2)", () => {
+  let m: TimerMocks;
+  beforeEach(() => {
+    logMock.mockReset();
+    m = makeTimerMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("topTask=null では動詞は no-op (gateway が呼ばれない)", async () => {
+    const { Wrapper } = wrapTimer(m);
+    const { result } = renderHook(() => useTopTaskTimer(null), { wrapper: Wrapper });
+    await act(async () => {
+      result.current.topTimer.onStart();
+      result.current.topTimer.onResume();
+      result.current.topTimer.onComplete();
+    });
+    expect(m.start).not.toHaveBeenCalled();
+    expect(m.update).not.toHaveBeenCalled();
+    expect(logMock).not.toHaveBeenCalled();
+  });
+
+  test("topTask が swap されると新 task id に対して start が発火する (auto-bind 追従)", async () => {
+    const topA: Task = { ...baseTask, id: "t-A", title: "A" };
+    const topB: Task = { ...baseTask, id: "t-B", title: "B" };
+    const { Wrapper } = wrapTimer(m);
+    const { result, rerender } = renderHook(
+      ({ top }: { top: Task | null }) => useTopTaskTimer(top),
+      {
+        wrapper: Wrapper,
+        initialProps: { top: topA as Task | null },
+      },
+    );
+
+    await act(async () => {
+      result.current.topTimer.onStart();
+    });
+    expect(m.start).toHaveBeenLastCalledWith("t-A");
+
+    // stack 並び替えで top が変わったケースを模擬する: AppShell は pendingTasks[0]
+    // の差し替えで topTask 引数を更新するだけ。timer subject はそれに従う。
+    rerender({ top: topB });
+    await act(async () => {
+      result.current.topTimer.onStart();
+    });
+    expect(m.start).toHaveBeenLastCalledWith("t-B");
+    expect(m.update).toHaveBeenLastCalledWith("t-B", { status: "active" });
+  });
+
+  test("topTask が null に戻ると以後の動詞は no-op (stack が空のケース)", async () => {
+    const top: Task = { ...baseTask, id: "t-A" };
+    const { Wrapper } = wrapTimer(m);
+    const { result, rerender } = renderHook(
+      ({ top }: { top: Task | null }) => useTopTaskTimer(top),
+      {
+        wrapper: Wrapper,
+        initialProps: { top: top as Task | null },
+      },
+    );
+
+    await act(async () => {
+      result.current.topTimer.onStart();
+    });
+    expect(m.start).toHaveBeenCalledTimes(1);
+
+    rerender({ top: null });
+    await act(async () => {
+      result.current.topTimer.onStart();
+      result.current.topTimer.onResume();
+      result.current.topTimer.onComplete();
+    });
+    // null 後に動詞を叩いても新たな gateway 呼び出しは増えない。
+    expect(m.start).toHaveBeenCalledTimes(1);
+  });
+
+  test("onPauseRequest は modal を開くだけで pause gateway を呼ばない (3 動詞 + reason capture; ADR-0058 Decision 1)", () => {
+    const { Wrapper } = wrapTimer(m);
+    const { result } = renderHook(() => useTopTaskTimer({ ...baseTask, status: "active" }), {
+      wrapper: Wrapper,
+    });
+    act(() => {
+      result.current.topTimer.onPauseRequest();
+    });
+    expect(result.current.pauseModalOpen).toBe(true);
+    expect(m.close).not.toHaveBeenCalled();
+    expect(m.update).not.toHaveBeenCalled();
+  });
+
+  test("handlePauseSelect で modal を閉じ、選んだ reason で pause を発火する", async () => {
+    const open = {
+      id: "te-open",
+      taskId: "t1",
+      startedAt: "2026-04-19T10:00:00.000Z",
+      pausedAt: null,
+      pauseReason: null,
+      durationSeconds: null,
+    };
+    m.list.mockResolvedValue([open]);
+    m.getOpen.mockResolvedValue(open);
+    const { Wrapper } = wrapTimer(m);
+    const { result } = renderHook(() => useTopTaskTimer({ ...baseTask, status: "active" }), {
+      wrapper: Wrapper,
+    });
+    act(() => {
+      result.current.topTimer.onPauseRequest();
+    });
+    expect(result.current.pauseModalOpen).toBe(true);
+    await act(async () => {
+      result.current.handlePauseSelect("meeting");
+    });
+    expect(result.current.pauseModalOpen).toBe(false);
+    expect(m.close).toHaveBeenCalledWith(open, "meeting");
+    expect(m.update).toHaveBeenCalledWith("t1", { status: "paused" });
+  });
+});

--- a/src/features/task-stack/TaskStack.test.tsx
+++ b/src/features/task-stack/TaskStack.test.tsx
@@ -582,4 +582,120 @@ describe("TaskStack", () => {
     fireEvent.click(getByText("Top task"));
     expect(onOpenDetail).toHaveBeenCalledWith("t1");
   });
+
+  // ADR-0058 Decision 2「stack top が timer の current task として自動 bind される」
+  // を行レンダリング側で守る。任意のタスクを「current task」として明示選択する UI
+  // (Top 以外の行の start/pause ボタン等) が増えると本テストで検出する。
+  describe("stack top と timer の auto-bind (ADR-0058 Decision 2)", () => {
+    test("timer 動詞 (開始/中断/再開/完了) は stack top の行にのみ存在する", () => {
+      const { getAllByLabelText, queryAllByLabelText } = render(
+        <TaskStack
+          events={[]}
+          now={NOW_MS}
+          // Top: idle (開始 + 完了), Second/Third: idle (動詞ボタン無し)
+          pendingTasks={pending}
+          doneTasks={[]}
+          topTimer={idleTimer}
+          onReorder={noop}
+          onReorderGroup={noop}
+          onToggleDone={noop}
+          onOpenDetail={noop}
+        />,
+      );
+      // Top: idle なので 開始 + 完了 が出る (TopTaskCard tests と整合)
+      expect(getAllByLabelText("開始")).toHaveLength(1);
+      expect(getAllByLabelText("完了")).toHaveLength(1);
+      // Top 以外の行 (TaskRow) には timer 動詞ボタンが存在しないこと
+      expect(queryAllByLabelText("中断")).toHaveLength(0);
+      expect(queryAllByLabelText("再開")).toHaveLength(0);
+    });
+
+    test("Top が active でも『中断/完了』ボタンは 1 つだけ (他行に伝播しない)", () => {
+      const activePending: Task[] = [
+        { ...baseTask, id: "t1", title: "Top task", status: "active" },
+        { ...baseTask, id: "t2", title: "Second task" },
+        { ...baseTask, id: "t3", title: "Third task" },
+      ];
+      const { getAllByLabelText, queryAllByLabelText } = render(
+        <TaskStack
+          events={[]}
+          now={NOW_MS}
+          pendingTasks={activePending}
+          doneTasks={[]}
+          topTimer={{ ...idleTimer, elapsedSeconds: 60 }}
+          onReorder={noop}
+          onReorderGroup={noop}
+          onToggleDone={noop}
+          onOpenDetail={noop}
+        />,
+      );
+      expect(getAllByLabelText("中断")).toHaveLength(1);
+      expect(getAllByLabelText("完了")).toHaveLength(1);
+      expect(queryAllByLabelText("開始")).toHaveLength(0);
+      expect(queryAllByLabelText("再開")).toHaveLength(0);
+    });
+
+    test("Top の『開始』ボタン押下で topTimer.onStart が発火する (Top 経由でのみ結線)", () => {
+      const onStart = vi.fn();
+      const { getByLabelText } = render(
+        <TaskStack
+          events={[]}
+          now={NOW_MS}
+          pendingTasks={pending}
+          doneTasks={[]}
+          topTimer={{ ...idleTimer, onStart }}
+          onReorder={noop}
+          onReorderGroup={noop}
+          onToggleDone={noop}
+          onOpenDetail={noop}
+        />,
+      );
+      fireEvent.click(getByLabelText("開始"));
+      expect(onStart).toHaveBeenCalledTimes(1);
+    });
+
+    test("pendingTasks の並び順が変わると Top に表示される task が追従する", () => {
+      const order1: Task[] = [
+        { ...baseTask, id: "t1", title: "Top task" },
+        { ...baseTask, id: "t2", title: "Second task" },
+      ];
+      const { rerender, container, getAllByLabelText } = render(
+        <TaskStack
+          events={[]}
+          now={NOW_MS}
+          pendingTasks={order1}
+          doneTasks={[]}
+          topTimer={idleTimer}
+          onReorder={noop}
+          onReorderGroup={noop}
+          onToggleDone={noop}
+          onOpenDetail={noop}
+        />,
+      );
+      // 最初は Top = "Top task"
+      const firstLi = container.querySelectorAll("ul[aria-label='タスクスタック'] > li")[0];
+      expect(firstLi?.textContent).toContain("Top task");
+
+      // 並び替えで Second が先頭に来た想定 (AppShell が pendingTasks を入れ替える)
+      const order2: Task[] = [order1[1], order1[0]];
+      rerender(
+        <TaskStack
+          events={[]}
+          now={NOW_MS}
+          pendingTasks={order2}
+          doneTasks={[]}
+          topTimer={idleTimer}
+          onReorder={noop}
+          onReorderGroup={noop}
+          onToggleDone={noop}
+          onOpenDetail={noop}
+        />,
+      );
+      const newFirstLi = container.querySelectorAll("ul[aria-label='タスクスタック'] > li")[0];
+      // 新しい Top は元の Second
+      expect(newFirstLi?.textContent).toContain("Second task");
+      // 並び替え後も Top にのみ動詞が集中
+      expect(getAllByLabelText("開始")).toHaveLength(1);
+    });
+  });
 });


### PR DESCRIPTION
## 概要 (What)

ADR-0058 Decision 2「stack top が timer の current task として自動 bind される」の不変条件を、実装変更なしに **回帰テスト** だけで守る PR。

## 関連 Issue

Closes #238

## 背景 (Why)

#237 audit の結論で「auto-bind は既に構造的に成立 (削除/移動対象ゼロ)。`AppShell` が `useTopTaskTimer(pendingTasks[0] ?? null)` を渡し、`TaskStack` が `items[0]` のみに `TopTaskCard` を描画する形で結線済み」と判定されている。

audit の派生提案 (option c) に従い、本 issue は **実装の現状維持** を「将来 current task 選択 UI や Top 以外への動詞ボタン伝播が混入したら CI で落ちる」テストで担保する方向に振り直した。ADR-0058 Decision 1 (3 動詞 + reason capture) も同じ hook 境界で固定する。

## Before → After (概念・フロー・メンタルモデル)

**Before:** auto-bind が「コードを読めば成立しているが明示的なテスト不在」。誰かが TaskRow に start ボタンを足したり、AppShell の `pendingTasks[0]` 経路を差し替えたりしても CI は気付かない。

**After:** auto-bind が **2 つのテスト境界** で固定される:

- **hook 境界 (`useTopTaskTimer`)**: topTask 引数を swap すると gateway 呼び出しの宛先 task id が追従する。null では noop。AppShell が「stack top をそのまま渡す」契約を破ったら検出。
- **行レンダリング境界 (`TaskStack`)**: 動詞ボタン (開始/中断/再開/完了) が stack top の 1 行だけに出る。Top の status を idle/active で切り替えても他行に動詞は出ない。並び順変更で Top の表示 task が追従する。

## 追加したテスト (How verified)

- [x] `src/app/useTopTaskTimer.test.tsx` (新規) 5 件:
  - topTask=null では動詞は no-op
  - topTask swap で新 task id 宛に start 発火 (auto-bind 追従)
  - null に戻ると以後の動詞は no-op
  - `onPauseRequest` は modal を開くだけで pause gateway を呼ばない (ADR-0058 Decision 1: 動詞は 3 つ + reason capture)
  - `handlePauseSelect` で modal を閉じて pause(reason) を発火
- [x] `src/features/task-stack/TaskStack.test.tsx` に describe 追加 4 件:
  - 動詞ボタンが stack top の行にのみ存在 (Top: idle)
  - Top が active でも『中断/完了』は 1 つだけ (他行に伝播しない)
  - Top の『開始』が `topTimer.onStart` に結線
  - 並び順変更で Top に表示される task が追従
- [x] `npm run lint` / `npm run typecheck` / `npm test` (全 644 件) pass

## このPRの範囲外 (Out of scope)

- 実装変更 (auto-bind は既に成立しているため不要)
- e2e での auto-bind 検証 (#241 で既に「timer 中の AI 介入禁止」を e2e で固定済。本 PR は unit/integration 層で十分カバー)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DfuM82wT3w5CpMkhXkbj6H)_