### PR TITLE
feat(task): 子タスク完了条件 (deliverable / done / first_step) の DB schema + 詳細パネル編集

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -120,6 +120,7 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
     updateDependency,
     updateCategory,
     updateSize,
+    updateCompletionCriteria,
     updateTaskProject,
     reorder,
     reorderGroup,
@@ -275,6 +276,7 @@ export function AppShell({ initialView, aiEnabled, user }: AppShellProps) {
               onChangeDependency={updateDependency}
               onChangeCategory={updateCategory}
               onChangeSize={updateSize}
+              onChangeCompletionCriteria={updateCompletionCriteria}
               onChangeProject={updateTaskProject}
               aiEnabled={aiEnabled}
               latestDecomposeLog={decomposeLogQuery.data ?? null}

--- a/src/app/useDashboardMutations.ts
+++ b/src/app/useDashboardMutations.ts
@@ -46,6 +46,16 @@ export type DashboardMutations = {
    */
   updateSize: (id: string, taskSize: TaskSize | null) => void;
   /**
+   * #246 / ADR 0061 / 0066: 詳細パネルからの完了条件編集。
+   * deliverable / done / first_step をまとめて `tasks` 同名列に書く。AI 分解が入れた
+   * 初期値を user が上書きするルート。updateSize と同じく action_log は今は持たない
+   * (補完タイミング / AI 値との競合解決は #244 / #245 で確定する)。
+   */
+  updateCompletionCriteria: (
+    id: string,
+    criteria: { deliverable: string; done: string; firstStep: string },
+  ) => void;
+  /**
    * Issue #171 / ADR 0039: タスクの project_id 編集と親→子 / 子→兄弟+親 への伝播。
    * cache から target の親子関係を判定して mode を決め、対応する RPC (atomic) または
    * 単独 update を呼ぶ。1 操作 = 1 ログ (`task_project_changed`) + payload に伝播範囲。
@@ -259,6 +269,33 @@ export function useDashboardMutations(): DashboardMutations {
       const previous = queryClient.getQueryData<Task[]>(dashboardKeys.tasks);
       queryClient.setQueryData<Task[]>(dashboardKeys.tasks, (prev) =>
         (prev ?? []).map((t) => (t.id === id ? { ...t, taskSize } : t)),
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(dashboardKeys.tasks, ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.tasks });
+    },
+  });
+
+  // #246 / ADR 0061 / 0066: 完了条件 (deliverable / done / first_step) の上書き。
+  // AI 分解が初期値を入れるルートと、ユーザーが詳細パネルで上書きするルートが両方あり、
+  // どちらも `tasks` の同名列に落ちる。updateSize と同じく action_log は今は持たない。
+  const updateCompletionCriteriaMutation = useMutation({
+    mutationFn: ({
+      id,
+      criteria,
+    }: {
+      id: string;
+      criteria: { deliverable: string; done: string; firstStep: string };
+    }) => taskGateway.update(id, criteria),
+    onMutate: async ({ id, criteria }) => {
+      await queryClient.cancelQueries({ queryKey: dashboardKeys.tasks });
+      const previous = queryClient.getQueryData<Task[]>(dashboardKeys.tasks);
+      queryClient.setQueryData<Task[]>(dashboardKeys.tasks, (prev) =>
+        (prev ?? []).map((t) => (t.id === id ? { ...t, ...criteria } : t)),
       );
       return { previous };
     },
@@ -803,6 +840,8 @@ export function useDashboardMutations(): DashboardMutations {
       updateDependencyMutation.mutate({ id, dependsOnEventId }),
     updateCategory: (id, taskCategory) => updateCategoryMutation.mutate({ id, taskCategory }),
     updateSize: (id, taskSize) => updateSizeMutation.mutate({ id, taskSize }),
+    updateCompletionCriteria: (id, criteria) =>
+      updateCompletionCriteriaMutation.mutate({ id, criteria }),
     updateTaskProject,
     reorder,
     reorderGroup,

--- a/src/app/useTopTaskTimer.test.tsx
+++ b/src/app/useTopTaskTimer.test.tsx
@@ -48,6 +48,9 @@ const baseTask: Task = {
   decomposeStatus: "none",
   taskCategory: null,
   taskSize: null,
+  deliverable: "",
+  done: "",
+  firstStep: "",
   createdAt: "2026-04-19T09:00:00.000Z",
   completedAt: null,
 };

--- a/src/entities/task/aggregations.test.ts
+++ b/src/entities/task/aggregations.test.ts
@@ -23,6 +23,9 @@ const baseTask: Task = {
   decomposeStatus: "none",
   taskCategory: null,
   taskSize: null,
+  deliverable: "",
+  done: "",
+  firstStep: "",
   createdAt: "2026-04-27T00:00:00",
   completedAt: null,
 };

--- a/src/entities/task/decompose-server.test.ts
+++ b/src/entities/task/decompose-server.test.ts
@@ -632,6 +632,42 @@ describe("decomposeTask", () => {
 
     expect(generate).toHaveBeenCalledWith(expect.stringContaining("task_size: 未設定"));
   });
+
+  test("完了条件 3 項目が rpc params に含まれる / 欠損は空文字に倒れる (ADR 0061 / 0066 / #246)", async () => {
+    const { client, calls } = makeSupabase(defaultPlan(makeParentRow()));
+    const generate = vi.fn(async () =>
+      JSON.stringify([
+        {
+          title: "a",
+          estimated_minutes: 30,
+          task_category: "coding",
+          deliverable: "API クライアント",
+          done: "ユニットテストが緑",
+          first_step: "型定義ファイルを作る",
+        },
+        // 完了条件が欠損 → parser が空文字に倒す (フェイルソフト)
+        { title: "b", estimated_minutes: 15, task_category: "doc" },
+      ]),
+    );
+
+    const result = await decomposeTask(makeDeps({ client, generate }));
+
+    expect(result.kind).toBe("decomposed");
+    const newChildren = calls.rpcCalls[0].params.p_new_children as Array<Record<string, unknown>>;
+    expect(newChildren).toHaveLength(2);
+    expect(newChildren[0]).toMatchObject({
+      title: "a",
+      deliverable: "API クライアント",
+      done: "ユニットテストが緑",
+      first_step: "型定義ファイルを作る",
+    });
+    expect(newChildren[1]).toMatchObject({
+      title: "b",
+      deliverable: "",
+      done: "",
+      first_step: "",
+    });
+  });
 });
 
 describe("classifyGenerateError", () => {

--- a/src/entities/task/decompose-server.ts
+++ b/src/entities/task/decompose-server.ts
@@ -149,6 +149,11 @@ async function runDecompose(
     // ADR 0038 / Issue #169: AI が推定した主観サイズ。fn_decompose_parent_task が
     // tasks.task_size 列に保存する (値域外 / null は parser 側で null に倒している)。
     task_size: child.taskSize,
+    // ADR 0061 / 0066 / Issue #246: AI が言語化した完了条件 3 項目。
+    // parser 側で欠損は空文字に倒しているので、ここでは素通しする。
+    deliverable: child.deliverable,
+    done: child.done,
+    first_step: child.firstStep,
   }));
 
   // ADR 0021 / Issue #150: 子 insert + 親 decompose_status 更新を 1 トランザクションで行う。

--- a/src/entities/task/gateway.ts
+++ b/src/entities/task/gateway.ts
@@ -34,6 +34,13 @@ export type UpdateTaskInput = {
   decomposeStatus?: DecomposeStatus;
   taskCategory?: TaskCategory | null;
   taskSize?: TaskSize | null;
+  /**
+   * 完了条件の編集 (ADR 0061 / 0066, #246)。詳細パネルからの user 手動入力。
+   * フェイルソフトで空文字を許容する (null は持たない)。
+   */
+  deliverable?: string;
+  done?: string;
+  firstStep?: string;
   completedAt?: string | null;
 };
 

--- a/src/entities/task/resplit-server.test.ts
+++ b/src/entities/task/resplit-server.test.ts
@@ -316,6 +316,42 @@ describe("resplitChildTask", () => {
     expect(generate).toHaveBeenCalledWith(expect.stringContaining("task_size: 2h"));
   });
 
+  test("完了条件 3 項目が rpc params に含まれる / 欠損は空文字に倒れる (ADR 0061 / 0066 / #246)", async () => {
+    const { client, calls } = makeSupabase(defaultPlan(makeTargetRow()));
+    const generate = vi.fn(async () =>
+      JSON.stringify([
+        {
+          title: "導入部の構成を決める",
+          estimated_minutes: 10,
+          task_category: "doc",
+          deliverable: "導入の骨子",
+          done: "節タイトルが 3 つ決まっている",
+          first_step: "結論の一文を書く",
+        },
+        // 完了条件が欠損 → parser が空文字に倒す (フェイルソフト)
+        { title: "本文を書く", estimated_minutes: 15, task_category: "doc" },
+      ]),
+    );
+
+    const result = await resplitChildTask(makeDeps({ client, generate }));
+
+    expect(result.kind).toBe("resplit_succeeded");
+    const newChildren = calls.rpcCalls[0].params.p_new_children as Array<Record<string, unknown>>;
+    expect(newChildren).toHaveLength(2);
+    expect(newChildren[0]).toMatchObject({
+      title: "導入部の構成を決める",
+      deliverable: "導入の骨子",
+      done: "節タイトルが 3 つ決まっている",
+      first_step: "結論の一文を書く",
+    });
+    expect(newChildren[1]).toMatchObject({
+      title: "本文を書く",
+      deliverable: "",
+      done: "",
+      first_step: "",
+    });
+  });
+
   test("siblings を prompt に渡す (ADR 0029)", async () => {
     const { client } = makeSupabase(defaultPlan(makeTargetRow()));
     const generate = vi.fn(async () => VALID_RAW);

--- a/src/entities/task/resplit-server.ts
+++ b/src/entities/task/resplit-server.ts
@@ -177,6 +177,10 @@ async function runResplit(
     task_category: c.taskCategory,
     // ADR 0038 / Issue #169: 子の主観サイズも保存する。
     task_size: c.taskSize,
+    // ADR 0061 / 0066 / Issue #246: 再分解後の子にも完了条件 3 項目を保存する。
+    deliverable: c.deliverable,
+    done: c.done,
+    first_step: c.firstStep,
   }));
 
   // ADR 0028 / 0030: rpc で delete + insert + reorder を atomic 実行する。

--- a/src/entities/task/supabase-gateway.test.ts
+++ b/src/entities/task/supabase-gateway.test.ts
@@ -52,6 +52,9 @@ function makeRow(overrides: Partial<Tables<"tasks">> = {}): Tables<"tasks"> {
     decompose_status: "none",
     task_category: null,
     task_size: null,
+    deliverable: "",
+    done: "",
+    first_step: "",
     created_at: "2026-04-27T00:00:00.000Z",
     completed_at: null,
     ...overrides,
@@ -261,6 +264,82 @@ describe("SupabaseTaskGateway: task_size mapping (#169)", () => {
 
     expect(tasks).toHaveLength(1);
     expect(tasks[0]!.taskSize).toBe("1d");
+  });
+});
+
+/**
+ * 完了条件 mapping (#246 / ADR 0061 / 0066)。
+ * deliverable / done / first_step は task_category / task_size と同じ薄ラッパー責務。
+ * CHECK 制約 / NOT NULL DEFAULT '' の検証は migration 側 (raw SQL) の責務。
+ */
+describe("SupabaseTaskGateway: completion criteria mapping (#246)", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  test("update: 完了条件 3 項目が update.deliverable / done / first_step に乗る", async () => {
+    const { client, chain } = makeSupabase(
+      makeRow({ deliverable: "成果物 X", done: "条件 Y", first_step: "一手 Z" }),
+    );
+    const gateway = new SupabaseTaskGateway(client);
+
+    const task = await gateway.update("t1", {
+      deliverable: "成果物 X",
+      done: "条件 Y",
+      firstStep: "一手 Z",
+    });
+
+    expect(chain.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deliverable: "成果物 X",
+        done: "条件 Y",
+        first_step: "一手 Z",
+      }),
+    );
+    expect(task.deliverable).toBe("成果物 X");
+    expect(task.done).toBe("条件 Y");
+    expect(task.firstStep).toBe("一手 Z");
+  });
+
+  test("update: 空文字も明示的に書ける (フェイルソフトで完了条件をクリアする)", async () => {
+    const { client, chain } = makeSupabase(makeRow());
+    const gateway = new SupabaseTaskGateway(client);
+
+    await gateway.update("t1", { deliverable: "", done: "", firstStep: "" });
+
+    expect(chain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ deliverable: "", done: "", first_step: "" }),
+    );
+  });
+
+  test("update: 完了条件を patch に含めなければ update に乗らない", async () => {
+    const { client, chain } = makeSupabase(makeRow());
+    const gateway = new SupabaseTaskGateway(client);
+
+    await gateway.update("t1", { title: "y" });
+
+    const call = chain.update.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(call).not.toHaveProperty("deliverable");
+    expect(call).not.toHaveProperty("done");
+    expect(call).not.toHaveProperty("first_step");
+  });
+
+  test("list: row.deliverable / done / first_step が Task の同名フィールドに写る", async () => {
+    const { client } = makeSupabase(makeRow());
+    const row = makeRow({ deliverable: "d", done: "x", first_step: "f" });
+    const orderInner = vi.fn(async () => ({ data: [row], error: null }));
+    const orderOuter = vi.fn(() => ({ order: orderInner }));
+    const select = vi.fn(() => ({ order: orderOuter }));
+    (client.from as ReturnType<typeof vi.fn>).mockReturnValueOnce({ select });
+
+    const gateway = new SupabaseTaskGateway(client);
+    const tasks = await gateway.list();
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]!.deliverable).toBe("d");
+    expect(tasks[0]!.done).toBe("x");
+    expect(tasks[0]!.firstStep).toBe("f");
   });
 });
 

