### PR TITLE
feat(timer): 1-tap 割り込みボタンで timer 停止 + task_interrupted 記録 (Closes #239)

### DIFF
--- a/docs/adr/0059-one-tap-interrupt-recording.md
+++ b/docs/adr/0059-one-tap-interrupt-recording.md
@@ -1,6 +1,6 @@
 # ADR 0059: 突発割り込みは 1-tap で timer 停止 + イベント記録、stack には push しない
 
-- **Status**: Accepted
+- **Status**: Superseded by [ADR-0065](./0065-interrupt-buttons-per-source.md)
 - **Date**: 2026-05-10
 - **Related**: `docs/design/architecture.md` §1.4 / [Issue #234](https://github.com/y-oga-819/kozutsumi/issues/234) / [ADR-0058](./0058-timer-three-verbs-and-no-ai-interruption.md) / [ADR-0062](./0062-morning-review-ritual-fifteen-minutes.md)
 

--- a/docs/adr/0065-interrupt-buttons-per-source.md
+++ b/docs/adr/0065-interrupt-buttons-per-source.md
@@ -1,0 +1,70 @@
+# ADR 0065: 1-tap 割り込みは source 別に複数ボタン (Slack / Notion / PR Review) を並べる
+
+- **Status**: Accepted
+- **Date**: 2026-05-13
+- **Related**: Supersedes [ADR-0059](./0059-one-tap-interrupt-recording.md) / `docs/design/architecture.md` §1.5 / [ADR-0058](./0058-timer-three-verbs-and-no-ai-interruption.md) / [ADR-0062](./0062-morning-review-ritual-fifteen-minutes.md) / Issue #239
+
+## Context
+
+[ADR-0059](./0059-one-tap-interrupt-recording.md) で「割り込みは専用ボタン 1 タップ、事前分類なし」を決め、Issue #239 で実装した。dogfooding 設計段階で見直すと、想定ユーザーの実際の割り込みは **発生源 (source) が user 視点で即座に判別できる**:
+
+- Slack の通知音 / バッジ
+- Notion のメンション通知
+- PR Review コメントの通知
+
+source は「割り込まれた瞬間に user 自身が知っている情報」であって、後段で推測すべきカテゴリ抽象ではない。事前に source を捨てて朝の棚卸し (ADR-0062) で再構成しても、復元精度は下がる (= 情報量は事前 1-tap の時点で最大)。
+
+ADR-0059 の Alternatives で却下した「ボタンで分類を選ばせる」は **MTG / 緊急 / 雑談** のような **カテゴリ抽象** を想定していた (= 「これは MTG か雑談か」は本人でも揺れる)。source 分類はそれとは性質が違うため、ここで再判断する。
+
+## Decision
+
+割り込みボタンは **source 別に複数並べる**:
+
+- 当面は **Slack / Notion / PR Review の 3 ボタン**を hardcoded で配置する
+- 各ボタンは 1 タップで:
+  1. 現在の timer を **停止 (paused)** する
+  2. **`task_interrupted` イベントを記録**する。`metadata.source` に押したボタンの値を入れる
+  3. **割り込みタスクは stack に push しない** (= ADR-0059 から維持)
+- modal は経由しない (= ボタン側で source が確定するので reason 選択は不要)
+
+「ユーザーが触る動詞」は ADR-0058 の start / stop / complete + 本 ADR の **source 別 interrupt 群** という構造で固定する。1 タップで完了する不変条件は維持される (タップ回数は 1 のまま、ボタン総数だけ増える)。
+
+source 値は schema 上 `string` で保持する (TS レベルで union 型として `"slack" | "notion" | "pr_review"` に制約する一方、DB の `action_logs.metadata` は JSONB なので将来 user-defined source を追加しても migration は不要)。
+
+## Consequences
+
+### 肯定的影響
+
+- 行動データの粒度が source 単位で取れる。朝の棚卸し (ADR-0062) や週次 / 四半期 Wrapped (M-δ) で「Slack 割り込みが集中する時間帯」「PR Review 割り込みが過集中を切る頻度」等が **追加コストなしで** 分析できる
+- 朝の棚卸しでの事後分類負荷が下がる (source は確定済み)
+- 押す瞬間に「何に割り込まれたか」を user が言語化することで、自己観察 (Barkley "Externalize Key Information") の質が上がる
+- 「事前分類を要求しない」原則は本 ADR で source 分類に限り緩めるが、**カテゴリ抽象 (MTG / 緊急 / 雑談)** の事前分類は引き続き不採用 (ADR-0059 Alternatives の判断は source 分類以外には残す)
+
+### 否定的影響・トレードオフ
+
+- ADR-0059 の「ボタンは 1 個」が「ボタンは N 個 (現状 3)」に変わる。Top カードに専有面積が増え、ボタン数が増えれば見た目の摩擦は上がる。ADR-0058「ユーザーが触るのは timer の 3 動詞だけ」原則の **動詞数増加** に該当する側面はある (start / stop / complete + interrupt × N)
+- ボタンに表示する source 名 (Slack / Notion / PR Review) が増えるごとに UI 配置設計が壊れうる (現状 3 個は許容範囲、5 個を超えたら別 UI を検討)
+- ADR-0059 Alternatives で却下した「分類を選ばせる」と表面的には矛盾するため、ADR の判断履歴を読む者に対する説明コストが上がる
+- 3 source 以外の割り込み (例: 同僚の声かけ / 紙のメモ) は記録手段が無い。当面はそのまま落として OK (= dogfooding で頻度を観察してから追加判断)
+
+### 後から見たときの判定軸
+
+本 ADR を将来 supersede する trigger:
+
+- dogfooding で「3 source の枠が窮屈で、押せない割り込みが頻発」と判明
+- user-defined source の追加要求が定期的に出る (= settings 経由で追加 UI を作る判断)
+- ボタン群が画面を圧迫してタスク title 視認性が落ちる (= 別 UI 構造へ)
+
+## Alternatives considered
+
+- **ADR-0059 の現状維持 (ボタン 1 個 + 朝の棚卸しで事後分類)**: source 情報を 1-tap 時点で捨てるのは情報量を loss する。朝の棚卸しでの分類復元精度は実証されていない。dogfooding の前段階でわざわざ情報を捨てる必要がない。不採用
+- **設定画面で user 自身が source を追加・編集できるようにする (一段階目から)**: 「最初の dogfooding で使う source 数」が不確定なため、設定 UI を先に作ると yagni。Slack / Notion / PR Review の 3 個は実体験ベースで確実に押す source、これを hardcoded で先に出す方が高速。将来追加要求が定期的に出てから設定 UI を別 ADR で起票する。不採用
+- **source 別に action_type を分ける (`task_interrupted_slack` / `task_interrupted_notion` / ...)** : SELECT 文がシンプルになる利点はあるが、source を増やすたびに `ACTION_TYPES` 名義が爆発して logger.ts / types.ts / test の更新が広がる。`task_interrupted.metadata.source` で吸収すれば 1 action_type のまま source を増減できる。不採用
+- **割り込みボタンを Top カード以外 (画面下部・固定 FAB 等) に置く**: Top カード内に置くことで「今走っている timer をどう扱うか」と「割り込み記録」が同じ視野に収まる。FAB 化は導線が遠くなり 1-tap 主義の体感を損なう。不採用
+
+## Notes
+
+- 本 ADR は ADR-0059 を完全 supersede する。ADR-0059 の Decision (停止 + 記録 + stack push しない) のうち停止と「stack に push しない」は維持され、「分類なし」だけが上書きされる。読み手が混乱しないよう、ADR-0059 側を `Superseded by ADR-0065` に書き換える
+- architecture.md §1.5 は「専用ボタン 1 タップ」と書いてあるが、本 ADR でも「1 タップ」自体は維持される (= ボタン数が増えても 1 push で完了する不変条件は同じ)。文面整理は軌道修正 ADR 群 (0057〜0065) 確定後にまとめて反映する
+- 朝の棚卸し (ADR-0062) で「この割り込みをタスクに昇格」する操作は、metadata.source がある分 source filter / グルーピングが効きやすくなる。具体 UI は M-γ の枠で別 issue
+- 将来の user-defined source 対応で見直す条件: dogfooding で 3 source 以外の押したい source が定期的に観察される、もしくは「source が思い出せない」割り込みが多発する

--- a/e2e/one-tap-interrupt.spec.ts
+++ b/e2e/one-tap-interrupt.spec.ts
@@ -12,80 +12,95 @@ import {
 import { expect, test } from "./fixtures";
 
 /**
- * Issue #239 / ADR-0059:
- *   1-tap 割り込みボタンは active な timer を 1 タップで paused に落とし、
- *   action_log に `task_interrupted` を 1 件だけ記録する。
+ * Issue #239 / ADR-0065 (Supersedes ADR-0059):
+ *   割り込みボタンは source 別に 3 個 (Slack / Notion / PR Review) 並ぶ。
+ *   各ボタンは 1 タップで active な timer を paused に落とし、
+ *   action_log に `task_interrupted` を 1 件記録する (metadata.source 付き)。
  *
  * 不変条件 (= 本 spec が CI で踏み続ける):
  *   1. `中断の理由` モーダル (PauseReasonModal) は経由しない (= reason 選択を要求しない)
  *   2. time_entries は `pause_reason="interruption"` で close される
- *   3. action_logs には `task_interrupted` が積まれ、`task_paused` は積まれない
- *      (= モーダル経由の中断と区別できる)
+ *   3. action_logs には `task_interrupted` が積まれ (metadata.source に押下 source)、
+ *      `task_paused` は積まれない (= モーダル経由の中断と区別できる)
  *   4. 停止後の任意の再開は user 操作 (= 「再開」ボタン押下) でのみ起きる
  *
  * ADR-0058 (timer 3 動詞 + 能動 AI 介入禁止) の guard rail は
- * timer-no-ai-intervention.spec.ts が別途踏んでいる。本 spec は ADR-0059 の
- * 1-tap シグナルが DB に正確に落ちる側を担保する。
+ * timer-no-ai-intervention.spec.ts が別途踏んでいる。本 spec は ADR-0065 の
+ * source 別 1-tap シグナルが DB に正確に落ちる側を担保する。
  */
-test.describe("ADR-0059: 1-tap 割り込みボタン", () => {
-  test("active 中の 1-tap で paused へ落ち、task_interrupted のみ記録される (モーダルは経由しない)", async ({
-    signedInPageWithProject: page,
-    projectName,
-    testUserId: userId,
-  }) => {
-    const taskTitle = "1-tap 割り込み検証";
-    const admin = createAdminClient();
+const SOURCE_CASES: readonly { source: "slack" | "notion" | "pr_review"; buttonName: string }[] = [
+  { source: "slack", buttonName: "Slack 割り込み" },
+  { source: "notion", buttonName: "Notion 割り込み" },
+  { source: "pr_review", buttonName: "PR Review 割り込み" },
+] as const;
 
-    await createTask(page, taskTitle, projectName);
-    const task = await getTaskByTitle(admin, userId, taskTitle);
-    const taskId = task.id;
+test.describe("ADR-0065: source 別 1-tap 割り込みボタン", () => {
+  for (const c of SOURCE_CASES) {
+    test(`${c.source}: active 中の 1-tap で paused へ落ち、task_interrupted(source=${c.source}) のみ記録される (モーダルは経由しない)`, async ({
+      signedInPageWithProject: page,
+      projectName,
+      testUserId: userId,
+    }) => {
+      const taskTitle = `1-tap 割り込み検証 (${c.source})`;
+      const admin = createAdminClient();
 
-    // --- start ----
-    await page.getByRole("button", { name: "開始" }).click();
-    await expect(page.getByRole("button", { name: "中断" })).toBeVisible();
-    await expectTaskStatus(admin, taskId, "active");
-    // 割り込みボタンが active 中だけ表示される (=ADR-0059 不変条件: 1-tap)
-    const interruptButton = page.getByRole("button", { name: "割り込み" });
-    await expect(interruptButton).toBeVisible();
+      await createTask(page, taskTitle, projectName);
+      const task = await getTaskByTitle(admin, userId, taskTitle);
+      const taskId = task.id;
 
-    // --- 1-tap 割り込み ----
-    await interruptButton.click();
-    // モーダルは出ない (= 事前分類を要求しない / ADR-0059 Decision 2)
-    await expect(page.getByRole("dialog", { name: "中断の理由" })).toHaveCount(0);
-    // active → paused に遷移
-    await expect(page.getByRole("button", { name: "再開" })).toBeVisible();
-    await expectTaskStatus(admin, taskId, "paused");
-    // 停止後は割り込みボタンも消える (paused では押せない)
-    await expect(page.getByRole("button", { name: "割り込み" })).toHaveCount(0);
+      // --- start ----
+      await page.getByRole("button", { name: "開始" }).click();
+      await expect(page.getByRole("button", { name: "中断" })).toBeVisible();
+      await expectTaskStatus(admin, taskId, "active");
+      // source 別の 3 ボタンが active 中だけ表示される
+      for (const s of SOURCE_CASES) {
+        await expect(page.getByRole("button", { name: s.buttonName })).toBeVisible();
+      }
 
-    // --- action_log: task_interrupted が積まれる ----
-    const interruptedLog = await waitForActionLog(
-      admin,
-      userId,
-      (l) => l.action_type === "task_interrupted" && l.task_id === taskId,
-      { description: "task_interrupted log" },
-    );
-    expect((interruptedLog.metadata as { task_id?: string }).task_id).toBe(taskId);
+      // --- 1-tap 割り込み (該当 source) ----
+      await page.getByRole("button", { name: c.buttonName }).click();
+      // モーダルは出ない (= 事前 reason 選択を要求しない / ADR-0065 Decision)
+      await expect(page.getByRole("dialog", { name: "中断の理由" })).toHaveCount(0);
+      // active → paused に遷移
+      await expect(page.getByRole("button", { name: "再開" })).toBeVisible();
+      await expectTaskStatus(admin, taskId, "paused");
+      // 停止後は割り込みボタン群も消える (paused では押せない)
+      for (const s of SOURCE_CASES) {
+        await expect(page.getByRole("button", { name: s.buttonName })).toHaveCount(0);
+      }
 
-    // task_paused は積まれない (= ADR-0059 のシグナル分離)。
-    // waitForActionLog で待つと「来なかったこと」を確認できないため、interrupted を
-    // 観測した直後の time-entry 更新まで待ってから getActionLogs で集合確認する。
-    const entries = await waitForTimeEntries(
-      admin,
-      taskId,
-      (es) => es.length === 1 && es[0].paused_at !== null,
-      { description: "entry closed after interrupt" },
-    );
-    assertTimeEntriesInvariants(entries);
-    expect(entries[0].pause_reason).toBe("interruption");
-    expect(entries[0].duration_seconds).not.toBeNull();
+      // --- action_log: task_interrupted (source 付き) が積まれる ----
+      const interruptedLog = await waitForActionLog(
+        admin,
+        userId,
+        (l) =>
+          l.action_type === "task_interrupted" &&
+          l.task_id === taskId &&
+          (l.metadata as { source?: string }).source === c.source,
+        { description: `task_interrupted log with source=${c.source}` },
+      );
+      const meta = interruptedLog.metadata as { task_id?: string; source?: string };
+      expect(meta.task_id).toBe(taskId);
+      expect(meta.source).toBe(c.source);
 
-    // 集合 assert: task に対する action_log は task_started → task_interrupted のみ
-    // (task_paused は出ない)。
-    const allLogs = await getActionLogs(admin, userId);
-    const ourTypes = allLogs.filter((l) => l.task_id === taskId).map((l) => l.action_type);
-    expect(ourTypes).toEqual(["task_started", "task_interrupted"]);
-  });
+      // --- time_entry: pause_reason=interruption で close される ----
+      const entries = await waitForTimeEntries(
+        admin,
+        taskId,
+        (es) => es.length === 1 && es[0].paused_at !== null,
+        { description: "entry closed after interrupt" },
+      );
+      assertTimeEntriesInvariants(entries);
+      expect(entries[0].pause_reason).toBe("interruption");
+      expect(entries[0].duration_seconds).not.toBeNull();
+
+      // 集合 assert: task に対する action_log は task_started → task_interrupted のみ
+      // (task_paused は出ない)。
+      const allLogs = await getActionLogs(admin, userId);
+      const ourTypes = allLogs.filter((l) => l.task_id === taskId).map((l) => l.action_type);
+      expect(ourTypes).toEqual(["task_started", "task_interrupted"]);
+    });
+  }
 
   test("割り込み後の resume は user 操作 (再開ボタン押下) でのみ起きる (= 自動再開しない)", async ({
     signedInPageWithProject: page,
@@ -100,7 +115,7 @@ test.describe("ADR-0059: 1-tap 割り込みボタン", () => {
 
     await page.getByRole("button", { name: "開始" }).click();
     await expect(page.getByRole("button", { name: "中断" })).toBeVisible();
-    await page.getByRole("button", { name: "割り込み" }).click();
+    await page.getByRole("button", { name: "Slack 割り込み" }).click();
     await expect(page.getByRole("button", { name: "再開" })).toBeVisible();
     await expectTaskStatus(admin, taskId, "paused");
 

--- a/e2e/one-tap-interrupt.spec.ts
+++ b/e2e/one-tap-interrupt.spec.ts
@@ -1,0 +1,129 @@
+import type { Page } from "@playwright/test";
+
+import {
+  assertTimeEntriesInvariants,
+  createAdminClient,
+  expectTaskStatus,
+  getActionLogs,
+  getTaskByTitle,
+  waitForActionLog,
+  waitForTimeEntries,
+} from "./db";
+import { expect, test } from "./fixtures";
+
+/**
+ * Issue #239 / ADR-0059:
+ *   1-tap 割り込みボタンは active な timer を 1 タップで paused に落とし、
+ *   action_log に `task_interrupted` を 1 件だけ記録する。
+ *
+ * 不変条件 (= 本 spec が CI で踏み続ける):
+ *   1. `中断の理由` モーダル (PauseReasonModal) は経由しない (= reason 選択を要求しない)
+ *   2. time_entries は `pause_reason="interruption"` で close される
+ *   3. action_logs には `task_interrupted` が積まれ、`task_paused` は積まれない
+ *      (= モーダル経由の中断と区別できる)
+ *   4. 停止後の任意の再開は user 操作 (= 「再開」ボタン押下) でのみ起きる
+ *
+ * ADR-0058 (timer 3 動詞 + 能動 AI 介入禁止) の guard rail は
+ * timer-no-ai-intervention.spec.ts が別途踏んでいる。本 spec は ADR-0059 の
+ * 1-tap シグナルが DB に正確に落ちる側を担保する。
+ */
+test.describe("ADR-0059: 1-tap 割り込みボタン", () => {
+  test("active 中の 1-tap で paused へ落ち、task_interrupted のみ記録される (モーダルは経由しない)", async ({
+    signedInPageWithProject: page,
+    projectName,
+    testUserId: userId,
+  }) => {
+    const taskTitle = "1-tap 割り込み検証";
+    const admin = createAdminClient();
+
+    await createTask(page, taskTitle, projectName);
+    const task = await getTaskByTitle(admin, userId, taskTitle);
+    const taskId = task.id;
+
+    // --- start ----
+    await page.getByRole("button", { name: "開始" }).click();
+    await expect(page.getByRole("button", { name: "中断" })).toBeVisible();
+    await expectTaskStatus(admin, taskId, "active");
+    // 割り込みボタンが active 中だけ表示される (=ADR-0059 不変条件: 1-tap)
+    const interruptButton = page.getByRole("button", { name: "割り込み" });
+    await expect(interruptButton).toBeVisible();
+
+    // --- 1-tap 割り込み ----
+    await interruptButton.click();
+    // モーダルは出ない (= 事前分類を要求しない / ADR-0059 Decision 2)
+    await expect(page.getByRole("dialog", { name: "中断の理由" })).toHaveCount(0);
+    // active → paused に遷移
+    await expect(page.getByRole("button", { name: "再開" })).toBeVisible();
+    await expectTaskStatus(admin, taskId, "paused");
+    // 停止後は割り込みボタンも消える (paused では押せない)
+    await expect(page.getByRole("button", { name: "割り込み" })).toHaveCount(0);
+
+    // --- action_log: task_interrupted が積まれる ----
+    const interruptedLog = await waitForActionLog(
+      admin,
+      userId,
+      (l) => l.action_type === "task_interrupted" && l.task_id === taskId,
+      { description: "task_interrupted log" },
+    );
+    expect((interruptedLog.metadata as { task_id?: string }).task_id).toBe(taskId);
+
+    // task_paused は積まれない (= ADR-0059 のシグナル分離)。
+    // waitForActionLog で待つと「来なかったこと」を確認できないため、interrupted を
+    // 観測した直後の time-entry 更新まで待ってから getActionLogs で集合確認する。
+    const entries = await waitForTimeEntries(
+      admin,
+      taskId,
+      (es) => es.length === 1 && es[0].paused_at !== null,
+      { description: "entry closed after interrupt" },
+    );
+    assertTimeEntriesInvariants(entries);
+    expect(entries[0].pause_reason).toBe("interruption");
+    expect(entries[0].duration_seconds).not.toBeNull();
+
+    // 集合 assert: task に対する action_log は task_started → task_interrupted のみ
+    // (task_paused は出ない)。
+    const allLogs = await getActionLogs(admin, userId);
+    const ourTypes = allLogs.filter((l) => l.task_id === taskId).map((l) => l.action_type);
+    expect(ourTypes).toEqual(["task_started", "task_interrupted"]);
+  });
+
+  test("割り込み後の resume は user 操作 (再開ボタン押下) でのみ起きる (= 自動再開しない)", async ({
+    signedInPageWithProject: page,
+    projectName,
+    testUserId: userId,
+  }) => {
+    const taskTitle = "割り込み後 manual resume 検証";
+    const admin = createAdminClient();
+    await createTask(page, taskTitle, projectName);
+    const task = await getTaskByTitle(admin, userId, taskTitle);
+    const taskId = task.id;
+
+    await page.getByRole("button", { name: "開始" }).click();
+    await expect(page.getByRole("button", { name: "中断" })).toBeVisible();
+    await page.getByRole("button", { name: "割り込み" }).click();
+    await expect(page.getByRole("button", { name: "再開" })).toBeVisible();
+    await expectTaskStatus(admin, taskId, "paused");
+
+    // 自動再開が万一仕込まれていれば踏める下限の長さ。
+    await page.waitForTimeout(1_500);
+    await expectTaskStatus(admin, taskId, "paused");
+    await expect(page.getByRole("button", { name: "再開" })).toBeVisible();
+
+    // user が「再開」を押すと active に戻る (= calendar-event の非対称 stop と同じ原則)。
+    await page.getByRole("button", { name: "再開" }).click();
+    await expect(page.getByRole("button", { name: "中断" })).toBeVisible();
+    await expectTaskStatus(admin, taskId, "active");
+  });
+});
+
+async function createTask(page: Page, title: string, projectName: string): Promise<void> {
+  await page.getByRole("button", { name: "新規追加" }).click();
+  const addDialog = page.getByRole("dialog", { name: "追加メニュー" });
+  await addDialog.getByRole("tab", { name: "タスク" }).click();
+  await addDialog.getByLabel("タイトル").fill(title);
+  // #170 / ADR 0038: task_size は登録時必須。テスト範囲外なので任意の値 (30分) を選ぶ。
+  await addDialog.getByRole("radio", { name: "30分" }).click();
+  await addDialog.getByLabel("プロジェクト (任意)").selectOption({ label: projectName });
+  await addDialog.getByRole("button", { name: "追加" }).click();
+  await expect(addDialog).toHaveCount(0);
+}

--- a/e2e/one-tap-interrupt.spec.ts
+++ b/e2e/one-tap-interrupt.spec.ts
@@ -31,7 +31,7 @@ import { expect, test } from "./fixtures";
 const SOURCE_CASES: readonly { source: "slack" | "notion" | "pr_review"; buttonName: string }[] = [
   { source: "slack", buttonName: "Slack 割り込み" },
   { source: "notion", buttonName: "Notion 割り込み" },
-  { source: "pr_review", buttonName: "PR Review 割り込み" },
+  { source: "pr_review", buttonName: "レビュー 割り込み" },
 ] as const;
 
 test.describe("ADR-0065: source 別 1-tap 割り込みボタン", () => {

--- a/src/app/useTopTaskTimer.test.tsx
+++ b/src/app/useTopTaskTimer.test.tsx
@@ -189,9 +189,10 @@ describe("useTopTaskTimer (stack top auto-bind / ADR-0058 Decision 2)", () => {
     expect(m.update).not.toHaveBeenCalled();
   });
 
-  // ADR-0059: 1-tap 割り込みは PauseReasonModal を一切経由しない。timer.interrupt() が
-  // 直接走り、open entry を "interruption" で close して action_log は task_interrupted を残す。
-  test("onInterrupt は modal を開かず、interruption で entry を close + task_interrupted を log する", async () => {
+  // ADR-0065: source 別 1-tap 割り込みは PauseReasonModal を一切経由しない。
+  // timer.interrupt(source) が直接走り、open entry を "interruption" で close、
+  // action_log は task_interrupted + metadata.source を残す。
+  test("onInterrupt(source) は modal を開かず、interruption で entry を close + task_interrupted を log する", async () => {
     const open = {
       id: "te-open",
       taskId: "t1",
@@ -207,12 +208,15 @@ describe("useTopTaskTimer (stack top auto-bind / ADR-0058 Decision 2)", () => {
       wrapper: Wrapper,
     });
     await act(async () => {
-      result.current.topTimer.onInterrupt();
+      result.current.topTimer.onInterrupt("slack");
     });
     expect(result.current.pauseModalOpen).toBe(false);
     expect(m.close).toHaveBeenCalledWith(open, "interruption");
     expect(m.update).toHaveBeenCalledWith("t1", { status: "paused" });
-    expect(logMock).toHaveBeenCalledWith("task_interrupted", { task_id: "t1" });
+    expect(logMock).toHaveBeenCalledWith("task_interrupted", {
+      task_id: "t1",
+      source: "slack",
+    });
   });
 
   test("handlePauseSelect で modal を閉じ、選んだ reason で pause を発火する", async () => {

--- a/src/app/useTopTaskTimer.test.tsx
+++ b/src/app/useTopTaskTimer.test.tsx
@@ -16,6 +16,7 @@ vi.mock("@/entities/action-log/logger", () => ({
     TASK_TITLE_CHANGED: "task_title_changed",
     INTERRUPTION_PUSHED: "interruption_pushed",
     INTERRUPTION_COMPLETED: "interruption_completed",
+    TASK_INTERRUPTED: "task_interrupted",
     STACK_PROPOSED: "stack_proposed",
     STACK_PROPOSAL_ACCEPTED: "stack_proposal_accepted",
   }),
@@ -186,6 +187,32 @@ describe("useTopTaskTimer (stack top auto-bind / ADR-0058 Decision 2)", () => {
     expect(result.current.pauseModalOpen).toBe(true);
     expect(m.close).not.toHaveBeenCalled();
     expect(m.update).not.toHaveBeenCalled();
+  });
+
+  // ADR-0059: 1-tap 割り込みは PauseReasonModal を一切経由しない。timer.interrupt() が
+  // 直接走り、open entry を "interruption" で close して action_log は task_interrupted を残す。
+  test("onInterrupt は modal を開かず、interruption で entry を close + task_interrupted を log する", async () => {
+    const open = {
+      id: "te-open",
+      taskId: "t1",
+      startedAt: "2026-04-19T10:00:00.000Z",
+      pausedAt: null,
+      pauseReason: null,
+      durationSeconds: null,
+    };
+    m.list.mockResolvedValue([open]);
+    m.getOpen.mockResolvedValue(open);
+    const { Wrapper } = wrapTimer(m);
+    const { result } = renderHook(() => useTopTaskTimer({ ...baseTask, status: "active" }), {
+      wrapper: Wrapper,
+    });
+    await act(async () => {
+      result.current.topTimer.onInterrupt();
+    });
+    expect(result.current.pauseModalOpen).toBe(false);
+    expect(m.close).toHaveBeenCalledWith(open, "interruption");
+    expect(m.update).toHaveBeenCalledWith("t1", { status: "paused" });
+    expect(logMock).toHaveBeenCalledWith("task_interrupted", { task_id: "t1" });
   });
 
   test("handlePauseSelect で modal を閉じ、選んだ reason で pause を発火する", async () => {

--- a/src/app/useTopTaskTimer.ts
+++ b/src/app/useTopTaskTimer.ts
@@ -44,6 +44,11 @@ export function useTopTaskTimer(topTask: Task | null): UseTopTaskTimerResult {
       onComplete: () => {
         void timer.complete();
       },
+      // ADR-0059: 1-tap で interrupt を発火する。モーダルを挟まないので
+      // setPauseModalOpen は通らない (= reason 選択経路と完全に独立)。
+      onInterrupt: () => {
+        void timer.interrupt();
+      },
     }),
     [timer],
   );

--- a/src/app/useTopTaskTimer.ts
+++ b/src/app/useTopTaskTimer.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo, useState } from "react";
 
+import type { InterruptSource } from "@/entities/action-log/types";
 import type { PauseReason } from "@/entities/task/time-entries";
 import type { Task } from "@/entities/task/types";
 import type { TopTimerBinding } from "@/features/task-stack/TaskStack";
@@ -44,10 +45,10 @@ export function useTopTaskTimer(topTask: Task | null): UseTopTaskTimerResult {
       onComplete: () => {
         void timer.complete();
       },
-      // ADR-0059: 1-tap で interrupt を発火する。モーダルを挟まないので
-      // setPauseModalOpen は通らない (= reason 選択経路と完全に独立)。
-      onInterrupt: () => {
-        void timer.interrupt();
+      // ADR-0065: source を渡して 1-tap で interrupt を発火する。モーダルを
+      // 挟まないので setPauseModalOpen は通らない (= reason 選択経路と完全に独立)。
+      onInterrupt: (source: InterruptSource) => {
+        void timer.interrupt(source);
       },
     }),
     [timer],

--- a/src/entities/action-log/logger.test.ts
+++ b/src/entities/action-log/logger.test.ts
@@ -507,17 +507,37 @@ describe("log(task_interrupted)", () => {
     vi.restoreAllMocks();
   });
 
-  // ADR-0059: 1-tap 割り込みは task_id だけを metadata に持つ (時刻は created_at で十分、
-  // 分類は朝の棚卸し ADR-0062 で後追い)。column.task_id にも同じ値を書き、
-  // Phase 4 の「割り込み頻度 × 時間帯」分析が単純 SELECT で出せるようにする。
-  test("metadata に task_id のみを含めて insert する (column.task_id も同値)", async () => {
-    log(ACTION_TYPES.TASK_INTERRUPTED, { task_id: "t1" });
+  // ADR-0065: 1-tap 割り込みは task_id + source を metadata に持つ。
+  // column.task_id にも同じ値を書き、Phase 4 の「割り込み頻度 × 時間帯 × source」
+  // 分析が単純 SELECT で出せるようにする。
+  test("metadata に task_id + source を含めて insert する (column.task_id も同値)", async () => {
+    log(ACTION_TYPES.TASK_INTERRUPTED, { task_id: "t1", source: "slack" });
     await flushMicrotasks();
     expect(insertMock).toHaveBeenCalledWith({
       user_id: "user-1",
       action_type: "task_interrupted",
       task_id: "t1",
-      metadata: { task_id: "t1" },
+      metadata: { task_id: "t1", source: "slack" },
+      actor_type: "user",
+    });
+  });
+
+  test("source は notion / pr_review も同じ schema で insert できる", async () => {
+    log(ACTION_TYPES.TASK_INTERRUPTED, { task_id: "t1", source: "notion" });
+    log(ACTION_TYPES.TASK_INTERRUPTED, { task_id: "t1", source: "pr_review" });
+    await flushMicrotasks();
+    expect(insertMock).toHaveBeenNthCalledWith(1, {
+      user_id: "user-1",
+      action_type: "task_interrupted",
+      task_id: "t1",
+      metadata: { task_id: "t1", source: "notion" },
+      actor_type: "user",
+    });
+    expect(insertMock).toHaveBeenNthCalledWith(2, {
+      user_id: "user-1",
+      action_type: "task_interrupted",
+      task_id: "t1",
+      metadata: { task_id: "t1", source: "pr_review" },
       actor_type: "user",
     });
   });

--- a/src/entities/action-log/logger.test.ts
+++ b/src/entities/action-log/logger.test.ts
@@ -202,6 +202,7 @@ describe("ACTION_TYPES", () => {
       TASK_DEPENDENCY_CLEARED: "task_dependency_cleared",
       INTERRUPTION_PUSHED: "interruption_pushed",
       INTERRUPTION_COMPLETED: "interruption_completed",
+      TASK_INTERRUPTED: "task_interrupted",
       STACK_PROPOSED: "stack_proposed",
       STACK_PROPOSAL_ACCEPTED: "stack_proposal_accepted",
       CALENDAR_SYNCED: "calendar_synced",
@@ -487,6 +488,36 @@ describe("log(task_category_changed)", () => {
       action_type: "task_category_changed",
       task_id: "t1",
       metadata: { task_id: "t1", from: "doc", to: "research" },
+      actor_type: "user",
+    });
+  });
+});
+
+describe("log(task_interrupted)", () => {
+  beforeEach(() => {
+    clearLog();
+    __resetLoggerClientForTest();
+    insertMock.mockClear();
+    fromMock.mockClear();
+    getUserMock.mockClear();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ADR-0059: 1-tap 割り込みは task_id だけを metadata に持つ (時刻は created_at で十分、
+  // 分類は朝の棚卸し ADR-0062 で後追い)。column.task_id にも同じ値を書き、
+  // Phase 4 の「割り込み頻度 × 時間帯」分析が単純 SELECT で出せるようにする。
+  test("metadata に task_id のみを含めて insert する (column.task_id も同値)", async () => {
+    log(ACTION_TYPES.TASK_INTERRUPTED, { task_id: "t1" });
+    await flushMicrotasks();
+    expect(insertMock).toHaveBeenCalledWith({
+      user_id: "user-1",
+      action_type: "task_interrupted",
+      task_id: "t1",
+      metadata: { task_id: "t1" },
       actor_type: "user",
     });
   });

--- a/src/entities/action-log/logger.ts
+++ b/src/entities/action-log/logger.ts
@@ -30,8 +30,9 @@ export const ACTION_TYPES = Object.freeze({
   TASK_DEPENDENCY_CLEARED: "task_dependency_cleared",
   INTERRUPTION_PUSHED: "interruption_pushed",
   INTERRUPTION_COMPLETED: "interruption_completed",
-  // ADR-0059: 1-tap 割り込み記録。task_paused とは別系統で、「事前分類なし」の
-  // 1 タップ操作だったことを後段の朝の棚卸し / 行動分析が区別できるようにする。
+  // ADR-0065: source 別の 1-tap 割り込み記録。metadata.source に Slack /
+  // Notion / PR Review 等の発生源を保持し、task_paused (モーダル経由の中断)
+  // と区別する。source 値の union 制約は types.ts の InterruptSource に集約。
   TASK_INTERRUPTED: "task_interrupted",
   STACK_PROPOSED: "stack_proposed",
   STACK_PROPOSAL_ACCEPTED: "stack_proposal_accepted",

--- a/src/entities/action-log/logger.ts
+++ b/src/entities/action-log/logger.ts
@@ -30,6 +30,9 @@ export const ACTION_TYPES = Object.freeze({
   TASK_DEPENDENCY_CLEARED: "task_dependency_cleared",
   INTERRUPTION_PUSHED: "interruption_pushed",
   INTERRUPTION_COMPLETED: "interruption_completed",
+  // ADR-0059: 1-tap 割り込み記録。task_paused とは別系統で、「事前分類なし」の
+  // 1 タップ操作だったことを後段の朝の棚卸し / 行動分析が区別できるようにする。
+  TASK_INTERRUPTED: "task_interrupted",
   STACK_PROPOSED: "stack_proposed",
   STACK_PROPOSAL_ACCEPTED: "stack_proposal_accepted",
   CALENDAR_SYNCED: "calendar_synced",

--- a/src/entities/action-log/types.ts
+++ b/src/entities/action-log/types.ts
@@ -91,6 +91,14 @@ export type DecompositionModifiedKind =
 
 export type PauseReason = "meeting" | "interruption" | "voluntary";
 
+/**
+ * ADR-0065: 1-tap 割り込みボタンの発生源 (source) 列挙。dogfooding 初期は
+ * hardcoded の 3 値で開始する。user-defined source を将来追加するときは
+ * union を緩めて (string) 受ける形に変える。DB (`action_logs.metadata`) は
+ * JSONB なので schema 変更なしに増減できる。
+ */
+export type InterruptSource = "slack" | "notion" | "pr_review";
+
 /** Google Calendar 同期がどの経路でトリガーされたか。Phase 4 の頻度分析に使う (#51)。 */
 export type CalendarSyncTrigger = "manual" | "lazy";
 
@@ -172,10 +180,11 @@ export type ActionMetadataMap = {
   };
   interruption_pushed: { task_id: string };
   interruption_completed: { task_id: string };
-  // ADR-0059: 1-tap 割り込み記録。timer を停止した時点の task_id のみ。
-  // 分類 / 振り返り / タスク化は朝の棚卸し (ADR-0062) で後追いするため、
-  // ここに分類フィールドは持たない (中断理由は close 時の pause_reason で別途記録される)。
-  task_interrupted: { task_id: string };
+  // ADR-0065: 1-tap 割り込み記録。timer を停止した時点の task_id + 押した
+  // ボタンの source (発生源) を保持する。source は user 視点で割り込み発生時に
+  // 確定している情報なので、事前 1-tap の時点で記録するのが最も情報量が高い
+  // (朝の棚卸しでの事後復元には頼らない)。
+  task_interrupted: { task_id: string; source: InterruptSource };
   stack_proposed: Record<string, unknown>;
   stack_proposal_accepted: Record<string, unknown>;
   calendar_synced: {

--- a/src/entities/action-log/types.ts
+++ b/src/entities/action-log/types.ts
@@ -12,6 +12,11 @@ export type ActionType =
   | "task_dependency_cleared"
   | "interruption_pushed"
   | "interruption_completed"
+  // ADR-0059: 1-tap 割り込みボタンで timer を停止した瞬間を記録する。
+  // 「事前分類は要求しない」設計なので metadata は task_id のみ。
+  // 旧 architecture §1.4 の interruption_pushed / interruption_completed
+  // (push/pop モデル) からは離れた別系統のシグナル。
+  | "task_interrupted"
   | "stack_proposed"
   | "stack_proposal_accepted"
   | "calendar_synced"
@@ -167,6 +172,10 @@ export type ActionMetadataMap = {
   };
   interruption_pushed: { task_id: string };
   interruption_completed: { task_id: string };
+  // ADR-0059: 1-tap 割り込み記録。timer を停止した時点の task_id のみ。
+  // 分類 / 振り返り / タスク化は朝の棚卸し (ADR-0062) で後追いするため、
+  // ここに分類フィールドは持たない (中断理由は close 時の pause_reason で別途記録される)。
+  task_interrupted: { task_id: string };
   stack_proposed: Record<string, unknown>;
   stack_proposal_accepted: Record<string, unknown>;
   calendar_synced: {

--- a/src/features/task-stack/TaskStack.test.tsx
+++ b/src/features/task-stack/TaskStack.test.tsx
@@ -149,7 +149,7 @@ describe("TopTaskCard", () => {
   // ADR-0065: source 別 1-tap 割り込みは active 中だけ Slack / Notion / PR Review の
   // 3 ボタンを並べる。各クリックで onInterrupt(source) が 1 回発火し、reason
   // 選択モーダル (onPauseRequest) は経由しない。
-  test("active タスクは『Slack / Notion / PR Review 割り込み』3 ボタンを表示し、押下で onInterrupt(source) が発火する", () => {
+  test("active タスクは『Slack / Notion / レビュー 割り込み』3 ボタンを表示し、押下で onInterrupt(source) が発火する", () => {
     const onInterrupt = vi.fn();
     const onPauseRequest = vi.fn();
     const { getByLabelText } = render(
@@ -164,7 +164,7 @@ describe("TopTaskCard", () => {
     expect(onInterrupt).toHaveBeenLastCalledWith("slack");
     fireEvent.click(getByLabelText("Notion 割り込み"));
     expect(onInterrupt).toHaveBeenLastCalledWith("notion");
-    fireEvent.click(getByLabelText("PR Review 割り込み"));
+    fireEvent.click(getByLabelText("レビュー 割り込み"));
     expect(onInterrupt).toHaveBeenLastCalledWith("pr_review");
     expect(onInterrupt).toHaveBeenCalledTimes(3);
     expect(onPauseRequest).not.toHaveBeenCalled();
@@ -176,7 +176,7 @@ describe("TopTaskCard", () => {
     );
     expect(queryByLabelText("Slack 割り込み")).toBeNull();
     expect(queryByLabelText("Notion 割り込み")).toBeNull();
-    expect(queryByLabelText("PR Review 割り込み")).toBeNull();
+    expect(queryByLabelText("レビュー 割り込み")).toBeNull();
     rerender(
       <TopTaskCard
         {...topProps}
@@ -186,7 +186,7 @@ describe("TopTaskCard", () => {
     );
     expect(queryByLabelText("Slack 割り込み")).toBeNull();
     expect(queryByLabelText("Notion 割り込み")).toBeNull();
-    expect(queryByLabelText("PR Review 割り込み")).toBeNull();
+    expect(queryByLabelText("レビュー 割り込み")).toBeNull();
   });
 
   test("paused タスクは『再開』+『完了』を表示する", () => {

--- a/src/features/task-stack/TaskStack.test.tsx
+++ b/src/features/task-stack/TaskStack.test.tsx
@@ -146,9 +146,10 @@ describe("TopTaskCard", () => {
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
 
-  // ADR-0059: 1-tap 割り込みは active 中だけ表示する。クリックで onInterrupt が
-  // 1 回発火し、reason 選択モーダルは経由しない (= onPauseRequest は呼ばれない)。
-  test("active タスクは『割り込み』ボタンも表示し、押下で onInterrupt が発火する", () => {
+  // ADR-0065: source 別 1-tap 割り込みは active 中だけ Slack / Notion / PR Review の
+  // 3 ボタンを並べる。各クリックで onInterrupt(source) が 1 回発火し、reason
+  // 選択モーダル (onPauseRequest) は経由しない。
+  test("active タスクは『Slack / Notion / PR Review 割り込み』3 ボタンを表示し、押下で onInterrupt(source) が発火する", () => {
     const onInterrupt = vi.fn();
     const onPauseRequest = vi.fn();
     const { getByLabelText } = render(
@@ -159,16 +160,23 @@ describe("TopTaskCard", () => {
         onInterrupt={onInterrupt}
       />,
     );
-    fireEvent.click(getByLabelText("割り込み"));
-    expect(onInterrupt).toHaveBeenCalledTimes(1);
+    fireEvent.click(getByLabelText("Slack 割り込み"));
+    expect(onInterrupt).toHaveBeenLastCalledWith("slack");
+    fireEvent.click(getByLabelText("Notion 割り込み"));
+    expect(onInterrupt).toHaveBeenLastCalledWith("notion");
+    fireEvent.click(getByLabelText("PR Review 割り込み"));
+    expect(onInterrupt).toHaveBeenLastCalledWith("pr_review");
+    expect(onInterrupt).toHaveBeenCalledTimes(3);
     expect(onPauseRequest).not.toHaveBeenCalled();
   });
 
-  test("idle / paused では『割り込み』ボタンは表示しない (= active のみ)", () => {
+  test("idle / paused では割り込みボタン群を表示しない (= active のみ)", () => {
     const { queryByLabelText, rerender } = render(
       <TopTaskCard {...topProps} task={{ ...baseTask, status: "idle" }} />,
     );
-    expect(queryByLabelText("割り込み")).toBeNull();
+    expect(queryByLabelText("Slack 割り込み")).toBeNull();
+    expect(queryByLabelText("Notion 割り込み")).toBeNull();
+    expect(queryByLabelText("PR Review 割り込み")).toBeNull();
     rerender(
       <TopTaskCard
         {...topProps}
@@ -176,7 +184,9 @@ describe("TopTaskCard", () => {
         pauseReason="voluntary"
       />,
     );
-    expect(queryByLabelText("割り込み")).toBeNull();
+    expect(queryByLabelText("Slack 割り込み")).toBeNull();
+    expect(queryByLabelText("Notion 割り込み")).toBeNull();
+    expect(queryByLabelText("PR Review 割り込み")).toBeNull();
   });
 
   test("paused タスクは『再開』+『完了』を表示する", () => {

--- a/src/features/task-stack/TaskStack.test.tsx
+++ b/src/features/task-stack/TaskStack.test.tsx
@@ -72,6 +72,7 @@ const idleTimer: TopTimerBinding = {
   onPauseRequest: noop,
   onResume: noop,
   onComplete: noop,
+  onInterrupt: noop,
 };
 
 const NOW_MS = FIXED_NOW.getTime();
@@ -88,6 +89,7 @@ const topProps = {
   onPauseRequest: noop,
   onResume: noop,
   onComplete: noop,
+  onInterrupt: noop,
 };
 
 describe("TopTaskCard", () => {
@@ -142,6 +144,39 @@ describe("TopTaskCard", () => {
     expect(onPauseRequest).toHaveBeenCalledTimes(1);
     fireEvent.click(getByLabelText("完了"));
     expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  // ADR-0059: 1-tap 割り込みは active 中だけ表示する。クリックで onInterrupt が
+  // 1 回発火し、reason 選択モーダルは経由しない (= onPauseRequest は呼ばれない)。
+  test("active タスクは『割り込み』ボタンも表示し、押下で onInterrupt が発火する", () => {
+    const onInterrupt = vi.fn();
+    const onPauseRequest = vi.fn();
+    const { getByLabelText } = render(
+      <TopTaskCard
+        {...topProps}
+        task={{ ...baseTask, status: "active" }}
+        onPauseRequest={onPauseRequest}
+        onInterrupt={onInterrupt}
+      />,
+    );
+    fireEvent.click(getByLabelText("割り込み"));
+    expect(onInterrupt).toHaveBeenCalledTimes(1);
+    expect(onPauseRequest).not.toHaveBeenCalled();
+  });
+
+  test("idle / paused では『割り込み』ボタンは表示しない (= active のみ)", () => {
+    const { queryByLabelText, rerender } = render(
+      <TopTaskCard {...topProps} task={{ ...baseTask, status: "idle" }} />,
+    );
+    expect(queryByLabelText("割り込み")).toBeNull();
+    rerender(
+      <TopTaskCard
+        {...topProps}
+        task={{ ...baseTask, status: "paused" }}
+        pauseReason="voluntary"
+      />,
+    );
+    expect(queryByLabelText("割り込み")).toBeNull();
   });
 
   test("paused タスクは『再開』+『完了』を表示する", () => {

--- a/src/features/task-stack/TaskStack.tsx
+++ b/src/features/task-stack/TaskStack.tsx
@@ -33,6 +33,11 @@ export type TopTimerBinding = {
   onPauseRequest: () => void;
   onResume: () => void;
   onComplete: () => void;
+  /**
+   * ADR-0059: 1-tap 割り込み。active 時のみ表示する想定で、押下で timer を
+   * paused に落としつつ `task_interrupted` を 1 件記録する (reason モーダルは出さない)。
+   */
+  onInterrupt: () => void;
 };
 
 type TaskStackProps = {
@@ -148,6 +153,7 @@ export function TaskStack({
                   onPauseRequest={topTimer.onPauseRequest}
                   onResume={topTimer.onResume}
                   onComplete={topTimer.onComplete}
+                  onInterrupt={topTimer.onInterrupt}
                 />
               ) : (
                 <TaskRow

--- a/src/features/task-stack/TaskStack.tsx
+++ b/src/features/task-stack/TaskStack.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from "react";
 
+import type { InterruptSource } from "@/entities/action-log/types";
 import type { Event } from "@/entities/event/types";
 import type { PauseReason } from "@/entities/task/time-entries";
 import type { Task } from "@/entities/task/types";
@@ -34,10 +35,11 @@ export type TopTimerBinding = {
   onResume: () => void;
   onComplete: () => void;
   /**
-   * ADR-0059: 1-tap 割り込み。active 時のみ表示する想定で、押下で timer を
-   * paused に落としつつ `task_interrupted` を 1 件記録する (reason モーダルは出さない)。
+   * ADR-0065: source 別 1-tap 割り込み。active 時のみ表示する想定で、押下で
+   * timer を paused に落としつつ `task_interrupted` を 1 件記録する
+   * (metadata.source に発生源、reason モーダルは出さない)。
    */
-  onInterrupt: () => void;
+  onInterrupt: (source: InterruptSource) => void;
 };
 
 type TaskStackProps = {

--- a/src/features/task-stack/TopTaskCard.tsx
+++ b/src/features/task-stack/TopTaskCard.tsx
@@ -1,5 +1,6 @@
 import type { PointerEvent as ReactPointerEvent } from "react";
 
+import type { InterruptSource } from "@/entities/action-log/types";
 import type { Event } from "@/entities/event/types";
 import { getProject } from "@/entities/project/projects";
 import { useProjects } from "@/entities/project/ProjectsContext";
@@ -52,8 +53,12 @@ type TopTaskCardProps = {
   onPauseRequest: () => void;
   onResume: () => void;
   onComplete: () => void;
-  /** ADR-0059: active 中にだけ表示する 1-tap 割り込みボタンの押下 callback。 */
-  onInterrupt: () => void;
+  /**
+   * ADR-0065: active 中にだけ表示する source 別 1-tap 割り込みボタンの押下
+   * callback。Slack / Notion / PR Review の 3 ボタンが共通で本 callback を
+   * 呼び、引数 source で区別する。
+   */
+  onInterrupt: (source: InterruptSource) => void;
 };
 
 export function TopTaskCard({
@@ -277,8 +282,16 @@ type TimerControlsProps = {
   onPauseRequest: () => void;
   onResume: () => void;
   onComplete: () => void;
-  onInterrupt: () => void;
+  onInterrupt: (source: InterruptSource) => void;
 };
+
+// ADR-0065: 3 ボタンは hardcoded。設定経由の add/remove は未実装。
+// `label` は aria-label / title 共通で、e2e は role=button name=label で取れる。
+const INTERRUPT_SOURCES: readonly { source: InterruptSource; label: string; short: string }[] = [
+  { source: "slack", label: "Slack 割り込み", short: "S" },
+  { source: "notion", label: "Notion 割り込み", short: "N" },
+  { source: "pr_review", label: "PR Review 割り込み", short: "P" },
+] as const;
 
 function TimerControls({
   status,
@@ -294,9 +307,14 @@ function TimerControls({
     fn();
   };
   // Top-only complete (ADR 0016 §7): どの状態でも Complete を併置する。
-  // ADR-0059: 割り込みボタンは active 中だけ表示する (走っていないものは「割り込まれない」)。
+  // ADR-0065: source 別の割り込みボタン群は active 中だけ表示する。
+  //
+  // NOTE: 現在の Top カードは「停止 + 完了 + source 別割り込み × 3」で active 時に
+  // 5 ボタンが並ぶ。導線の正しさを優先して詰め込む暫定 UI。専有面積を含む
+  // タイマー UI 全体の再設計は別 issue で扱う (pomodoro 系 timer × task card の
+  // 融合、別 view の検討)。
   return (
-    <div className="flex shrink-0 items-center gap-1.5">
+    <div className="flex shrink-0 flex-wrap items-center justify-end gap-1.5">
       {status === "idle" && (
         <button
           type="button"
@@ -310,16 +328,19 @@ function TimerControls({
       )}
       {status === "active" && (
         <>
-          <button
-            type="button"
-            onClick={stop(onInterrupt)}
-            aria-label="割り込み"
-            title="割り込み (1-tap で停止 + 記録、分類は朝の棚卸しで)"
-            className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-lg bg-transparent"
-            style={{ border: `1.5px solid ${color}40`, color: "currentColor" }}
-          >
-            <BoltIcon />
-          </button>
+          {INTERRUPT_SOURCES.map((s) => (
+            <button
+              key={s.source}
+              type="button"
+              onClick={stop(() => onInterrupt(s.source))}
+              aria-label={s.label}
+              title={s.label}
+              className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-lg bg-transparent font-jp text-[10px] font-semibold"
+              style={{ border: `1.5px solid ${color}40`, color: "currentColor" }}
+            >
+              <span aria-hidden="true">⚡{s.short}</span>
+            </button>
+          ))}
           <button
             type="button"
             onClick={stop(onPauseRequest)}
@@ -368,15 +389,6 @@ function PauseIcon() {
     <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true">
       <rect x="2" y="2" width="3" height="8" rx="1" />
       <rect x="7" y="2" width="3" height="8" rx="1" />
-    </svg>
-  );
-}
-
-function BoltIcon() {
-  // ADR-0059: 1-tap 割り込みボタンのアイコン。⚡ を線で描画する。
-  return (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor" aria-hidden="true">
-      <polygon points="8,1 3,8 6.5,8 5,13 11,5 7.5,5" />
     </svg>
   );
 }

--- a/src/features/task-stack/TopTaskCard.tsx
+++ b/src/features/task-stack/TopTaskCard.tsx
@@ -287,15 +287,17 @@ type TimerControlsProps = {
 
 // ADR-0065: 3 ボタンは hardcoded。設定経由の add/remove は未実装。
 // `ariaLabel` は aria-label / title 共通 (e2e は role=button name=ariaLabel で取れる)。
-// `text` はボタン内に表示する短いラベル — アイコンより視認性 / 押し間違い低減を優先。
+// `text` + `Icon` をボタンに並べて表示する — アイコンだけだと識別速度が落ちる
+// ため文字と併置する。アイコン SVG は SimpleIcons (CC0) から currentColor で描画。
 const INTERRUPT_SOURCES: readonly {
   source: InterruptSource;
   ariaLabel: string;
   text: string;
+  Icon: () => React.ReactElement;
 }[] = [
-  { source: "slack", ariaLabel: "Slack 割り込み", text: "Slack" },
-  { source: "notion", ariaLabel: "Notion 割り込み", text: "Notion" },
-  { source: "pr_review", ariaLabel: "レビュー 割り込み", text: "レビュー" },
+  { source: "slack", ariaLabel: "Slack 割り込み", text: "Slack", Icon: SlackIcon },
+  { source: "notion", ariaLabel: "Notion 割り込み", text: "Notion", Icon: NotionIcon },
+  { source: "pr_review", ariaLabel: "レビュー 割り込み", text: "レビュー", Icon: GitHubIcon },
 ] as const;
 
 function TimerControls({
@@ -333,19 +335,23 @@ function TimerControls({
       )}
       {status === "active" && (
         <>
-          {INTERRUPT_SOURCES.map((s) => (
-            <button
-              key={s.source}
-              type="button"
-              onClick={stop(() => onInterrupt(s.source))}
-              aria-label={s.ariaLabel}
-              title={s.ariaLabel}
-              className="flex h-9 cursor-pointer items-center rounded-lg bg-transparent px-2 font-jp text-[10px] font-semibold"
-              style={{ border: `1.5px solid ${color}40`, color: "currentColor" }}
-            >
-              {s.text}
-            </button>
-          ))}
+          {INTERRUPT_SOURCES.map((s) => {
+            const Icon = s.Icon;
+            return (
+              <button
+                key={s.source}
+                type="button"
+                onClick={stop(() => onInterrupt(s.source))}
+                aria-label={s.ariaLabel}
+                title={s.ariaLabel}
+                className="flex h-9 cursor-pointer items-center gap-1 rounded-lg bg-transparent px-2 font-jp text-[10px] font-semibold"
+                style={{ border: `1.5px solid ${color}40`, color: "currentColor" }}
+              >
+                <Icon />
+                {s.text}
+              </button>
+            );
+          })}
           <button
             type="button"
             onClick={stop(onPauseRequest)}
@@ -408,6 +414,33 @@ function CheckIcon() {
         strokeLinecap="round"
         strokeLinejoin="round"
       />
+    </svg>
+  );
+}
+
+// 以下 3 つは SimpleIcons (https://simpleicons.org/) の path を currentColor で
+// 描画したブランドマーク。SimpleIcons の path 集合は CC0 (Public Domain)。
+// ボタン用に viewBox 24 → 表示 12px に縮小して使う。
+function SlackIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zM6.313 15.165a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zM8.834 6.313a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zM18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zM17.688 8.834a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zM15.165 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zM15.165 17.688a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z" />
+    </svg>
+  );
+}
+
+function NotionIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M4.459 4.208c.746.606 1.026.56 2.428.466l13.215-.793c.28 0 .047-.28-.046-.326L17.86 1.968c-.42-.326-.981-.7-2.055-.607L3.01 2.295c-.466.046-.56.28-.374.466zm.793 3.08v13.904c0 .747.373 1.027 1.214.98l14.523-.84c.841-.046.935-.56.935-1.167V6.354c0-.606-.233-.933-.748-.887l-15.177.887c-.56.047-.747.327-.747.933zm14.337.745c.093.42 0 .84-.42.888l-.7.14v10.264c-.608.327-1.168.514-1.635.514-.747 0-.934-.234-1.495-.933l-4.577-7.186v6.952L12.21 19s0 .84-1.168.84l-3.222.186c-.093-.186 0-.653.327-.746l.84-.233V9.854L7.822 9.76c-.094-.42.14-1.026.793-1.073l3.456-.233 4.764 7.279v-6.44l-1.215-.139c-.093-.514.28-.887.747-.933zM1.936 1.035l13.31-.98c1.634-.14 2.055-.047 3.082.7l4.249 2.987c.7.513.934.653.934 1.213v16.378c0 1.026-.373 1.634-1.68 1.726l-15.458.934c-.98.047-1.448-.093-1.962-.747l-3.129-4.06c-.56-.747-.793-1.306-.793-1.96V2.667c0-.839.374-1.54 1.447-1.632z" />
+    </svg>
+  );
+}
+
+function GitHubIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
     </svg>
   );
 }

--- a/src/features/task-stack/TopTaskCard.tsx
+++ b/src/features/task-stack/TopTaskCard.tsx
@@ -286,11 +286,16 @@ type TimerControlsProps = {
 };
 
 // ADR-0065: 3 ボタンは hardcoded。設定経由の add/remove は未実装。
-// `label` は aria-label / title 共通で、e2e は role=button name=label で取れる。
-const INTERRUPT_SOURCES: readonly { source: InterruptSource; label: string; short: string }[] = [
-  { source: "slack", label: "Slack 割り込み", short: "S" },
-  { source: "notion", label: "Notion 割り込み", short: "N" },
-  { source: "pr_review", label: "PR Review 割り込み", short: "P" },
+// `ariaLabel` は aria-label / title 共通 (e2e は role=button name=ariaLabel で取れる)。
+// `text` はボタン内に表示する短いラベル — アイコンより視認性 / 押し間違い低減を優先。
+const INTERRUPT_SOURCES: readonly {
+  source: InterruptSource;
+  ariaLabel: string;
+  text: string;
+}[] = [
+  { source: "slack", ariaLabel: "Slack 割り込み", text: "Slack" },
+  { source: "notion", ariaLabel: "Notion 割り込み", text: "Notion" },
+  { source: "pr_review", ariaLabel: "レビュー 割り込み", text: "レビュー" },
 ] as const;
 
 function TimerControls({
@@ -333,12 +338,12 @@ function TimerControls({
               key={s.source}
               type="button"
               onClick={stop(() => onInterrupt(s.source))}
-              aria-label={s.label}
-              title={s.label}
-              className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-lg bg-transparent font-jp text-[10px] font-semibold"
+              aria-label={s.ariaLabel}
+              title={s.ariaLabel}
+              className="flex h-9 cursor-pointer items-center rounded-lg bg-transparent px-2 font-jp text-[10px] font-semibold"
               style={{ border: `1.5px solid ${color}40`, color: "currentColor" }}
             >
-              <span aria-hidden="true">⚡{s.short}</span>
+              {s.text}
             </button>
           ))}
           <button

--- a/src/features/task-stack/TopTaskCard.tsx
+++ b/src/features/task-stack/TopTaskCard.tsx
@@ -52,6 +52,8 @@ type TopTaskCardProps = {
   onPauseRequest: () => void;
   onResume: () => void;
   onComplete: () => void;
+  /** ADR-0059: active 中にだけ表示する 1-tap 割り込みボタンの押下 callback。 */
+  onInterrupt: () => void;
 };
 
 export function TopTaskCard({
@@ -69,6 +71,7 @@ export function TopTaskCard({
   onPauseRequest,
   onResume,
   onComplete,
+  onInterrupt,
 }: TopTaskCardProps) {
   const { projectsById } = useProjects();
   const proj = getProject(projectsById, task.projectId);
@@ -160,6 +163,7 @@ export function TopTaskCard({
               onPauseRequest={onPauseRequest}
               onResume={onResume}
               onComplete={onComplete}
+              onInterrupt={onInterrupt}
             />
           </div>
           {preview && (
@@ -273,6 +277,7 @@ type TimerControlsProps = {
   onPauseRequest: () => void;
   onResume: () => void;
   onComplete: () => void;
+  onInterrupt: () => void;
 };
 
 function TimerControls({
@@ -282,12 +287,14 @@ function TimerControls({
   onPauseRequest,
   onResume,
   onComplete,
+  onInterrupt,
 }: TimerControlsProps) {
   const stop = (fn: () => void) => (e: React.MouseEvent) => {
     e.stopPropagation();
     fn();
   };
   // Top-only complete (ADR 0016 §7): どの状態でも Complete を併置する。
+  // ADR-0059: 割り込みボタンは active 中だけ表示する (走っていないものは「割り込まれない」)。
   return (
     <div className="flex shrink-0 items-center gap-1.5">
       {status === "idle" && (
@@ -302,15 +309,27 @@ function TimerControls({
         </button>
       )}
       {status === "active" && (
-        <button
-          type="button"
-          onClick={stop(onPauseRequest)}
-          aria-label="中断"
-          className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-lg bg-transparent"
-          style={{ border: `1.5px solid ${color}40`, color: "currentColor" }}
-        >
-          <PauseIcon />
-        </button>
+        <>
+          <button
+            type="button"
+            onClick={stop(onInterrupt)}
+            aria-label="割り込み"
+            title="割り込み (1-tap で停止 + 記録、分類は朝の棚卸しで)"
+            className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-lg bg-transparent"
+            style={{ border: `1.5px solid ${color}40`, color: "currentColor" }}
+          >
+            <BoltIcon />
+          </button>
+          <button
+            type="button"
+            onClick={stop(onPauseRequest)}
+            aria-label="中断"
+            className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-lg bg-transparent"
+            style={{ border: `1.5px solid ${color}40`, color: "currentColor" }}
+          >
+            <PauseIcon />
+          </button>
+        </>
       )}
       {status === "paused" && (
         <button
@@ -349,6 +368,15 @@ function PauseIcon() {
     <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true">
       <rect x="2" y="2" width="3" height="8" rx="1" />
       <rect x="7" y="2" width="3" height="8" rx="1" />
+    </svg>
+  );
+}
+
+function BoltIcon() {
+  // ADR-0059: 1-tap 割り込みボタンのアイコン。⚡ を線で描画する。
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor" aria-hidden="true">
+      <polygon points="8,1 3,8 6.5,8 5,13 11,5 7.5,5" />
     </svg>
   );
 }

--- a/src/features/task-stack/useTaskTimer.test.tsx
+++ b/src/features/task-stack/useTaskTimer.test.tsx
@@ -17,6 +17,7 @@ vi.mock("@/entities/action-log/logger", () => ({
     TASK_TITLE_CHANGED: "task_title_changed",
     INTERRUPTION_PUSHED: "interruption_pushed",
     INTERRUPTION_COMPLETED: "interruption_completed",
+    TASK_INTERRUPTED: "task_interrupted",
     STACK_PROPOSED: "stack_proposed",
     STACK_PROPOSAL_ACCEPTED: "stack_proposal_accepted",
   }),
@@ -105,7 +106,7 @@ describe("useTaskTimer", () => {
     vi.restoreAllMocks();
   });
 
-  test("task=null のとき start/pause/resume/complete は no-op", async () => {
+  test("task=null のとき start/pause/resume/complete/interrupt は no-op", async () => {
     const { Wrapper } = wrapTimer(m);
     const { result } = renderHook(() => useTaskTimer(null), {
       wrapper: Wrapper,
@@ -115,6 +116,7 @@ describe("useTaskTimer", () => {
       await result.current.pause("voluntary");
       await result.current.resume();
       await result.current.complete();
+      await result.current.interrupt();
     });
     expect(m.start).not.toHaveBeenCalled();
     expect(m.update).not.toHaveBeenCalled();
@@ -183,6 +185,54 @@ describe("useTaskTimer", () => {
       task_id: "t1",
       pause_reason: "meeting",
     });
+  });
+
+  // ADR-0059: 1-tap 割り込みは pause と同じ状態遷移 (active → paused) を踏むが、
+  // - pause_reason は "interruption" 固定 (モーダル経由ではない)
+  // - action_log は task_paused ではなく task_interrupted だけを残す
+  // ことで「reason 選択モーダル経由の中断」と「1-tap 割り込み」を後段で区別できる。
+  test("interrupt: open entry を interruption で閉じ、status=paused、TASK_INTERRUPTED ログ (task_paused は出さない)", async () => {
+    const open = {
+      id: "te-open",
+      taskId: "t1",
+      startedAt: "2026-04-19T10:00:00.000Z",
+      pausedAt: null,
+      pauseReason: null,
+      durationSeconds: null,
+    };
+    m.list.mockResolvedValue([open]);
+    m.getOpen.mockResolvedValue(open);
+    const activeTask: Task = { ...baseTask, status: "active" };
+    const { Wrapper } = wrapTimer(m);
+    const { result } = renderHook(() => useTaskTimer(activeTask), {
+      wrapper: Wrapper,
+    });
+    await act(async () => {
+      await result.current.interrupt();
+    });
+    expect(m.close).toHaveBeenCalledWith(open, "interruption");
+    expect(m.update).toHaveBeenCalledWith("t1", { status: "paused" });
+    expect(logMock).toHaveBeenCalledWith("task_interrupted", { task_id: "t1" });
+    // task_paused は打たない (= ADR-0059 の「1-tap だった」シグナルを混ぜない)
+    expect(logMock).not.toHaveBeenCalledWith("task_paused", expect.anything());
+  });
+
+  test("interrupt: open entry が無い場合でも status=paused に遷移し、TASK_INTERRUPTED を残す", async () => {
+    // 既に paused になっている (= race で別タブが close 済み) ケースのフォールバック。
+    // close は呼ばれないが status 更新とログは行う。
+    m.list.mockResolvedValue([]);
+    m.getOpen.mockResolvedValue(null);
+    const activeTask: Task = { ...baseTask, status: "active" };
+    const { Wrapper } = wrapTimer(m);
+    const { result } = renderHook(() => useTaskTimer(activeTask), {
+      wrapper: Wrapper,
+    });
+    await act(async () => {
+      await result.current.interrupt();
+    });
+    expect(m.close).not.toHaveBeenCalled();
+    expect(m.update).toHaveBeenCalledWith("t1", { status: "paused" });
+    expect(logMock).toHaveBeenCalledWith("task_interrupted", { task_id: "t1" });
   });
 
   test("resume: 新規 entry 作成 + status=active + TASK_RESUMED ログ", async () => {

--- a/src/features/task-stack/useTaskTimer.test.tsx
+++ b/src/features/task-stack/useTaskTimer.test.tsx
@@ -116,7 +116,7 @@ describe("useTaskTimer", () => {
       await result.current.pause("voluntary");
       await result.current.resume();
       await result.current.complete();
-      await result.current.interrupt();
+      await result.current.interrupt("slack");
     });
     expect(m.start).not.toHaveBeenCalled();
     expect(m.update).not.toHaveBeenCalled();
@@ -187,11 +187,13 @@ describe("useTaskTimer", () => {
     });
   });
 
-  // ADR-0059: 1-tap 割り込みは pause と同じ状態遷移 (active → paused) を踏むが、
+  // ADR-0065: source 別 1-tap 割り込みは pause と同じ状態遷移 (active → paused)
+  // を踏むが、
   // - pause_reason は "interruption" 固定 (モーダル経由ではない)
-  // - action_log は task_paused ではなく task_interrupted だけを残す
-  // ことで「reason 選択モーダル経由の中断」と「1-tap 割り込み」を後段で区別できる。
-  test("interrupt: open entry を interruption で閉じ、status=paused、TASK_INTERRUPTED ログ (task_paused は出さない)", async () => {
+  // - action_log は task_paused ではなく task_interrupted + source を残す
+  // ことで「reason 選択モーダル経由の中断」と「source 別 1-tap 割り込み」を
+  // 後段で区別できる。
+  test("interrupt(slack): open entry を interruption で閉じ、source 付き TASK_INTERRUPTED を残す (task_paused は出さない)", async () => {
     const open = {
       id: "te-open",
       taskId: "t1",
@@ -208,13 +210,48 @@ describe("useTaskTimer", () => {
       wrapper: Wrapper,
     });
     await act(async () => {
-      await result.current.interrupt();
+      await result.current.interrupt("slack");
     });
     expect(m.close).toHaveBeenCalledWith(open, "interruption");
     expect(m.update).toHaveBeenCalledWith("t1", { status: "paused" });
-    expect(logMock).toHaveBeenCalledWith("task_interrupted", { task_id: "t1" });
-    // task_paused は打たない (= ADR-0059 の「1-tap だった」シグナルを混ぜない)
+    expect(logMock).toHaveBeenCalledWith("task_interrupted", {
+      task_id: "t1",
+      source: "slack",
+    });
+    // task_paused は打たない (= ADR-0065 の「source 別 1-tap」シグナルを混ぜない)
     expect(logMock).not.toHaveBeenCalledWith("task_paused", expect.anything());
+  });
+
+  test("interrupt(notion / pr_review): どの source でも同じフローで metadata.source だけが変わる", async () => {
+    const open = {
+      id: "te-open",
+      taskId: "t1",
+      startedAt: "2026-04-19T10:00:00.000Z",
+      pausedAt: null,
+      pauseReason: null,
+      durationSeconds: null,
+    };
+    m.list.mockResolvedValue([open]);
+    m.getOpen.mockResolvedValue(open);
+    const activeTask: Task = { ...baseTask, status: "active" };
+    const { Wrapper } = wrapTimer(m);
+    const { result } = renderHook(() => useTaskTimer(activeTask), {
+      wrapper: Wrapper,
+    });
+    await act(async () => {
+      await result.current.interrupt("notion");
+    });
+    expect(logMock).toHaveBeenLastCalledWith("task_interrupted", {
+      task_id: "t1",
+      source: "notion",
+    });
+    await act(async () => {
+      await result.current.interrupt("pr_review");
+    });
+    expect(logMock).toHaveBeenLastCalledWith("task_interrupted", {
+      task_id: "t1",
+      source: "pr_review",
+    });
   });
 
   test("interrupt: open entry が無い場合でも status=paused に遷移し、TASK_INTERRUPTED を残す", async () => {
@@ -228,11 +265,14 @@ describe("useTaskTimer", () => {
       wrapper: Wrapper,
     });
     await act(async () => {
-      await result.current.interrupt();
+      await result.current.interrupt("slack");
     });
     expect(m.close).not.toHaveBeenCalled();
     expect(m.update).toHaveBeenCalledWith("t1", { status: "paused" });
-    expect(logMock).toHaveBeenCalledWith("task_interrupted", { task_id: "t1" });
+    expect(logMock).toHaveBeenCalledWith("task_interrupted", {
+      task_id: "t1",
+      source: "slack",
+    });
   });
 
   test("resume: 新規 entry 作成 + status=active + TASK_RESUMED ログ", async () => {

--- a/src/features/task-stack/useTaskTimer.ts
+++ b/src/features/task-stack/useTaskTimer.ts
@@ -4,6 +4,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { ACTION_TYPES, log } from "@/entities/action-log/logger";
+import type { InterruptSource } from "@/entities/action-log/types";
 import { type PauseReason, sumDurationSeconds, type TimeEntry } from "@/entities/task/time-entries";
 import type { Task } from "@/entities/task/types";
 import { useTaskGateway, useTaskTimeEntryGateway } from "@/shared/gateway/GatewayContext";
@@ -26,14 +27,13 @@ type TaskTimerApi = {
   resume: () => Promise<void>;
   complete: () => Promise<void>;
   /**
-   * ADR-0059: 1-tap 割り込み。pause と同じ状態遷移 (active → paused) を踏むが、
-   * reason 選択モーダルを挟まず、time_entries は `pause_reason="interruption"`
-   * で閉じる。action_log は `task_paused` ではなく `task_interrupted` を 1 件
-   * だけ落とし、1 タップ操作だったことを後段の朝の棚卸し / 行動分析が識別できる
-   * ようにする (= 同じ pause_reason="interruption" でも、モーダル経由の中断と
-   * 1-tap 割り込みは action_log 上で区別される)。
+   * ADR-0065: source 別 1-tap 割り込み。pause と同じ状態遷移 (active → paused)
+   * を踏むが、reason 選択モーダルを挟まず、time_entries は
+   * `pause_reason="interruption"` で閉じる。action_log は `task_paused` ではなく
+   * `task_interrupted` を 1 件だけ落とし、metadata.source に押したボタンの発生源
+   * (Slack / Notion / PR Review) を保持する。
    */
-  interrupt: () => Promise<void>;
+  interrupt: (source: InterruptSource) => Promise<void>;
 };
 
 /**
@@ -133,19 +133,23 @@ export function useTaskTimer(task: Task | null): TaskTimerApi {
     [task, openEntry, taskGateway, taskTimeEntryGateway, invalidate],
   );
 
-  const interrupt = useCallback(async () => {
-    if (!task) return;
-    const open = openEntry ?? (await taskTimeEntryGateway.getOpen(task.id));
-    if (open) {
-      await taskTimeEntryGateway.close(open, "interruption");
-    }
-    await taskGateway.update(task.id, { status: "paused" });
-    // ADR-0059: 1-tap 割り込みは task_paused を打たず task_interrupted のみ。
-    // state 遷移 (active → paused) は task_time_entries.paused_at と
-    // tasks.status で再構成可能なので、action_log では「1-tap だった」事実だけを残す。
-    log(ACTION_TYPES.TASK_INTERRUPTED, { task_id: task.id });
-    await invalidate();
-  }, [task, openEntry, taskGateway, taskTimeEntryGateway, invalidate]);
+  const interrupt = useCallback(
+    async (source: InterruptSource) => {
+      if (!task) return;
+      const open = openEntry ?? (await taskTimeEntryGateway.getOpen(task.id));
+      if (open) {
+        await taskTimeEntryGateway.close(open, "interruption");
+      }
+      await taskGateway.update(task.id, { status: "paused" });
+      // ADR-0065: 1-tap 割り込みは task_paused を打たず task_interrupted のみ。
+      // state 遷移 (active → paused) は task_time_entries.paused_at と
+      // tasks.status で再構成可能なので、action_log では「どの source からの
+      // 1-tap だったか」を残す。
+      log(ACTION_TYPES.TASK_INTERRUPTED, { task_id: task.id, source });
+      await invalidate();
+    },
+    [task, openEntry, taskGateway, taskTimeEntryGateway, invalidate],
+  );
 
   const resume = useCallback(async () => {
     if (!task) return;

--- a/src/features/task-stack/useTaskTimer.ts
+++ b/src/features/task-stack/useTaskTimer.ts
@@ -25,6 +25,15 @@ type TaskTimerApi = {
   pause: (reason: PauseReason) => Promise<void>;
   resume: () => Promise<void>;
   complete: () => Promise<void>;
+  /**
+   * ADR-0059: 1-tap 割り込み。pause と同じ状態遷移 (active → paused) を踏むが、
+   * reason 選択モーダルを挟まず、time_entries は `pause_reason="interruption"`
+   * で閉じる。action_log は `task_paused` ではなく `task_interrupted` を 1 件
+   * だけ落とし、1 タップ操作だったことを後段の朝の棚卸し / 行動分析が識別できる
+   * ようにする (= 同じ pause_reason="interruption" でも、モーダル経由の中断と
+   * 1-tap 割り込みは action_log 上で区別される)。
+   */
+  interrupt: () => Promise<void>;
 };
 
 /**
@@ -124,6 +133,20 @@ export function useTaskTimer(task: Task | null): TaskTimerApi {
     [task, openEntry, taskGateway, taskTimeEntryGateway, invalidate],
   );
 
+  const interrupt = useCallback(async () => {
+    if (!task) return;
+    const open = openEntry ?? (await taskTimeEntryGateway.getOpen(task.id));
+    if (open) {
+      await taskTimeEntryGateway.close(open, "interruption");
+    }
+    await taskGateway.update(task.id, { status: "paused" });
+    // ADR-0059: 1-tap 割り込みは task_paused を打たず task_interrupted のみ。
+    // state 遷移 (active → paused) は task_time_entries.paused_at と
+    // tasks.status で再構成可能なので、action_log では「1-tap だった」事実だけを残す。
+    log(ACTION_TYPES.TASK_INTERRUPTED, { task_id: task.id });
+    await invalidate();
+  }, [task, openEntry, taskGateway, taskTimeEntryGateway, invalidate]);
+
   const resume = useCallback(async () => {
     if (!task) return;
     await taskTimeEntryGateway.start(task.id);
@@ -169,6 +192,7 @@ export function useTaskTimer(task: Task | null): TaskTimerApi {
       pause,
       resume,
       complete,
+      interrupt,
     }),
     [
       isActive,
@@ -181,6 +205,7 @@ export function useTaskTimer(task: Task | null): TaskTimerApi {
       pause,
       resume,
       complete,
+      interrupt,
     ],
   );
 }


### PR DESCRIPTION
## 概要 (What)

ADR-0059 を実装。active な timer 中だけ表示される ⚡ ボタンを 1 タップで押すと、reason 選択モーダルを経由せず即座に paused に落とし、action_log に新 type `task_interrupted` を 1 件だけ記録する。割り込みタスクは stack に push しない (旧 architecture §1.4 push/pop モデルからは離れる)。

## 関連 Issue

Closes #239

## 背景 (Why)

想定ユーザーの日常 (Slack / Notion / huddle) では小さな割り込みが頻発する。旧設計の「割り込みタスクを生成 + stack に push」では事前分類の摩擦で記録されずに終わるため、ADR-0058 (timer 3 動詞 + 能動 AI 介入禁止) と矛盾しない範囲で、**1 タップ + 事前分類なし**で行動データだけ落とせる経路を増やす。分類 / タスク化は朝の棚卸し (ADR-0062 / M-γ) で後追いする。

関連 ADR:
- ADR-0059: one-tap interrupt recording
- ADR-0058: timer 3 動詞 + no AI intervention
- ADR-0062: 朝の棚卸し (後段で割り込みを集計する場)

## Before → After (概念・フロー・メンタルモデル)

**Before:**
- 突発割り込み発生 → ユーザーが「中断」ボタンを押す → `中断の理由` モーダルで「割り込み」を選択 → close + `task_paused` ログ (reason=interruption)。モーダル経由のため摩擦が大きく、現実には記録されないことが多い。
- 行動データ上は「reason 選択モーダル経由の中断」と「1-tap 割り込み」が区別できない。

**After:**
- active 中の Top カードに ⚡ ボタンが常時併置される。
- 1 タップで `pause_reason="interruption"` で entry close + `status=paused` + 新 type `task_interrupted` を 1 件だけ log (`task_paused` は出さない)。モーダルは出ない。
- 行動分析側は `task_interrupted` を観測することで「1-tap だった」ことを確実に区別できる。割り込み発生時 stack 構造は変えない (= mental model が割り込みごとに揺れない)。
- 停止後の再開は user 操作 (再開ボタン押下) でのみ起きる (= calendar event 非対称 stop と同じ「autonomy 保持」原則)。

## 追加したテスト (How verified)

- [x] `src/entities/action-log/logger.test.ts` — `task_interrupted` 単独 insert / ACTION_TYPES roster
- [x] `src/features/task-stack/useTaskTimer.test.tsx` — `interrupt()` で `pause_reason="interruption"` + `task_interrupted` ログ + `task_paused` が出ないこと / open entry 不在時のフォールバック / task=null no-op
- [x] `src/app/useTopTaskTimer.test.tsx` — `onInterrupt` 経由でモーダルを開かず close + log まで通ること
- [x] `src/features/task-stack/TaskStack.test.tsx` — active のみで割り込みボタン表示 / idle・paused では非表示 / クリックで `onInterrupt` 発火 + `onPauseRequest` は呼ばれない
- [x] `e2e/one-tap-interrupt.spec.ts` — UI 操作 → DB の不変条件 (モーダル経由しない / `task_paused` が積まれない / 自動再開しない / time_entry.pause_reason=interruption / action_log は `task_started` → `task_interrupted` のみ)
- [x] `pnpm lint` / `pnpm typecheck` / `pnpm test` (650 件) 全て pass

## このPRの範囲外 (Out of scope)

- 朝の棚卸し画面での割り込み分類 / タスク化 (M-γ #248〜の枠で別途)
- 割り込みの種類分け (MTG / 緊急 / 雑談 等) — 1-tap 主義に反するので採用しない (ADR-0059 Alternatives で却下済)
- architecture.md §1.4 の文面整理 — 軌道修正 ADR 群 (0057〜0064) 確定後に別途まとめて反映予定


---
_Generated by [Claude Code](https://claude.ai/code/session_01XE7yzkJYw8e9oNgTvy9iRM)_