--- a/src/entities/task/supabase-gateway.ts
+++ b/src/entities/task/supabase-gateway.ts
@@ -24,6 +24,9 @@ function fromRow(row: Tables<"tasks">): Task {
     decomposeStatus: row.decompose_status,
     taskCategory: row.task_category,
     taskSize: row.task_size,
+    deliverable: row.deliverable,
+    done: row.done,
+    firstStep: row.first_step,
     createdAt: row.created_at,
     completedAt: row.completed_at,
   };
@@ -149,6 +152,9 @@ export class SupabaseTaskGateway implements TaskGateway {
     if (patch.decomposeStatus !== undefined) update.decompose_status = patch.decomposeStatus;
     if (patch.taskCategory !== undefined) update.task_category = patch.taskCategory;
     if (patch.taskSize !== undefined) update.task_size = patch.taskSize;
+    if (patch.deliverable !== undefined) update.deliverable = patch.deliverable;
+    if (patch.done !== undefined) update.done = patch.done;
+    if (patch.firstStep !== undefined) update.first_step = patch.firstStep;
     if (patch.completedAt !== undefined) update.completed_at = patch.completedAt;
     const { data, error } = await this.supabase
       .from("tasks")

--- a/src/entities/task/types.ts
+++ b/src/entities/task/types.ts
@@ -49,6 +49,17 @@ export type Task = {
   decomposeStatus: DecomposeStatus;
   taskCategory: TaskCategory | null;
   taskSize: TaskSize | null;
+  /**
+   * 完了条件 (ADR 0061 / 0066, #246)。AI 分解が言語化し、詳細パネルで user が編集できる。
+   * 3 項目は別軸 (何を生むか / いつ完了か / どう始めるか):
+   * - deliverable = そのタスクが生む成果物 (名詞)
+   * - done        = deliverable が完成したと言える観測可能な条件
+   * - firstStep   = 着手の最初の一手
+   * フェイルソフト: 未設定 / AI が言語化できなかったケースは空文字 (null は持たない)。
+   */
+  deliverable: string;
+  done: string;
+  firstStep: string;
   createdAt: string;
   completedAt: string | null;
 };

--- a/src/features/task-detail/TaskDetailPanel.test.tsx
+++ b/src/features/task-detail/TaskDetailPanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render as rtlRender } from "@testing-library/react";
+import { fireEvent, render as rtlRender, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { LatestDecomposeLog } from "../../entities/action-log/gateway";
 import type { Event } from "../../entities/event/types";
@@ -43,6 +43,9 @@ const baseTask: Task = {
   decomposeStatus: "none",
   taskCategory: null,
   taskSize: null,
+  deliverable: "",
+  done: "",
+  firstStep: "",
   createdAt: "2026-04-11T00:00:00",
   completedAt: null,
 };
@@ -1026,5 +1029,97 @@ describe("TaskDetailPanel - 子タスクの再分解 (Issue #121 / ADR 0027)", (
     });
     expect(queryByRole("button", { name: "もっと細かく" })).toBeNull();
     expect(queryByRole("button", { name: "AI 分解を実行" })).toBeNull();
+  });
+});
+
+// 完了条件 (deliverable / done / first_step) の表示・編集 (#246 / ADR 0061 / 0066)。
+// AI 分解が初期値を入れ、user が詳細パネルで上書きする。3 項目はまとめて編集し、
+// callback には trim 済みの値が渡る。section は role=region で scope できる。
+describe("TaskDetailPanel - 完了条件 (#246 / ADR 0061 / 0066)", () => {
+  test("onChangeCompletionCriteria 未指定なら完了条件 UI を出さない (旧呼び出し互換)", () => {
+    const { queryByRole } = renderPanel();
+    expect(queryByRole("region", { name: "完了条件" })).toBeNull();
+  });
+
+  test("onChangeCompletionCriteria 指定時、3 項目を表示する (値あり / 未設定の出し分け)", () => {
+    const { getByRole } = renderPanel({
+      task: { ...baseTask, deliverable: "API クライアント", done: "", firstStep: "" },
+      onChangeCompletionCriteria: vi.fn(),
+    });
+    const section = getByRole("region", { name: "完了条件" });
+    expect(within(section).getByText("API クライアント")).toBeTruthy();
+    // done / firstStep は空文字 → 「未設定」表示
+    expect(within(section).getAllByText("未設定")).toHaveLength(2);
+  });
+
+  test("「完了条件を編集」押下で入力欄 + 保存 / キャンセルに切り替わる", () => {
+    const { getByRole } = renderPanel({ onChangeCompletionCriteria: vi.fn() });
+    const section = getByRole("region", { name: "完了条件" });
+    fireEvent.click(within(section).getByRole("button", { name: "完了条件を編集" }));
+    expect(within(section).getByLabelText("成果物")).toBeTruthy();
+    expect(within(section).getByLabelText("完了の判定")).toBeTruthy();
+    expect(within(section).getByLabelText("最初の一歩")).toBeTruthy();
+    expect(within(section).getByRole("button", { name: "保存" })).toBeTruthy();
+    expect(within(section).getByRole("button", { name: "キャンセル" })).toBeTruthy();
+  });
+
+  test("編集 → 入力 → 保存で onChangeCompletionCriteria(taskId, 3 項目) を呼ぶ (前後空白は trim)", () => {
+    const onChangeCompletionCriteria = vi.fn();
+    const { getByRole } = renderPanel({ onChangeCompletionCriteria });
+    const section = getByRole("region", { name: "完了条件" });
+    fireEvent.click(within(section).getByRole("button", { name: "完了条件を編集" }));
+    fireEvent.change(within(section).getByLabelText("成果物"), {
+      target: { value: "  成果物 X  " },
+    });
+    fireEvent.change(within(section).getByLabelText("完了の判定"), {
+      target: { value: "条件 Y" },
+    });
+    fireEvent.change(within(section).getByLabelText("最初の一歩"), {
+      target: { value: "一手 Z" },
+    });
+    fireEvent.click(within(section).getByRole("button", { name: "保存" }));
+    expect(onChangeCompletionCriteria).toHaveBeenCalledWith("t1", {
+      deliverable: "成果物 X",
+      done: "条件 Y",
+      firstStep: "一手 Z",
+    });
+  });
+
+  test("保存後は display モードに戻り、入力欄は消える", () => {
+    const { getByRole } = renderPanel({ onChangeCompletionCriteria: vi.fn() });
+    const section = getByRole("region", { name: "完了条件" });
+    fireEvent.click(within(section).getByRole("button", { name: "完了条件を編集" }));
+    fireEvent.click(within(section).getByRole("button", { name: "保存" }));
+    expect(within(section).queryByLabelText("成果物")).toBeNull();
+    expect(within(section).getByRole("button", { name: "完了条件を編集" })).toBeTruthy();
+  });
+
+  test("キャンセルで onChangeCompletionCriteria は呼ばれず display モードに戻る", () => {
+    const onChangeCompletionCriteria = vi.fn();
+    const { getByRole } = renderPanel({ onChangeCompletionCriteria });
+    const section = getByRole("region", { name: "完了条件" });
+    fireEvent.click(within(section).getByRole("button", { name: "完了条件を編集" }));
+    fireEvent.change(within(section).getByLabelText("成果物"), {
+      target: { value: "破棄される" },
+    });
+    fireEvent.click(within(section).getByRole("button", { name: "キャンセル" }));
+    expect(onChangeCompletionCriteria).not.toHaveBeenCalled();
+    expect(within(section).getByRole("button", { name: "完了条件を編集" })).toBeTruthy();
+  });
+
+  test("編集開始時、入力欄には現在の完了条件値が入っている", () => {
+    const { getByRole } = renderPanel({
+      task: { ...baseTask, deliverable: "既存成果物", done: "既存完了", firstStep: "既存一手" },
+      onChangeCompletionCriteria: vi.fn(),
+    });
+    const section = getByRole("region", { name: "完了条件" });
+    fireEvent.click(within(section).getByRole("button", { name: "完了条件を編集" }));
+    expect((within(section).getByLabelText("成果物") as HTMLInputElement).value).toBe("既存成果物");
+    expect((within(section).getByLabelText("完了の判定") as HTMLInputElement).value).toBe(
+      "既存完了",
+    );
+    expect((within(section).getByLabelText("最初の一歩") as HTMLInputElement).value).toBe(
+      "既存一手",
+    );
   });
 });

--- a/src/features/task-detail/TaskDetailPanel.tsx
+++ b/src/features/task-detail/TaskDetailPanel.tsx
@@ -55,6 +55,16 @@ export type TaskDetailPanelProps = {
    */
   onChangeProject?: (id: string, projectId: string | null) => void;
   /**
+   * 完了条件 (`tasks.deliverable` / `done` / `first_step`) の編集 (ADR 0061 / 0066 / #246)。
+   * AI 分解が初期値を言語化し、user が詳細パネルで上書きできる。3 項目はまとめて渡す
+   * (フェイルソフトで空文字を許容、null は持たない)。
+   * 未指定なら完了条件 UI を出さない (旧呼び出し / テスト互換)。
+   */
+  onChangeCompletionCriteria?: (
+    id: string,
+    criteria: { deliverable: string; done: string; firstStep: string },
+  ) => void;
+  /**
    * AI 分解の最新試行ログ (`task_decomposed` / `task_decompose_failed` /
    * `task_decompose_skipped` の最新 1 件)。なければ null。
    * 親が undefined を渡した場合は AI 分解情報エリアを描画しない (旧呼び出し互換)。
@@ -90,6 +100,7 @@ export function TaskDetailPanel({
   onChangeCategory,
   onChangeSize,
   onChangeProject,
+  onChangeCompletionCriteria,
   latestDecomposeLog,
   isDecomposeLogLoading,
   aiEnabled = true,
@@ -429,6 +440,14 @@ export function TaskDetailPanel({
             </div>
           )}
 
+          {onChangeCompletionCriteria && (
+            <CompletionCriteriaSection
+              task={task}
+              onChange={onChangeCompletionCriteria}
+              accentColor={proj.color}
+            />
+          )}
+
           {showDecomposeSection && (
             <DecomposeInfoSection
               task={task}
@@ -594,6 +613,131 @@ function ProjectChangeConfirmDialog({
         </div>
       </div>
     </div>
+  );
+}
+
+// ADR 0061 / 0066 / #246: 完了条件 3 項目。値域 (deliverable / done / first_step) は
+// DB の列 / Task 型と single source of truth で揃え、ここでは表示ラベルと placeholder のみ持つ。
+const COMPLETION_CRITERIA_FIELDS = [
+  { key: "deliverable", label: "成果物", placeholder: "何が出来上がるか" },
+  { key: "done", label: "完了の判定", placeholder: "完成したと言える条件" },
+  { key: "firstStep", label: "最初の一歩", placeholder: "まず手を動かす一手" },
+] as const;
+
+/**
+ * 完了条件セクション (ADR 0061 / 0066 / #246)。
+ * deliverable / done / first_step の 3 項目を表示し、まとめて編集できる。
+ * AI 分解が初期値を言語化し、user が詳細パネルで上書きする。3 項目はフェイルソフトで
+ * 空文字を許容する (未設定 / AI が言語化できなかったケースを空文字で表す)。
+ *
+ * 編集体験は body editor と揃える (編集ボタン → 入力欄 → 保存 / キャンセル)。
+ * セクションは `<section aria-label="完了条件">` で scope し、編集ボタンは body の
+ * 「編集」ボタンと accessible name が衝突しないよう「完了条件を編集」とする。
+ */
+function CompletionCriteriaSection({
+  task,
+  onChange,
+  accentColor,
+}: {
+  task: Task;
+  onChange: (
+    id: string,
+    criteria: { deliverable: string; done: string; firstStep: string },
+  ) => void;
+  accentColor: string;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState({
+    deliverable: task.deliverable,
+    done: task.done,
+    firstStep: task.firstStep,
+  });
+
+  const startEditing = () => {
+    // 編集開始時に最新の task 値で draft を初期化する (AI 分解で値が後から入る経路に追従)。
+    setDraft({ deliverable: task.deliverable, done: task.done, firstStep: task.firstStep });
+    setEditing(true);
+  };
+
+  const handleSave = () => {
+    onChange(task.id, {
+      deliverable: draft.deliverable.trim(),
+      done: draft.done.trim(),
+      firstStep: draft.firstStep.trim(),
+    });
+    setEditing(false);
+  };
+
+  return (
+    <section aria-label="完了条件" className="px-5 pb-2 pt-1">
+      <div className="mb-1 font-jp text-[10px] text-fg-weak">完了条件</div>
+      {editing ? (
+        <>
+          <div className="flex flex-col gap-2">
+            {COMPLETION_CRITERIA_FIELDS.map((field) => (
+              <label key={field.key} className="flex flex-col gap-0.5">
+                <span className="font-jp text-[10px] text-fg-subtle">{field.label}</span>
+                <input
+                  type="text"
+                  value={draft[field.key]}
+                  placeholder={field.placeholder}
+                  onChange={(e) => setDraft((prev) => ({ ...prev, [field.key]: e.target.value }))}
+                  className="rounded border border-bg-divider bg-bg-elevated px-2 py-1 font-jp text-[11px] text-fg-default outline-none focus:border-accent-blue"
+                />
+              </label>
+            ))}
+          </div>
+          <div className="mt-2 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => setEditing(false)}
+              className="cursor-pointer rounded-[4px] border border-bg-divider bg-transparent px-3 py-1 font-jp text-[10px] text-fg-subtle"
+            >
+              キャンセル
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              className="cursor-pointer rounded-[4px] px-3 py-1 font-jp text-[10px] font-semibold text-fg-invert"
+              style={{ background: accentColor }}
+            >
+              保存
+            </button>
+          </div>
+        </>
+      ) : (
+        <>
+          <dl className="m-0 flex flex-col gap-1">
+            {COMPLETION_CRITERIA_FIELDS.map((field) => {
+              const value = task[field.key];
+              return (
+                <div key={field.key} className="flex gap-2">
+                  <dt className="w-[52px] shrink-0 font-jp text-[10px] text-fg-weak">
+                    {field.label}
+                  </dt>
+                  <dd
+                    className={`m-0 font-jp text-[10px] leading-[1.5] ${
+                      value ? "text-fg-subtle" : "italic text-fg-faint"
+                    }`}
+                  >
+                    {value || "未設定"}
+                  </dd>
+                </div>
+              );
+            })}
+          </dl>
+          <div className="mt-1.5 flex justify-end">
+            <button
+              type="button"
+              onClick={startEditing}
+              className="cursor-pointer rounded-[4px] border border-bg-divider bg-transparent px-2.5 py-[3px] font-jp text-[10px] text-fg-subtle"
+            >
+              完了条件を編集
+            </button>
+          </div>
+        </>
+      )}
+    </section>
   );
 }
 

--- a/src/features/task-stack/TaskStack.test.tsx
+++ b/src/features/task-stack/TaskStack.test.tsx
@@ -42,6 +42,9 @@ const baseTask: Task = {
   decomposeStatus: "none",
   taskCategory: null,
   taskSize: null,
+  deliverable: "",
+  done: "",
+  firstStep: "",
   createdAt: "2026-04-11T00:00:00",
   completedAt: null,
 };

--- a/src/features/task-stack/reorderTasks.test.ts
+++ b/src/features/task-stack/reorderTasks.test.ts
@@ -18,6 +18,9 @@ const baseTask: Task = {
   decomposeStatus: "none",
   taskCategory: null,
   taskSize: null,
+  deliverable: "",
+  done: "",
+  firstStep: "",
   createdAt: "2026-04-27T00:00:00",
   completedAt: null,
 };

--- a/src/features/task-stack/stackItems.test.ts
+++ b/src/features/task-stack/stackItems.test.ts
@@ -23,6 +23,9 @@ const baseTask: Task = {
   decomposeStatus: "none",
   taskCategory: null,
   taskSize: null,
+  deliverable: "",
+  done: "",
+  firstStep: "",
   createdAt: "2026-04-27T00:00:00",
   completedAt: null,
 };

--- a/src/features/task-stack/useTaskTimer.test.tsx
+++ b/src/features/task-stack/useTaskTimer.test.tsx
@@ -49,6 +49,9 @@ const baseTask: Task = {
   decomposeStatus: "none",
   taskCategory: null,
   taskSize: null,
+  deliverable: "",
+  done: "",
+  firstStep: "",
   createdAt: "2026-04-19T09:00:00.000Z",
   completedAt: null,
 };

--- a/src/mocks/tasks.ts
+++ b/src/mocks/tasks.ts
@@ -14,6 +14,9 @@ export function buildInitialTasks(): Task[] {
     decomposeStatus: "none" as const,
     taskCategory: null,
     taskSize: null,
+    deliverable: "",
+    done: "",
+    firstStep: "",
     createdAt: now,
     completedAt: null,
   };

--- a/src/shared/types/database.ts
+++ b/src/shared/types/database.ts
@@ -82,6 +82,9 @@ export type Database = {
           decompose_status: Database["public"]["Enums"]["decompose_status"];
           task_category: TaskCategoryValue | null;
           task_size: TaskSizeValue | null;
+          deliverable: string;
+          done: string;
+          first_step: string;
           created_at: string;
           completed_at: string | null;
         };
@@ -100,6 +103,9 @@ export type Database = {
           decompose_status?: Database["public"]["Enums"]["decompose_status"];
           task_category?: TaskCategoryValue | null;
           task_size?: TaskSizeValue | null;
+          deliverable?: string;
+          done?: string;
+          first_step?: string;
           created_at?: string;
           completed_at?: string | null;
         };
@@ -118,6 +124,9 @@ export type Database = {
           decompose_status?: Database["public"]["Enums"]["decompose_status"];
           task_category?: TaskCategoryValue | null;
           task_size?: TaskSizeValue | null;
+          deliverable?: string;
+          done?: string;
+          first_step?: string;
           created_at?: string;
           completed_at?: string | null;
         };

--- a/supabase/migrations/20260516000000_completion_criteria_columns.sql
+++ b/supabase/migrations/20260516000000_completion_criteria_columns.sql
@@ -1,0 +1,34 @@
+-- kozutsumi (issue #246): tasks に完了条件 3 列を追加 (ADR 0061 / 0066)
+--
+-- References:
+-- * docs/adr/0061-ai-decomposition-one-hour-target-and-done-condition-schema.md
+--   (各子タスクに完了条件を AI が言語化する)
+-- * docs/adr/0066-decompose-completion-criteria-deliverable-done-first-step.md
+--   (完了条件 schema を deliverable / done / first_step の 3 項目に確定。
+--    物理表現 = カラム追加 or JSONB は #246 の実装判断に委譲)
+-- * supabase/migrations/20260504000000_task_size.sql (列追加 + フェイルソフト列の先行例)
+--
+-- 設計判断 (ADR 0066 が #246 に委譲した「物理表現」の確定):
+-- * `completion_criteria` JSONB 1 列ではなく `deliverable` / `done` / `first_step` の
+--   3 text 列を追加する。理由:
+--   - ADR 0066 §否定的影響 / #247 (親進捗可視化) / #245 (AI 後追い補完) が field 単位で
+--     アクセスする。列なら CHECK / index / クエリが素直で、JSONB のキー欠損ガードが要らない。
+--   - 既存の構造化属性 (task_category / task_size) と同じく「1 属性 1 列」で揃う。
+-- * `text not null default ''`。body 列 (`text not null default ''`) と同じ扱い:
+--   - ADR 0066 §Decision: 3 項目はフェイルソフトで空文字を許容する (必須にしない)。
+--     「未設定」「AI が言語化できなかった」をどちらも空文字で表し、null は導入しない。
+--   - 既存タスク (Phase 1〜2 由来 / ADR 0064 の title のみ作成) は空文字で backfill される。
+-- * 値域 CHECK は置かない。body と同じ自由テキスト。長さの hard cap は AI parser 側
+--   (MAX_CRITERION_LEN, src/shared/ai/prompts/decompose.ts) で持つ。
+
+alter table public.tasks
+  add column deliverable text not null default '',
+  add column done text not null default '',
+  add column first_step text not null default '';
+
+comment on column public.tasks.deliverable is
+  'ADR 0066: 完了条件。そのタスクが生む成果物 (名詞)。フェイルソフトで空文字を許容。';
+comment on column public.tasks.done is
+  'ADR 0066: 完了条件。deliverable が完成したと言える観測可能な条件。フェイルソフトで空文字を許容。';
+comment on column public.tasks.first_step is
+  'ADR 0066: 完了条件。着手の最初の一手。フェイルソフトで空文字を許容。';

--- a/supabase/migrations/20260516000001_decompose_resplit_fn_completion_criteria.sql
+++ b/supabase/migrations/20260516000001_decompose_resplit_fn_completion_criteria.sql
@@ -1,0 +1,225 @@
+-- kozutsumi (issue #246): fn_decompose_parent_task / fn_resplit_child_task を完了条件対応に更新
+--
+-- References:
+-- * docs/adr/0066-decompose-completion-criteria-deliverable-done-first-step.md
+--   (完了条件 schema = deliverable / done / first_step)
+-- * supabase/migrations/20260516000000_completion_criteria_columns.sql (列追加)
+-- * supabase/migrations/20260505000000_p3_204_decompose_global_stack_order.sql (旧 fn v3)
+--
+-- 変更点:
+-- * `p_new_children` jsonb の各要素に `deliverable` / `done` / `first_step` を追加
+--   (旧: title / body / estimated_minutes / task_category / task_size)
+-- * 子 insert 時に 3 列も埋める。body と同じく `coalesce(v_child ->> 'x', '')` で
+--   キー欠損を空文字に倒す (NOT NULL DEFAULT '' 列なので欠損は空文字が正)。
+--
+-- 後方互換: 呼び出し側が 3 キーを渡さない場合は coalesce で空文字になり、列の
+-- NOT NULL DEFAULT '' と整合する。stack_order の global shift ロジック (ADR 0047) は v3 のまま。
+
+-- =====================================================================
+-- fn_decompose_parent_task v4 (ADR 0066: completion criteria)
+-- =====================================================================
+
+create or replace function public.fn_decompose_parent_task(
+  p_parent_id uuid,
+  p_base_stack_order integer,
+  p_new_children jsonb
+) returns uuid[]
+language plpgsql
+security invoker
+as $$
+declare
+  v_user_id uuid;
+  v_project_id uuid;
+  v_depends_on_event_id uuid;
+  v_idx int;
+  v_count int;
+  v_child jsonb;
+  v_new_id uuid;
+  v_new_ids uuid[] := '{}';
+begin
+  -- 1. 親 row の継承用属性を取得 (RLS で別 user の親は 0 行 → v_user_id is null になる)
+  select user_id, project_id, depends_on_event_id
+    into v_user_id, v_project_id, v_depends_on_event_id
+    from public.tasks
+   where id = p_parent_id;
+
+  if v_user_id is null then
+    raise exception 'fn_decompose_parent_task: parent task not found or not authorized: %', p_parent_id;
+  end if;
+
+  -- 2. 新規子配列のサイズを確認 (空配列禁止: orchestrator で 0 件は skipped 経路に流れる)
+  v_count := jsonb_array_length(p_new_children);
+  if v_count < 1 then
+    raise exception 'fn_decompose_parent_task: new_children must be non-empty (got %)', v_count;
+  end if;
+
+  -- 3. ADR 0047: 同一 user 内で stack_order > p_base_stack_order のすべての task を
+  --    v_count だけシフト。子と親兄弟が同じ視覚平面に並ぶため、shift も user スコープ全体。
+  update public.tasks
+     set stack_order = stack_order + v_count
+   where user_id = v_user_id
+     and stack_order > p_base_stack_order
+     and id <> p_parent_id;
+
+  -- 4. 新規子を p_base_stack_order+1, +2, ..., +N で順に insert (= 親の直後)
+  for v_idx in 0 .. v_count - 1 loop
+    v_child := p_new_children -> v_idx;
+    insert into public.tasks (
+      user_id,
+      project_id,
+      parent_task_id,
+      depends_on_event_id,
+      title,
+      body,
+      estimated_minutes,
+      task_category,
+      task_size,
+      deliverable,
+      done,
+      first_step,
+      stack_order,
+      decompose_status
+    ) values (
+      v_user_id,
+      v_project_id,
+      p_parent_id,
+      v_depends_on_event_id,
+      v_child ->> 'title',
+      coalesce(v_child ->> 'body', ''),
+      nullif(v_child ->> 'estimated_minutes', '')::integer,
+      nullif(v_child ->> 'task_category', '')::text,
+      nullif(v_child ->> 'task_size', '')::text,
+      coalesce(v_child ->> 'deliverable', ''),
+      coalesce(v_child ->> 'done', ''),
+      coalesce(v_child ->> 'first_step', ''),
+      p_base_stack_order + 1 + v_idx,
+      'none'::public.decompose_status
+    )
+    returning id into v_new_id;
+
+    v_new_ids := array_append(v_new_ids, v_new_id);
+  end loop;
+
+  -- 5. 親の decompose_status を 'decomposed' に倒す (ADR 0021 の終端 status)
+  update public.tasks
+     set decompose_status = 'decomposed'::public.decompose_status
+   where id = p_parent_id;
+
+  return v_new_ids;
+end;
+$$;
+
+comment on function public.fn_decompose_parent_task(uuid, integer, jsonb) is
+  'Issue #246 / ADR 0021 / 0047 / 0066: AI 分解の子 insert + 親 decompose_status 更新を 1 トランザクション化。完了条件 (deliverable / done / first_step) 対応。security invoker (RLS 適用)。';
+
+-- =====================================================================
+-- fn_resplit_child_task v4 (ADR 0066: completion criteria)
+-- =====================================================================
+
+create or replace function public.fn_resplit_child_task(
+  p_target_id uuid,
+  p_parent_id uuid,
+  p_base_stack_order integer,
+  p_shift_amount integer,
+  p_new_children jsonb
+) returns uuid[]
+language plpgsql
+security invoker
+as $$
+declare
+  v_user_id uuid;
+  v_project_id uuid;
+  v_depends_on_event_id uuid;
+  v_target_parent_id uuid;
+  v_idx int;
+  v_count int;
+  v_child jsonb;
+  v_new_id uuid;
+  v_new_ids uuid[] := '{}';
+begin
+  -- 1. target row の継承用属性を取得 (parent_task_id も併せて取り、HC-1 検証に使う)
+  select user_id, project_id, depends_on_event_id, parent_task_id
+    into v_user_id, v_project_id, v_depends_on_event_id, v_target_parent_id
+    from public.tasks
+   where id = p_target_id;
+
+  if v_user_id is null then
+    raise exception 'fn_resplit_child_task: target task not found or not authorized: %', p_target_id;
+  end if;
+
+  -- 1.1 HC-1 (孫禁止) の SQL 防衛層
+  if v_target_parent_id is null or v_target_parent_id <> p_parent_id then
+    raise exception 'fn_resplit_child_task: HC-1 violation: target.parent_task_id (%) does not match p_parent_id (%)',
+      v_target_parent_id, p_parent_id;
+  end if;
+
+  -- 2. 新規子配列のサイズを確認 (空配列禁止)
+  v_count := jsonb_array_length(p_new_children);
+  if v_count < 1 then
+    raise exception 'fn_resplit_child_task: new_children must be non-empty (got %)', v_count;
+  end if;
+
+  -- 2.1 HC-3 (並び順決定論性) の SQL 防衛層: caller が渡す shift_amount は new_children 数 - 1
+  --     と一致しなければならない (= 元の target 1 件を消した分だけ後続が前にずれる)。
+  if p_shift_amount <> v_count - 1 then
+    raise exception 'fn_resplit_child_task: shift_amount (%) must equal new_children length (%) - 1',
+      p_shift_amount, v_count;
+  end if;
+
+  -- 3. ADR 0047: 同一 user 内で stack_order > base のすべての task を p_shift_amount シフト。
+  if p_shift_amount > 0 then
+    update public.tasks
+       set stack_order = stack_order + p_shift_amount
+     where user_id = v_user_id
+       and stack_order > p_base_stack_order
+       and id <> p_target_id;
+  end if;
+
+  -- 4. target を delete (base_stack_order 位置を空ける)
+  delete from public.tasks where id = p_target_id;
+
+  -- 5. 新規子を base_stack_order, base+1, ..., base+N-1 で順に insert
+  for v_idx in 0 .. v_count - 1 loop
+    v_child := p_new_children -> v_idx;
+    insert into public.tasks (
+      user_id,
+      project_id,
+      parent_task_id,
+      depends_on_event_id,
+      title,
+      body,
+      estimated_minutes,
+      task_category,
+      task_size,
+      deliverable,
+      done,
+      first_step,
+      stack_order,
+      decompose_status
+    ) values (
+      v_user_id,
+      v_project_id,
+      p_parent_id,
+      v_depends_on_event_id,
+      v_child ->> 'title',
+      coalesce(v_child ->> 'body', ''),
+      nullif(v_child ->> 'estimated_minutes', '')::integer,
+      nullif(v_child ->> 'task_category', '')::text,
+      nullif(v_child ->> 'task_size', '')::text,
+      coalesce(v_child ->> 'deliverable', ''),
+      coalesce(v_child ->> 'done', ''),
+      coalesce(v_child ->> 'first_step', ''),
+      p_base_stack_order + v_idx,
+      'none'::public.decompose_status
+    )
+    returning id into v_new_id;
+
+    v_new_ids := array_append(v_new_ids, v_new_id);
+  end loop;
+
+  return v_new_ids;
+end;
+$$;
+
+comment on function public.fn_resplit_child_task(uuid, uuid, integer, integer, jsonb) is
+  'Issue #246 / ADR 0027 / 0047 / 0066: 子タスクの再分解 flatten。完了条件 (deliverable / done / first_step) 対応。security invoker (RLS 適用)。';


### PR DESCRIPTION
## 概要 (What)

AI 分解が言語化する完了条件 (deliverable / done / first_step) を `tasks` テーブルに永続化し、タスク詳細パネルで表示・編集できるようにする。

## 関連 Issue

Closes #246

## 背景 (Why)

ADR-0061 が「各子タスクに完了条件を AI が言語化する」と決め、ADR-0066 が schema 項目を `deliverable` / `done` / `first_step` の 3 項目に確定した。prompt / parser は #243 / #263 で実装済みだったが、出力が DB に保存されず詳細パネルにも出ていなかった。本 PR はその永続化と UI を埋める。

物理表現は ADR-0066 が #246 に明示的に委譲した実装判断。`completion_criteria` JSONB 1 列ではなく **3 つの text 列**を採用した。理由は #247 (親進捗可視化) / #245 (AI 後追い補完) が field 単位でアクセスするため、列のほうがクエリが素直で JSONB のキー欠損ガードが不要になること。既存の構造化属性 (`task_category` / `task_size`) と「1 属性 1 列」で揃う点も踏まえた。判断根拠は migration ファイルの「設計判断」コメントに記録済み。

関連: ADR-0061 / ADR-0066

## Before → After (概念・フロー・メンタルモデル)

**Before:** AI 分解は完了条件 3 項目を生成していたが、`DecomposedChild` 止まりで DB に落ちず破棄されていた。子タスクは「何を仕上げれば done か」を構造化して持っていなかった。

**After:** 完了条件は `tasks.deliverable` / `done` / `first_step` 列に永続化される。AI 分解 / 再分解の両経路が値を書き込み、ユーザーは詳細パネルで上書きできる。「子タスクは完了条件を構造化して持つ」が schema レベルで保証される。

## 追加したテスト (How verified)

- [x] `decompose-server` / `resplit-server`: 完了条件 3 項目が RPC params に乗る / 欠損は空文字に倒れる
- [x] `supabase-gateway`: deliverable / done / first_step の read (fromRow) / write (update) / patch 非包含時の非反映
- [x] `TaskDetailPanel`: 完了条件セクションの表示・編集モード切替・保存 callback (trim 込み)・キャンセル・region scope
- [x] typecheck / lint / 全 670 テスト pass

## リリース前チェックリスト (When / Before merge)

- [x] マイグレーションの適用順を確認した (`20260516000000` 列追加 → `20260516000001` fn 更新の順)
- [ ] 既存ユーザーへの影響: 3 列は `not null default ''` なので既存行は空文字で backfill される (破壊的変更なし)

## このPRの範囲外 (Out of scope)

- 親進捗の可視化 (#247 で別途)
- AI 後追い補完処理・補完タイミング / ユーザー入力との競合解決ルール (#244 / #245 で確定)
- 完了条件編集の action_log 化 (updateSize と同じく今は持たない)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AA7Qw6xHDA6MJR2j1k6Qhb)_